### PR TITLE
Ticket #5940: Suport Facebook links with `pg` and `album.php`

### DIFF
--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -63,6 +63,10 @@ module MediaFacebookItem
       params = CGI.parse(uri.query)
       id = params['set'].first.split('.')[1]
     end
+    if id === 'photos'
+      params = CGI.parse(uri.query)
+      id = params['album_id'].first
+    end
     id = '' if id === 'livemap'
     self.data['object_id'] = id.sub(/:0$/, '')
   end
@@ -117,8 +121,13 @@ module MediaFacebookItem
 
   def get_url_from_object(object)
     return unless ['video', 'photo', 'status'].include?(object['type'])
-    self.url = object['link'] if object['type'] === 'video'
-    self.url = object['permalink_url'] if object['type'] == 'status' || object['type'] === 'photo'
+    self.url = if object['type'] === 'video'
+      object['link']
+    elsif object['type'] == 'status'
+      object['permalink_url']
+    elsif object['type'] === 'photo'
+      object['permalink_url'].match(/album\.php/) ? object['link'] : object['permalink_url']
+    end
     normalize_url
   end
 

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -470,7 +470,7 @@ class MediaTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.facebook.com/quoted.pictures/photos/a.128828073875334.28784.128791873878954/1096134023811396/?type=3&theater'
     d = m.as_json
     assert_equal 'New Quoted Pictures Everyday on Facebook', d['title']
-    assert_equal 'New Quoted Pictures Everyday added a new photo.', d['description']
+    assert_match(/New Quoted Pictures Everyday added a new photo./, d['description'])
   end
 
   test "should parse Facebook photo post within an album url" do
@@ -1366,6 +1366,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Mariano Rajoy Brey', d['user_name']
     assert_equal 10, d['media_count']
     assert_equal '10154534110871407', d['object_id']
+    assert_equal 'https://www.facebook.com/54212446406/photos/a.10154534110871407.1073742048.54212446406/10154534111016407?type=3', m.url
   end
 
   test "should get all information of a truncated tweet" do
@@ -1374,4 +1375,30 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Anti immigrant graffiti in a portajon on a residential construction site in Mtn Brook, AL. Job has about 50% Latino workers. https://t.co/bS5vI4Jq7I', d['description']
     assert_not_nil d['entities']['media'][0]['media_url_https']
   end
+
+  test "should support facebook pattern with pg" do
+    m = create_media url: 'https://www.facebook.com/pg/Mariano-Rajoy-Brey-54212446406/photos/?tab=album&album_id=10154534110871407'
+    d = m.as_json
+    assert_equal '54212446406_10154534110871407', d['uuid']
+    assert_match(/En el Museo Serralves de Oporto/, d['text'])
+    assert_equal '54212446406', d['user_uuid']
+    assert_equal 'Mariano Rajoy Brey', d['user_name']
+    assert_equal 10, d['media_count']
+    assert_equal '10154534110871407', d['object_id']
+    assert_equal 'https://www.facebook.com/54212446406/photos/a.10154534110871407.1073742048.54212446406/10154534111016407?type=3',
+    m.url
+  end
+
+  test "should support facebook pattern with album" do
+    m = create_media url: 'https://www.facebook.com/album.php?fbid=10154534110871407&id=54212446406&aid=1073742048'
+    d = m.as_json
+    assert_equal '54212446406_10154534110871407', d['uuid']
+    assert_match(/En el Museo Serralves de Oporto/, d['text'])
+    assert_equal '54212446406', d['user_uuid']
+    assert_equal 'Mariano Rajoy Brey', d['user_name']
+    assert_equal 10, d['media_count']
+    assert_equal '10154534110871407', d['object_id']
+    assert_equal 'https://www.facebook.com/54212446406/photos/a.10154534110871407.1073742048.54212446406/10154534111016407?type=3', m.url
+  end
+
 end


### PR DESCRIPTION
Also: avoid FB url's with `album.php` because they can't be used as embed