### PR TITLE
Ticket #5757: Fix how to get twitter metatags from pages

### DIFF
--- a/app/models/concerns/media_page_item.rb
+++ b/app/models/concerns/media_page_item.rb
@@ -29,8 +29,9 @@ module MediaPageItem
 
   def get_twitter_metadata
     metatags = { title: 'twitter:title', picture: 'twitter:image', description: 'twitter:description', username: 'twitter:creator' }
-    data = get_html_metadata('property', metatags)
-    data['author_url'] = 'https://twitter.com/' + twitter_data['username'] if data['username']
+    data = get_html_metadata('name', metatags).with_indifferent_access
+    data.merge!(get_html_metadata('property', metatags))
+    data['author_url'] = 'https://twitter.com/' + data['username'] if data['username']
     data
   end
 

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -562,6 +562,16 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'https://www.flickr.com/photos/bees/', d['author_url']
   end
 
+  test "should parse twitter metatags 2" do
+    m = create_media url: 'https://www.hongkongfp.com/2017/03/08/top-officials-suing-defamation-may-give-perception-bullying-says-chief-exec-candidate-woo/'
+    d = m.as_json
+    assert_match(/Hong Kong Free Press/, d['title'])
+    assert_equal 'https://www.hongkongfp.com/wp-content/uploads/2017/03/2017-03-06_11-45-23.jpg', d['picture']
+    assert_match(/Chief executive candidate Woo Kw-hing/, d['description'])
+    assert_equal '@krislc', d['username']
+    assert_equal 'https://twitter.com/@krislc', d['author_url']
+  end
+
   test "should parse opengraph metatags" do
     m = create_media url: 'http://hacktoon.com/nerdson/2016/poker-planning'
     d = m.as_json
@@ -929,8 +939,8 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Larry Sanders on brother Bernie and why Tony Blair was ‘destructive’', d['title']
     assert_match /The Green party candidate, who is fighting the byelection in David Cameron’s old seat/, d['description']
     assert_match /2016-10/, d['published_at']
-    assert_equal 'https://www.theguardian.com/profile/zoewilliams', d['username']
-    assert_equal 'http://www.theguardian.com', d['author_url']
+    assert_equal '@zoesqwilliams', d['username']
+    assert_equal 'https://twitter.com/@zoesqwilliams', d['author_url']
     assert_match /https:\/\/i.guim.co.uk\/img\/media\/d43d8d320520d7f287adab71fd3a1d337baf7516\/0_945_3850_2310\/master\/3850.jpg/, d['picture']
   end
 
@@ -1205,8 +1215,8 @@ class MediaTest < ActiveSupport::TestCase
     assert_match(/Hong Kong Free Press/, data['title'])
     assert_match(/Hong Kong/, data['description'])
     assert_not_nil data['published_at']
-    assert_equal 'https://www.facebook.com/AFPnewsenglish?fref=ts', data['username']
-    assert_equal 'https://www.hongkongfp.com', data['author_url']
+    assert_equal '@AFP', data['username']
+    assert_equal 'https://twitter.com/@AFP', data['author_url']
     assert_not_nil data['picture']
     assert_nil data['error']
   end
@@ -1221,8 +1231,8 @@ class MediaTest < ActiveSupport::TestCase
     assert_match(/Hong Kong Free Press/, data['title'])
     assert_match(/Hong Kong/, data['description'])
     assert_not_nil data['published_at']
-    assert_equal 'https://www.facebook.com/AFPnewsenglish?fref=ts', data['username']
-    assert_equal 'https://www.hongkongfp.com', data['author_url']
+    assert_equal '@AFP', data['username']
+    assert_equal 'https://twitter.com/@AFP', data['author_url']
     assert_not_nil data['picture']
     assert_match(/StandardError/, data['error']['message'])
   end


### PR DESCRIPTION
Twitter recommends the metatag with the format:
<meta *name*="twitter:creator" content="<something>"/>

But on flickr, for example, the metatag is like:
<meta *property*="twitter:creator" content="<something>" />

Now Pender will support both metatags