### PR TITLE
Ticket #6237: Normalize url before trying to find the media cache

### DIFF
--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -18,7 +18,7 @@ module Api
         (render_parameters_missing and return) if @url.blank?
 
         @refresh = params[:refresh] == '1'
-        @id = Digest::MD5.hexdigest(@url)
+        @id = Digest::MD5.hexdigest(Media.normalize_url(@url))
 
         (render_uncached_media and return) if @refresh || Rails.cache.read(@id).nil?
 

--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -18,7 +18,7 @@ module Api
         (render_parameters_missing and return) if @url.blank?
 
         @refresh = params[:refresh] == '1'
-        @id = Digest::MD5.hexdigest(Media.normalize_url(@url))
+        @id = Media.get_id(@url)
 
         (render_uncached_media and return) if @refresh || Rails.cache.read(@id).nil?
 
@@ -33,7 +33,7 @@ module Api
         return unless request.format.json?
         urls = params[:url].is_a?(Array) ? params[:url] : params[:url].split(' ')
         urls.each do |url|
-          @id = Digest::MD5.hexdigest(url)
+          @id = Media.get_id(url)
           Rails.cache.delete(@id)
           cc_url = request.domain + '/api/medias.html?url=' + url
           CcDeville.clear_cache_for_url(cc_url)

--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -132,7 +132,7 @@ module MediaFacebookItem
                elsif object['type'] == 'photo'
                  object['permalink_url'].match(/album\.php/) ? object['link'] : object['permalink_url']
                end
-    normalize_url
+    self.url = Media.normalize_url(self.url)
   end
 
   def get_facebook_picture(id)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -56,7 +56,7 @@ class Media
     end
     self.original_url = self.url
     self.follow_redirections
-    self.normalize_url unless self.get_canonical_url
+    self.url = Media.normalize_url(self.url) unless self.get_canonical_url
     self.try_https
     self.data = {}.with_indifferent_access
   end
@@ -184,8 +184,8 @@ class Media
     true
   end
 
-  def normalize_url
-    self.url = PostRank::URI.normalize(self.url).to_s
+  def self.normalize_url(url)
+    PostRank::URI.normalize(url).to_s
   end
 
   ##

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -54,7 +54,7 @@ class Media
     attributes.each do |name, value|
       send("#{name}=", value)
     end
-    self.original_url = self.url
+    self.original_url = self.url.strip
     self.follow_redirections
     self.url = Media.normalize_url(self.url) unless self.get_canonical_url
     self.try_https
@@ -66,7 +66,7 @@ class Media
   end
 
   def as_json(options = {})
-    Rails.cache.fetch(self.get_id, options) do
+    Rails.cache.fetch(Media.get_id(self.original_url), options) do
       self.parse
       self.data.merge(Media.required_fields(self)).with_indifferent_access
     end
@@ -139,11 +139,11 @@ class Media
     "<iframe src=\"#{src}\" width=\"#{maxwidth}\" height=\"#{maxheight}\" scrolling=\"no\" border=\"0\" seamless>Not supported</iframe>"
   end
 
-  protected
-
-  def get_id
-    Digest::MD5.hexdigest(self.original_url)
+  def self.get_id(url)
+    Digest::MD5.hexdigest(Media.normalize_url(url))
   end
+
+  protected
 
   def parse
     self.data = Media.minimal_data(self)

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -342,8 +342,8 @@ class MediasControllerTest < ActionController::TestCase
     authenticate_with_token
     url1 = 'http://ca.ios.ba'
     url2 = 'https://twitter.com/caiosba/status/742779467521773568'
-    id1 = Digest::MD5.hexdigest(url1)
-    id2 = Digest::MD5.hexdigest(url2)
+    id1 = Media.get_id(url1)
+    id2 = Media.get_id(url2)
     cachefile1 = File.join('public', 'cache', Rails.env, "#{id1}.html")
     cachefile2 = File.join('public', 'cache', Rails.env, "#{id2}.html")
     

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -425,4 +425,15 @@ class MediasControllerTest < ActionController::TestCase
     Airbrake.configuration.unstub(:api_key)
     Airbrake.unstub(:notify)
   end
+
+  test "should parse Facebook user profile with normalized urls" do
+    authenticate_with_token
+    get :index, url: 'https://facebook.com/caiosba', refresh: '1', format: :json
+    first_parsed_at = Time.parse(JSON.parse(@response.body)['data']['parsed_at']).to_i
+    sleep 1
+    get :index, url: 'https://facebook.com/caiosba/', format: :json
+    second_parsed_at = Time.parse(JSON.parse(@response.body)['data']['parsed_at']).to_i
+    assert_equal first_parsed_at, second_parsed_at
+  end
+
 end


### PR DESCRIPTION
With this fix, Pender will recognize urls like the example below as the
same on controller and avoid parsing again:
"https://facebook.com/caiosba" and "https://facebook.com/caiosba/"