### PR TITLE
Ticket #5317: Normalize canonical url taken from facebook object

### DIFF
--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -77,7 +77,10 @@ module MediaFacebookItem
       self.data['published'] = object['created_time'] || object['updated_time']
       self.data['user_name'] = object['name'] || object['from']['name']
       self.data['user_uuid'] = object['owner']['id'] unless self.url.match(EVENT_URL).nil?
-      self.url = object['link'] if object['type'] === 'video'
+      if object['type'] === 'video'
+        self.url = object['link']
+        normalize_url
+      end
 
       self.parse_facebook_media(object)
 
@@ -140,7 +143,7 @@ module MediaFacebookItem
     user_name = self.doc.to_s.match(/ownerName:"([^"]+)"/)
     permalink = self.doc.to_s.match(/permalink:"([^"]+)"/)
 
-    self.url = absolute_url(permalink[1])
+    self.url = absolute_url(permalink[1]) if permalink
     self.data['user_name'] = user_name.nil? ? 'Not Identified' : user_name[1]
   end
 

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -740,11 +740,15 @@ class MediaTest < ActiveSupport::TestCase
   end
 
   test "should get canonical URL from facebook object" do
-    media1 = create_media url: 'https://www.facebook.com/democrats/posts/10154268929856943/'
-    media2 = create_media url: 'https://www.facebook.com/democrats/videos/10154268929856943/'
-    media1.as_json
-    media2.as_json
-    assert_equal media2.url, media1.url
+    expected = 'https://www.facebook.com/democrats/videos/10154268929856943'
+    variations = %w(
+      https://www.facebook.com/democrats/videos/10154268929856943/
+      https://www.facebook.com/democrats/posts/10154268929856943/
+    )
+    variations.each do |url|
+      media = Media.new(url: url)
+      media.as_json
+      assert_equal expected, media.url
+    end
   end
-
 end


### PR DESCRIPTION
Also avoid error when page doesn't have a permalink