### PR TITLE
Ticket #5545: Changes order of identification of Facebook pattern

### DIFF
--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -15,6 +15,7 @@ module MediaFacebookItem
     /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/story.php\?story_fbid=(?<id>[0-9]+)&id=([0-9]+).*/,
     /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/livemap(\/.*)?/,
     /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/events\/(?<id>[0-9]+)\/permalink\/([0-9]+).*/,
+    /^https?:\/\/(www\.)?facebook\.com\/([^\/\?]+).*$/,
     EVENT_URL
   ]
 
@@ -198,7 +199,6 @@ module MediaFacebookItem
       self.parse_from_facebook_html unless self.parse_from_facebook_api
       self.data['text'].strip!
       self.data['media_count'] = 1 unless self.url.match(/photo\.php/).nil?
-
       self.data.merge!({
         username: self.data['user_name'],
         title: self.data['user_name'] + ' on Facebook',

--- a/app/models/concerns/media_facebook_profile.rb
+++ b/app/models/concerns/media_facebook_profile.rb
@@ -4,9 +4,9 @@ module MediaFacebookProfile
   included do
     Media.declare('facebook_profile',
       [
-        /^https?:\/\/(www\.)?facebook\.com\/([^\/\?]+).*$/,
         /^https?:\/\/([^\.]+\.)?facebook\.com\/(pages|people)\/([^\/]+)\/([^\/\?]+).*$/,
-        /^https?:\/\/(www\.)?facebook\.com\/profile\.php\?id=([0-9]+).*$/
+        /^https?:\/\/(www\.)?facebook\.com\/profile\.php\?id=([0-9]+).*$/,
+        /^https?:\/\/([^\.]+\.)?facebook\.com\/(?!(permalink\.php|story\.php|photo\.php|livemap))([^\/\?]+)\/?(\?.*)*$/
       ]
     )
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -30,8 +30,8 @@ class Media
   include MediaYoutubeProfile
   include MediaTwitterProfile
   include MediaTwitterItem
-  include MediaFacebookItem
   include MediaFacebookProfile
+  include MediaFacebookItem
   include MediaInstagramItem
   include MediaInstagramProfile
   include MediaBridgeItem

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -1010,4 +1010,28 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'https://speakbridge.io/medias/embed/milestone/M29/1bfdfb37e84960622cb9e94a66b7f6b4ab079591.png', d['picture']
   end
 
+  test "should parse facebook url without identified pattern as item" do
+    m = create_media url: 'https://www.facebook.com/Bimbo.Memories/photos/pb.235404669918505.-2207520000.1481570271./1051597428299221/?type=3&theater'
+    d = m.as_json
+    assert_equal 'item', d['type']
+    assert_equal 'Bimbo Memories on Facebook', d['title']
+    assert_not_nil d['description']
+    assert_not_nil d['published_at']
+    assert_equal 'Bimbo Memories', d['username']
+    assert_equal 'http://facebook.com/235404669918505', d['author_url']
+    assert_equal 'https://graph.facebook.com/235404669918505/picture', d['picture']
+  end
+
+  test "should parse facebook url without identified pattern as item 2" do
+    m = create_media url: 'https://www.facebook.com/Classic.mou/photos/pb.136985363145802.-2207520000.1481570401./640132509497749/?type=3&theater'
+    d = m.as_json
+    assert_equal 'item', d['type']
+    assert_equal 'Classic on Facebook', d['title']
+    assert_match /سعاد/, d['description']
+    assert_not_nil d['published_at']
+    assert_equal 'Classic', d['username']
+    assert_equal 'http://facebook.com/136985363145802', d['author_url']
+    assert_equal 'https://graph.facebook.com/136985363145802/picture', d['picture']
+  end
+
 end


### PR DESCRIPTION
Try to identify if the url pattern matches facebook profile before
comparing with facebook item

Facebook urls that are not identified by a specific pattern will be identified as
facebook item