### PR TITLE
Ticket #6617: Raise errbit error only when FB token is expired

### DIFF
--- a/app/models/concerns/media_facebook_profile.rb
+++ b/app/models/concerns/media_facebook_profile.rb
@@ -69,7 +69,8 @@ module MediaFacebookProfile
       begin
         self.data.merge! self.get_data_from_facebook
       rescue Koala::Facebook::ClientError => e
-        Airbrake.notify("#{e}: #{self.url}") if Airbrake.configuration.api_key
+        Rails.logger.info "[Facebook Profile] Parsing `#{url}`: Error Code: #{e.fb_error_code} Subcode #{e.fb_error_subcode} Message: #{e.fb_error_message}"
+        Airbrake.notify(e) if Airbrake.configuration.api_key && e.fb_error_code == 190
         raise e
       end
     end


### PR DESCRIPTION
Other errors with Facebook profile urls will not raise Errbit error, but
will be on log