### PR TITLE
Ticket #6146: Handle error when call oembed format

### DIFF
--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -116,8 +116,14 @@ module Api
       end
 
       def render_as_oembed
-        json = @media.as_oembed(request.original_url, params[:maxwidth], params[:maxheight], { force: @refresh })
-        render json: json, status: 200
+        begin
+          json = @media.as_oembed(request.original_url, params[:maxwidth], params[:maxheight], { force: @refresh })
+          render json: json, status: 200
+        rescue StandardError => e
+          data = @media.nil? ? {} : @media.data
+          Airbrake.notify(e) if Airbrake.configuration.api_key
+          render_media(data.merge(error: { message: e.message, code: 'UNKNOWN' }))
+        end
       end
 
       def save_cache

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -37,7 +37,7 @@ class Media
   def as_oembed(original_url, maxwidth, maxheight, options = {})
     data = self.as_json(options)
     oembed = "#{data['provider']}_as_oembed"
-    self.respond_to?(oembed)? self.send(oembed, original_url, maxwidth, maxheight) : self.default_oembed(original_url, maxwidth, maxheight)
+    self.respond_to?(oembed)? self.send(oembed, original_url, maxwidth, maxheight) : self.default_oembed(data, original_url, maxwidth, maxheight)
   end
 
   def self.minimal_data(instance)
@@ -82,10 +82,9 @@ class Media
 
   protected
 
-  def default_oembed(original_url, maxwidth, maxheight)
+  def default_oembed(data, original_url, maxwidth, maxheight)
     maxwidth ||= 800
     maxheight ||= 200
-    data = self.as_json
     src = original_url.gsub('medias.oembed', 'medias.html')
     {
       type: 'rich',

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -370,4 +370,22 @@ class MediasControllerTest < ActionController::TestCase
     delete :delete, url: 'http://test.com', format: 'json'
     assert_response 401
   end
+
+  test "should return custom oEmbed format for scmp url" do
+    url = 'http://www.scmp.com/news/hong-kong/politics/article/2071886/crucial-next-hong-kong-leader-have-central-governments-trust'
+    get :index, url: url, format: :oembed, refresh: '1'
+    assert_response :success
+    assert_not_nil response.body
+  end
+
+  test "should handle error when calls oembed format" do
+    url = 'http://www.scmp.com/news/hong-kong/politics/article/2071886/crucial-next-hong-kong-leader-have-central-governments-trust'
+    Media.any_instance.stubs(:as_oembed).raises(StandardError)
+    get :index, url: url, format: :oembed, refresh: '1'
+    assert_response :success
+    assert_not_nil response.body
+    Media.any_instance.unstub(:as_oembed)
+  end
+
+
 end


### PR DESCRIPTION
Also avoid calling `as_json` twice