### PR TITLE
Ticket #6173: Add support to pages that redirect from https to http

### DIFF
--- a/app/models/concerns/media_facebook_profile.rb
+++ b/app/models/concerns/media_facebook_profile.rb
@@ -105,7 +105,7 @@ module MediaFacebookProfile
       /^https:\/\/(www\.)?facebook\.com\/([0-9]+)$/,
       /^https?:\/\/(www\.)?facebook\.com\/([^\/\?]+)/
     ]
-    username = compare_patterns(patterns)
+    username = compare_patterns(URI.decode(self.url), patterns)
     return if ['events', 'livemap'].include? username
     if username === 'pages'
       username = self.url.match(/^https?:\/\/(www\.)?facebook\.com\/pages\/([^\/]+)\/([^\/\?]+).*/)[2]
@@ -125,14 +125,14 @@ module MediaFacebookProfile
         /^https:\/\/(www\.)?facebook\.com\/([0-9]+)$/,
         /^https?:\/\/([^\.]+\.)?facebook\.com\/people\/[^\/\?]+\/([0-9]+)$/
       ]
-      id = compare_patterns(patterns).to_i
+      id = compare_patterns(self.url, patterns).to_i
     end
     id
   end
 
-  def compare_patterns(patterns)
+  def compare_patterns(url, patterns)
     patterns.each do |p|
-      match = self.url.match p
+      match = url.match p
       return match[2] unless match.nil?
     end
     nil

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -250,6 +250,9 @@ class Media
       return nil
     rescue Zlib::DataError
       self.get_html(html_options.merge('Accept-Encoding' => 'identity'))
+    rescue RuntimeError => e
+      Airbrake.notify(e) if Airbrake.configuration.api_key
+      return nil
     end
   end
 

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -1208,6 +1208,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_not_nil d['published_at']
     assert_equal '', d['username']
     assert_equal 'https://br.yahoo.com', d['author_url']
+    assert_equal 'Yahoo', d['author_name']
     assert_not_nil d['picture']
   end
 
@@ -1223,6 +1224,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_not_nil d['published_at']
     assert_equal '', d['username']
     assert_equal 'https://ca.yahoo.com', d['author_url']
+    assert_equal 'Yahoo', d['author_name']
     assert_not_nil d['picture']
     assert_nil d['error']
   end
@@ -1239,6 +1241,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_not_nil d['published_at']
     assert_equal '', d['username']
     assert_not_nil d['author_url']
+    assert_equal 'Yahoo', d['author_name']
     assert_not_nil d['picture']
     assert_nil d['error']
   end
@@ -1785,5 +1788,50 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'https://graph.facebook.com/735450245/picture', d['author_picture']
     assert_equal 0, d['media_count']
     assert_not_nil d['picture']
+  end
+
+  test "should parse url with redirection https -> http" do
+    m = create_media url: 'https://noticias.uol.com.br/cotidiano/ultimas-noticias/2017/07/18/nove-anos-apos-ser-condenado-por-moro-beira-mar-repete-trafico-em-presidio-federal.htm'
+    d = m.as_json
+    assert_equal 'item', d['type']
+    assert_equal 'page', d['provider']
+    assert_match /Nove anos após ser condenado/, d['title']
+    assert_not_nil d['description']
+    assert_not_nil d['published_at']
+    assert_equal '', d['username']
+    assert_equal 'https://noticias.uol.com.br', d['author_url']
+    assert_equal 'Cotidiano', d['author_name']
+    assert_not_nil d['picture']
+    assert_nil d['error']
+  end
+
+  test "should parse url with redirection https -> http 2" do
+    m = create_media url: 'https://www.nature.com/articles/s41562-017-0132'
+    d = m.as_json
+    assert_equal 'item', d['type']
+    assert_equal 'page', d['provider']
+    assert_equal 'Limited individual attention and online virality of low-quality inform', d['title']
+    assert_not_nil d['description']
+    assert_not_nil d['published_at']
+    assert_equal '', d['username']
+    assert_equal 'https://www.nature.com', d['author_url']
+    assert_equal '@NatureHumBehav', d['author_name']
+    assert_equal 'https://media.springernature.com/m685/nature-static/assets/v1/image-assets/s41562-017-0132-f1.jpg',  d['picture']
+    assert_nil d['error']
+  end
+
+  test "should get author_name from site" do
+    m = create_media url: 'https://noticias.uol.com.br/'
+    d = m.as_json
+    assert_equal 'item', d['type']
+    assert_equal 'page', d['provider']
+    assert_match /UOL Notícias:/, d['title']
+    assert_not_nil d['description']
+    assert_not_nil d['published_at']
+    assert_equal '', d['username']
+    assert_equal 'https://noticias.uol.com.br', d['author_url']
+    assert_equal 'UOL Notícias', d['author_name']
+    assert_not_nil d['picture']
+    assert_nil d['error']
   end
 end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -400,7 +400,7 @@ class MediaTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.facebook.com/photo.php?fbid=1028424567222135&set=a.1028424563888802.1073741827.749262715138323&type=3'
     d = m.as_json
     assert_equal '749262715138323_1028424567222135', d['uuid']
-    assert_equal 'Teste updated their profile picture.', d['text']
+    assert_equal 'Teste added a new photo.', d['text']
     assert_equal '749262715138323', d['user_uuid']
     assert_equal 'Teste', d['author_name']
     assert_equal 1, d['media_count']


### PR DESCRIPTION
The redirection `https` to `http` is allowed only when the request
doesn't have credentials for `http_basic_authentication` header

Also:
- search for `author_name` in more meta tags
- decode url when trying to parse FB username;