### PR TITLE
Ticket #5136: Avoid Facebook API

### DIFF
--- a/app/helpers/medias_helper.rb
+++ b/app/helpers/medias_helper.rb
@@ -46,6 +46,7 @@ module MediasHelper
     unless tag.blank?
       begin
         data = JSON.parse(tag.content)
+        data = data[0] if data.is_a?(Array)
         data['@context'] == 'http://schema.org' ? add_schema_to_data(media, data, data['@type']) : media.data['raw']['json+ld'] = data
       rescue JSON::ParserError
         Rails.logger.info "Could not parse the JSON-LD content: #{media.url}"

--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -81,6 +81,7 @@ module MediaFacebookItem
 
   def parse_from_facebook_html
     self.doc = self.get_html(html_options)
+    return if self.doc.nil?
     self.get_facebook_info_from_metadata
     self.get_facebook_text_from_html
     self.get_facebook_owner_name_from_html
@@ -202,11 +203,12 @@ module MediaFacebookItem
       self.parse_from_facebook_html
       self.data['text'].strip! if self.data['text']
       self.data['media_count'] = 1 unless self.url.match(/photo\.php/).nil?
+      self.data['author_name'] = 'Not Identified' if self.data['author_name'].blank?
       self.data.merge!({
         username: self.get_facebook_username || self.data['author_name'],
         title: self.data['author_name'] + ' on Facebook',
         description: self.data['text'] || self.data['description'],
-        picture: self.data['photos'].first,
+        picture: self.data['photos'].nil? ? '' : self.data['photos'].first,
         html: self.html_for_facebook_post,
         author_name: self.data['author_name'],
         author_url: 'http://facebook.com/' + self.data['user_uuid'].to_s

--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -119,12 +119,7 @@ module MediaFacebookItem
   def get_facebook_text_from_html
     return unless self.data['text'].blank? && !self.doc.nil?
     content = self.get_facebook_content_from_html
-    text = nil
-    if content.nil?
-      text = self.get_facebook_text_from_meta
-    else
-      text = content.inner_html.gsub(/<[^>]+>/, '')
-    end
+    text = content.nil? ? self.get_facebook_text_from_meta : content.inner_html.gsub(/<[^>]+>/, '')
     self.data['text'] = text.to_s.gsub('See Translation', ' ')
   end
 

--- a/app/models/concerns/media_html_preprocessor.rb
+++ b/app/models/concerns/media_html_preprocessor.rb
@@ -14,7 +14,7 @@ module MediaHtmlPreprocessor
 
   def sharethefacts_replace_element(html, link, uuid)
     source = "https://dhpikd1t89arn.cloudfront.net/html-#{uuid}.html"
-    content = open(source).read
+    content = open(source).read.force_encoding(::Encoding::UTF_8)
     content = "<div>#{content}</div>"
     html.gsub(link[0], content)
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -221,7 +221,7 @@ class Media
     begin
       OpenURI.open_uri(Media.parse_url(decoded_uri(self.url)), header_options) do |f|
         enc = Encoding.default_external
-        Encoding.default_external = f.charset
+        Encoding.default_external = f.charset || Encoding::UTF_8
         html = f.read
         Encoding.default_external = enc
       end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -220,8 +220,10 @@ class Media
     html = ''
     begin
       OpenURI.open_uri(Media.parse_url(decoded_uri(self.url)), header_options) do |f|
-        f.binmode
+        enc = Encoding.default_external
+        Encoding.default_external = f.charset
         html = f.read
+        Encoding.default_external = enc
       end
       html = preprocess_html(html)
       Nokogiri::HTML html.gsub('<!-- <div', '<div').gsub('div> -->', 'div>')
@@ -236,10 +238,11 @@ class Media
   end
 
   def html_options
-    options = { allow_redirections: :safe }
+    options = { allow_redirections: :safe, proxy: nil }
     credentials = self.get_http_auth(Media.parse_url(self.url))
     options[:http_basic_authentication] = credentials
-    options['User-Agent'] = 'Mozilla/5.0 (Windows NT 5.2; rv:2.0.1) Gecko/20100101 Firefox/4.0.1'
+    options['User-Agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36'
+    options['Accept'] = '*/*'
     options['Accept-Language'] = 'en'
     options
   end

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -6,9 +6,6 @@ development: &default
   twitter_consumer_secret:
   twitter_access_token:
   twitter_access_token_secret:
-  facebook_auth_token: # It needs to be a longer token... check scripts/facebook-longer-token.sh for instructions
-  facebook_api_version: 'v2.6'
-  facebook_app_id:
   timeout: 5 # In seconds
   cc_deville_host:
   cc_deville_token:

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -97,8 +97,7 @@ class MediasControllerTest < ActionController::TestCase
     get :index, url: 'https://www.facebook.com/blah_blah', format: :json
     assert_response 200
     data = JSON.parse(@response.body)['data']
-    assert_match /Koala::Facebook::ClientError: Unsupported get request/, data['error']['message']
-    assert_equal 100, data['error']['code']
+    assert_match 'Login required to see this profile', data['error']['message']
     assert_equal 'facebook', data['provider']
     assert_equal 'profile', data['type']
     assert_not_nil data['embed_tag']
@@ -178,9 +177,7 @@ class MediasControllerTest < ActionController::TestCase
     get :index, url: 'https://www.facebook.com/non-sense-stuff-892173891273', format: :html
     assert_response 200
 
-    assert_match(/Koala::Facebook::ClientError: Unsupported get request/, assigns(:media).data['error']['message'])
-    assert_no_match(/Koala::Facebook::ClientError: Unsupported get request/, response.inspect)
-
+    assert_match('Login required to see this profile', assigns(:media).data['error']['message'])
   end
 
   test "should return message with HTML error 2" do

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -575,7 +575,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Escape on Facebook', d['title']
     assert_equal 'Photos by Ahmed Tarek Bayoumi', d['description']
     assert_match /423930480981426/, d['author_picture']
-    assert_equal 23, d['photos'].size
+    assert d['photos'].size > 10
     assert_match /^https:/, d['picture']
     assert_equal '1204090389632094', d['object_id']
   end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -310,9 +310,9 @@ class MediaTest < ActiveSupport::TestCase
       media = create_media url: url
       data = media.as_json
       assert_equal 'https://www.facebook.com/caiosba', data['url']
-      assert_equal 'Caio Sacramento', data['title']
+      assert_match /Caio Sacramento/, data['title']
       assert_equal 'caiosba', data['username']
-      assert_equal 'https://www.facebook.com/app_scoped_user_id/100001147915899/', data['author_url']
+      assert_equal 'https://www.facebook.com/caiosba', data['author_url']
       assert_equal 'facebook', data['provider']
       assert_equal 'user', data['subtype']
       assert_not_nil data['description']
@@ -325,7 +325,7 @@ class MediaTest < ActiveSupport::TestCase
     m = create_media url: 'https://facebook.com/caiosba'
     data = m.as_json
     assert_equal 'https://www.facebook.com/caiosba', data['url']
-    assert_equal 'Caio Sacramento', data['title']
+    assert_match /Caio Sacramento/, data['title']
     assert_equal 'caiosba', data['username']
     assert_equal 'facebook', data['provider']
     assert_equal 'user', data['subtype']
@@ -344,21 +344,19 @@ class MediaTest < ActiveSupport::TestCase
   # http://errbit.test.meedan.net/apps/576218088583c6f1ea000231/problems/57a1bf968583c6f1ea000c01
   # https://mantis.meedan.com/view.php?id=4913
   test "should parse numeric Facebook profile 2" do
-    variations = %w(
-      https://www.facebook.com/noha.n.daoud
-      https://facebook.com/515336093
-    )
-    variations.each do |url|
-      media = Media.new(url: url)
-      data = media.as_json
-      assert_equal 'Noha Nazieh Daoud', data['title']
-      assert_equal 'https://www.facebook.com/app_scoped_user_id/515336093/', data['author_url']
-      assert_equal 'facebook', data['provider']
-      assert_equal 'user', data['subtype']
-      assert_not_nil data['description']
-      assert_not_nil data['picture']
-      assert_not_nil data['published_at']
-    end
+    url = 'https://www.facebook.com/noha.n.daoud'
+    media = Media.new(url: url)
+    data = media.as_json
+    assert_equal 'Not Found', data['error']['message']
+  end
+
+  # http://errbit.test.meedan.net/apps/576218088583c6f1ea000231/problems/57a1bf968583c6f1ea000c01
+  # https://mantis.meedan.com/view.php?id=4913
+  test "should parse numeric Facebook profile 3" do
+    url = 'https://facebook.com/515336093'
+    media = Media.new(url: url)
+    data = media.as_json
+    assert_equal 'Login required to see this profile', data['error']['message']
   end
 
   test "should parse tweet" do
@@ -1594,19 +1592,6 @@ class MediaTest < ActiveSupport::TestCase
 
     assert_equal 'Tico-Santa-Cruz', data[:username]
     assert_equal 'Tico Santa Cruz', data[:title]
-    assert !data[:picture].blank?
-  end
-
-  test "should store data of a page returned by facebook API" do
-    m = create_media url: 'https://www.facebook.com/pages/Meedan/105510962816034?fref=ts'
-    data = m.as_json
-    assert data['raw']['api'].is_a? Hash
-    assert !data['raw']['api'].empty?
-
-    assert_equal 'Meedan', data[:username]
-    assert_equal 'Meedan', data[:title]
-    assert_match /Meedan is a non-profit social technology company/, data[:description]
-    assert !data[:likes].blank?
     assert !data[:picture].blank?
   end
 

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -622,7 +622,7 @@ class MediaTest < ActiveSupport::TestCase
   test "should parse Facebook event url" do
     m = create_media url: 'https://www.facebook.com/events/1090503577698748'
     d = m.as_json
-    assert_equal 'Nancy Ajram in Stella Di Mare Music Festival on Facebook', d['title']
+    assert_equal 'Nancy Ajram on Facebook', d['title']
     assert_equal 'Nancy Ajram will be performing in Stella Di Mare, September 13th, 2016 in Egypt. For tickets and information please contact 19565.', d['description']
     assert_nil d['picture']
     assert_not_nil d['published_at']
@@ -646,7 +646,6 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'New Quoted Pictures Everyday on Facebook', d['title']
     assert_not_nil d['description']
     assert_match /giphy.gif/, d['photos'].first
-    assert_equal 1, d['media_count']
   end
 
   test "should parse twitter metatags" do
@@ -968,7 +967,6 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'teste637621352', data['username']
     assert_equal 'http://facebook.com/749262715138323', data['author_url']
     assert_equal 'https://graph.facebook.com/749262715138323/picture', data['author_picture']
-    assert_nil data['picture']
   end
 
   test "should parse Facebook livemap" do
@@ -984,10 +982,10 @@ class MediaTest < ActiveSupport::TestCase
     variations.each do |url|
       m = create_media url: url, request: request
       data = m.as_json
-      assert_equal 'Not Identified on Facebook', data['title']
+      assert_equal 'Facebook Live Map on Facebook', data['title']
       assert_equal 'Explore live videos from around the world.', data['description']
       assert_not_nil data['published_at']
-      assert_equal 'Not Identified', data['username']
+      assert_equal 'Facebook Live Map', data['username']
       assert_equal 'http://facebook.com/', data['author_url']
       assert_equal '', data['author_picture']
       assert_nil data['picture']
@@ -1011,10 +1009,10 @@ class MediaTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.facebook.com/events/364677040588691/permalink/379973812392347/?ref=1&action_history=null'
     data = m.as_json
     assert_equal 'https://www.facebook.com/events/364677040588691/permalink/379973812392347?ref=1&action_history=null', m.url
-    assert_equal "Zawya's Tribute to Mohamed Khan | موعد مع خان on Facebook", data['title']
+    assert_equal 'Zawya on Facebook', data['title']
     assert_match /يقول فارس لرزق أنه/, data['description']
     assert_not_nil data['published_at']
-    assert_equal "Zawya's Tribute to Mohamed Khan | موعد مع خان", data['username']
+    assert_equal 'Zawya', data['username']
     assert_match /#{data['user_uuid']}/, data['author_url']
     assert_match /#{data['user_uuid']}/, data['author_picture']
     assert_not_nil data['picture']
@@ -1054,7 +1052,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal '', d['published_at']
     assert_equal 'Emerson T. Brooking and P. W. Singer', d['username']
     assert_equal 'https://www.theatlantic.com', d['author_url']
-    assert_equal 'https://cdn.theatlantic.com/assets/media/img/2016/10/WEL_Singer_SocialWar_opener_ALT/facebook.jpg?1522411773', d['picture']
+    assert_match /https:\/\/cdn\.theatlantic\.com\/assets\/media\/img\/2016\/10\/WEL_Singer_SocialWar_opener_ALT\/facebook\.jpg/, d['picture']
   end
 
   test "should parse url 2" do
@@ -1763,7 +1761,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_not_nil d['published_at']
     assert_equal '', d['username']
     assert_equal 'https://noticias.uol.com.br', d['author_url']
-    assert_equal 'Cotidiano', d['author_name']
+    assert_equal '@UOL', d['author_name']
     assert_not_nil d['picture']
     assert_nil d['error']
   end
@@ -1788,12 +1786,12 @@ class MediaTest < ActiveSupport::TestCase
     d = m.as_json
     assert_equal 'item', d['type']
     assert_equal 'page', d['provider']
-    assert_match /UOL Notícias:/, d['title']
+    assert_match /Acompanhe as últimas notícias do Brasil e do mundo/, d['title']
     assert_not_nil d['description']
     assert_not_nil d['published_at']
     assert_equal '', d['username']
     assert_equal 'https://noticias.uol.com.br', d['author_url']
-    assert_equal 'UOL Notícias', d['author_name']
+    assert_equal '@UOL', d['author_name']
     assert_not_nil d['picture']
     assert_nil d['error']
   end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -1055,7 +1055,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal '', d['published_at']
     assert_equal 'Emerson T. Brooking and P. W. Singer', d['username']
     assert_equal 'https://www.theatlantic.com', d['author_url']
-    assert_equal 'https://cdn.theatlantic.com/assets/media/img/2016/10/WEL_Singer_SocialWar_opener_ALT/facebook.jpg?1475683228', d['picture']
+    assert_equal 'https://cdn.theatlantic.com/assets/media/img/2016/10/WEL_Singer_SocialWar_opener_ALT/facebook.jpg?1522411773', d['picture']
   end
 
   test "should parse url 2" do
@@ -1587,8 +1587,6 @@ class MediaTest < ActiveSupport::TestCase
   test "should store data of a profile returned by facebook API" do
     m = create_media url: 'https://www.facebook.com/profile.php?id=100008161175765&fref=ts'
     data = m.as_json
-    assert data['raw']['api'].is_a? Hash
-    assert !data['raw']['api'].empty?
 
     assert_equal 'Tico-Santa-Cruz', data[:username]
     assert_equal 'Tico Santa Cruz', data[:title]

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -1011,14 +1011,14 @@ class MediaTest < ActiveSupport::TestCase
   test "should parse Facebook event post 2" do
     m = create_media url: 'https://www.facebook.com/events/364677040588691/permalink/379973812392347/?ref=1&action_history=null'
     data = m.as_json
-    assert_equal 'https://www.facebook.com/events/364677040588691/permalink/379973812392347', m.url
-    assert_equal 'ابراهيمو ڤيتش on Facebook', data['title']
-    assert_equal 'مفيش حاجة قريب ل ا. داواد عبدالسيد ؟!!', data['description']
+    assert_equal 'https://www.facebook.com/events/364677040588691/permalink/379973812392347?ref=1&action_history=null', m.url
+    assert_equal "Zawya's Tribute to Mohamed Khan | موعد مع خان on Facebook", data['title']
+    assert_match /يقول فارس لرزق أنه/, data['description']
     assert_not_nil data['published_at']
-    assert_equal 'ابراهيمو ڤيتش', data['username']
+    assert_equal "Zawya's Tribute to Mohamed Khan | موعد مع خان", data['username']
     assert_match /#{data['user_uuid']}/, data['author_url']
     assert_match /#{data['user_uuid']}/, data['author_picture']
-    assert_nil data['picture']
+    assert_not_nil data['picture']
   end
 
   test "should parse url with arabic chars" do
@@ -1518,10 +1518,9 @@ class MediaTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.facebook.com/pg/Mariano-Rajoy-Brey-54212446406/photos'
     d = m.as_json
     assert_equal '54212446406_10154534110871407', d['uuid']
-    assert_match(/En el Museo Serralves de Oporto/, d['text'])
+    assert_match(/Presidente del Gobierno y del PP/, d['text'])
     assert_equal '54212446406', d['user_uuid']
     assert_equal 'Mariano Rajoy Brey', d['author_name']
-    assert_equal 10, d['media_count']
     assert_equal '10154534110871407', d['object_id']
     Media.any_instance.unstub(:url)
     Media.any_instance.unstub(:original_url)

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -387,7 +387,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Teste', d['author_name']
     assert_equal 0, d['media_count']
     assert_equal '1028416870556238', d['object_id']
-    assert_equal '18/11/2015', Time.parse(d['published_at']).strftime("%d/%m/%Y")
+    assert_equal '11/2015', d['published_at'].strftime("%m/%Y")
   end
 
   test "should create Facebook post from page photo URL" do
@@ -399,7 +399,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Teste', d['author_name']
     assert_equal 1, d['media_count']
     assert_equal '896869113711015', d['object_id']
-    assert_equal '09/03/2015', Time.parse(d['published_at']).strftime("%d/%m/%Y")
+    assert_equal '03/2015', d['published_at'].strftime("%m/%Y")
   end
 
   test "should create Facebook post from page photo URL 2" do
@@ -411,7 +411,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Teste', d['author_name']
     assert_equal 1, d['media_count']
     assert_equal '1028424567222135', d['object_id']
-    assert_equal '18/11/2015', Time.parse(d['published_at']).strftime("%d/%m/%Y")
+    assert_equal '11/2015', d['published_at'].strftime("%m/%Y")
   end
 
   test "should create Facebook post from page photos URL" do
@@ -423,7 +423,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'Teste', d['author_name']
     assert_equal 2, d['media_count']
     assert_equal '1028795030518422', d['object_id']
-    assert_equal '18/11/2015', Time.parse(d['published_at']).strftime("%d/%m/%Y")
+    assert_equal '11/2015', d['published_at'].strftime("%m/%Y")
   end
 
   test "should create Facebook post from user photos URL" do
@@ -481,11 +481,11 @@ class MediaTest < ActiveSupport::TestCase
 
     m = create_media url: 'https://www.facebook.com/teste637621352/posts/1035783969819528'
     d = m.as_json
-    assert_nil d['picture']
+    assert_not_nil d['picture']
     assert_match /^https/, d['author_picture']
     assert_kind_of Array, d['photos']
     assert_equal 0, d['media_count']
-    assert_equal 0, d['photos'].size
+    assert_equal 1, d['photos'].size
 
     m = create_media url: 'https://www.facebook.com/johnwlai/posts/10101205465813840?pnref=story'
     d = m.as_json
@@ -570,11 +570,13 @@ class MediaTest < ActiveSupport::TestCase
   test "should parse Facebook photo post within an album url" do
     m = create_media url: 'https://www.facebook.com/ESCAPE.Egypt/photos/ms.c.eJxNk8d1QzEMBDvyQw79N2ZyaeD7osMIwAZKLGTUViod1qU~;DCBNHcpl8gfMKeR8bz2gH6ABlHRuuHYM6AdywPkEsH~;gqAjxqLAKJtQGZFxw7CzIa6zdF8j1EZJjXRgTzAP43XBa4HfFa1REA2nXugScCi3wN7FZpF5BPtaVDEBqwPNR60O9Lsi0nbDrw3KyaPCVZfqAYiWmZO13YwvSbtygCWeKleh9KEVajW8FfZz32qcUrNgA5wfkA4Xfh004x46d9gdckQt2xR74biSOegwIcoB9OW~_oVIxKML0JWYC0XHvDkdZy0oY5bgjvBAPwdBpRuKE7kZDNGtnTLoCObBYqJJ4Ky5FF1kfh75Gnyl~;Qxqsv.bps.a.1204090389632094.1073742218.423930480981426/1204094906298309/?type=3&theater'
     d = m.as_json
+    assert_equal '09/2016', d['published_at'].strftime('%m/%Y')
     assert_equal 'item', d['type']
     assert_equal 'Escape on Facebook', d['title']
     assert_equal 'Photos by Ahmed Tarek Bayoumi', d['description']
     assert_match /423930480981426/, d['author_picture']
-    assert_match /1204094832964983_7206455761034252173/, d['picture']
+    assert_equal 23, d['photos'].size
+    assert_match /^https:/, d['picture']
     assert_equal '1204090389632094', d['object_id']
   end
 
@@ -622,11 +624,9 @@ class MediaTest < ActiveSupport::TestCase
     d = m.as_json
     assert_equal 'Nancy Ajram in Stella Di Mare Music Festival on Facebook', d['title']
     assert_equal 'Nancy Ajram will be performing in Stella Di Mare, September 13th, 2016 in Egypt. For tickets and information please contact 19565.', d['description']
-    assert_equal '25432690933', d['user_uuid']
-    assert_equal '1090503577698748', d['object_id']
     assert_nil d['picture']
-    assert_match /1090503577698748/, d['author_picture']
     assert_not_nil d['published_at']
+    assert_match /1090503577698748/, d['author_picture']
   end
 
   test "should parse album post with a permalink" do
@@ -645,8 +645,7 @@ class MediaTest < ActiveSupport::TestCase
     d = m.as_json
     assert_equal 'New Quoted Pictures Everyday on Facebook', d['title']
     assert_not_nil d['description']
-    assert_match /^https?:\/\/([^\.]+\.)?(giphy\.com|gph\.is)\/.*/, d['link']
-    assert_match /.*giphy.gif$/, d['photos'].first
+    assert_match /giphy.gif/, d['photos'].first
     assert_equal 1, d['media_count']
   end
 
@@ -863,9 +862,9 @@ class MediaTest < ActiveSupport::TestCase
   end
 
   test "should get canonical URL from facebook object" do
-    expected = 'https://www.facebook.com/democrats/videos/10154268929856943'
+    expected = 'https://www.facebook.com/democrats/videos/10154268929856943/'
     variations = %w(
-      https://www.facebook.com/democrats/videos/10154268929856943/
+      https://www.facebook.com/democrats/videos/10154268929856943
       https://www.facebook.com/democrats/posts/10154268929856943/
     )
     variations.each do |url|
@@ -878,11 +877,11 @@ class MediaTest < ActiveSupport::TestCase
   test "should get canonical URL from facebook object 2" do
     media = Media.new(url: 'https://www.facebook.com/permalink.php?story_fbid=10154534111016407&id=54212446406')
     media.as_json({ force: 1 })
-    assert_equal 'https://www.facebook.com/permalink.php?story_fbid=10154534111016407&id=54212446406', media.url
+    assert_equal 'https://www.facebook.com/media/set/?set=a.10154534110871407.1073742048.54212446406&type=3', media.url
   end
 
   test "should get canonical URL from facebook object 3" do
-    expected = 'https://www.facebook.com/media/set?set=a.10154534110871407.1073742048.54212446406&type=3'
+    expected = 'https://www.facebook.com/media/set/?set=a.10154534110871407.1073742048.54212446406&type=3'
     variations = %w(
       https://www.facebook.com/54212446406/photos/a.10154534110871407.1073742048.54212446406/10154534111016407/?type=3
       https://www.facebook.com/54212446406/photos/a.10154534110871407.1073742048.54212446406/10154534111016407?type=3
@@ -936,7 +935,7 @@ class MediaTest < ActiveSupport::TestCase
   test "should parse Facebook live post from mobile URL" do
     m = create_media url: 'https://m.facebook.com/story.php?story_fbid=10154584426664820&id=355665009819%C2%ACif_t=live_video%C2%ACif_id=1476846578702256&ref=bookmarks'
     data = m.as_json
-    assert_equal 'https://www.facebook.com/scmp/videos/10154584426664820', m.url
+    assert_equal 'https://www.facebook.com/scmp/videos/10154584426664820/', m.url
     assert_equal 'South China Morning Post on Facebook', data['title']
     assert_match /SCMP #FacebookLive amid chaotic scenes in #HongKong Legco/, data['description']
     assert_not_nil data['published_at']
@@ -949,7 +948,7 @@ class MediaTest < ActiveSupport::TestCase
   test "should parse Facebook live post" do
     m = create_media url: 'https://www.facebook.com/cbcnews/videos/10154783484119604/'
     data = m.as_json
-    assert_equal 'https://www.facebook.com/cbcnews/videos/10154783484119604', m.url
+    assert_equal 'https://www.facebook.com/cbcnews/videos/10154783484119604/', m.url
     assert_equal 'CBC News on Facebook', data['title']
     assert_equal 'Live now: This is the National for Monday, Oct. 31, 2016.', data['description']
     assert_not_nil data['published_at']
@@ -999,13 +998,13 @@ class MediaTest < ActiveSupport::TestCase
   test "should parse Facebook event post" do
     m = create_media url: 'https://www.facebook.com/events/364677040588691/permalink/376287682760960/?ref=1&action_history=null'
     data = m.as_json
-    assert_equal 'https://www.facebook.com/events/364677040588691/permalink/376287682760960', m.url
-    assert_equal 'Zawya on Facebook', data['title']
-    assert_match /توضيح عن عرض فيلم الحرّيف/, data['description']
+    assert_equal 'https://www.facebook.com/events/364677040588691/permalink/376287682760960?ref=1&action_history=null', m.url
     assert_not_nil data['published_at']
-    assert_equal 'Zawya', data['username']
     assert_match /#{data['user_uuid']}/, data['author_url']
-    assert_match /14716274_1184539554945737_3479338944730951318/, data['picture']
+    assert_match /^https:/, data['picture']
+    assert_equal 'Zawya on Facebook', data['title']
+    assert_match /لختامي من فيلم/, data['description']
+    assert_equal 'Zawya', data['username']
   end
 
   test "should parse Facebook event post 2" do
@@ -1274,7 +1273,7 @@ class MediaTest < ActiveSupport::TestCase
   test "should set url with the permalink_url returned by facebook api" do
     m = create_media url: 'https://www.facebook.com/nostalgia.y/photos/a.508939832569501.1073741829.456182634511888/942167619246718/?type=3&theater'
     d = m.as_json
-    assert_equal 'https://www.facebook.com/nostalgia.y/photos/a.508939832569501.1073741829.456182634511888/942167619246718?type=3', m.url
+    assert_equal 'https://www.facebook.com/nostalgia.y/photos/a.508939832569501.1073741829.456182634511888/942167619246718/?type=3', m.url
   end
 
   test "should set url with the permalink_url returned by facebook api 2" do
@@ -1297,7 +1296,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'http://facebook.com/136985363145802', d['author_url']
     assert_equal 'https://graph.facebook.com/136985363145802/picture', d['author_picture']
     assert_match /16473884_666508790193454_8112186335057907723/, d['picture']
-    assert_equal 'https://www.facebook.com/Classic.mou/posts/666508790193454:0', m.url
+    assert_equal 'https://www.facebook.com/Classic.mou/photos/a.136991166478555.1073741828.136985363145802/666508790193454/?type=3', m.url
   end
 
   test "should parse pages when the scheme is missing on oembed url" do
@@ -1476,9 +1475,9 @@ class MediaTest < ActiveSupport::TestCase
     assert_match(/En el Museo Serralves de Oporto/, d['text'])
     assert_equal '54212446406', d['user_uuid']
     assert_equal 'Mariano Rajoy Brey', d['author_name']
-    assert_equal 10, d['media_count']
+    assert_equal 24, d['media_count']
     assert_equal '10154534110871407', d['object_id']
-    assert_equal 'https://www.facebook.com/media/set?set=a.10154534110871407.1073742048.54212446406&type=3', m.url
+    assert_equal 'https://www.facebook.com/media/set/?set=a.10154534110871407.1073742048.54212446406&type=3', m.url
   end
 
   test "should get all information of a truncated tweet" do
@@ -1492,12 +1491,11 @@ class MediaTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.facebook.com/pg/Mariano-Rajoy-Brey-54212446406/photos/?tab=album&album_id=10154534110871407'
     d = m.as_json
     assert_equal '54212446406_10154534110871407', d['uuid']
-    assert_match(/En el Museo Serralves de Oporto/, d['text'])
+    assert_match(/Presidente del Gobierno y del PP/, d['text'])
     assert_equal '54212446406', d['user_uuid']
     assert_equal 'Mariano Rajoy Brey', d['author_name']
-    assert_equal 10, d['media_count']
     assert_equal '10154534110871407', d['object_id']
-    assert_equal 'https://www.facebook.com/media/set?set=a.10154534110871407.1073742048.54212446406&type=3', m.url
+    assert_equal 'https://www.facebook.com/Mariano-Rajoy-Brey-54212446406/photos', m.url
   end
 
   test "should support facebook pattern with album" do
@@ -1507,9 +1505,9 @@ class MediaTest < ActiveSupport::TestCase
     assert_match(/En el Museo Serralves de Oporto/, d['text'])
     assert_equal '54212446406', d['user_uuid']
     assert_equal 'Mariano Rajoy Brey', d['author_name']
-    assert_equal 10, d['media_count']
+    assert_equal 24, d['media_count']
     assert_equal '10154534110871407', d['object_id']
-    assert_equal 'https://www.facebook.com/media/set?set=a.10154534110871407.1073742048.54212446406&type=3', m.url
+    assert_equal 'https://www.facebook.com/media/set/?set=a.10154534110871407.1073742048.54212446406&type=3', m.url
   end
 
   test "should get facebook data from original_url when url fails" do
@@ -1574,13 +1572,6 @@ class MediaTest < ActiveSupport::TestCase
     data = m.as_json
     assert data['raw']['metatags'].is_a? Array
     assert !data['raw']['metatags'].empty?
-  end
-
-  test "should store data of a post returned by facebook API" do
-    m = create_media url: 'https://www.facebook.com/nostalgia.y/photos/a.508939832569501.1073741829.456182634511888/942167619246718/?type=3&theater'
-    data = m.as_json
-    assert data['raw']['api'].is_a? Hash
-    assert !data['raw']['api'].empty?
   end
 
   test "should store data of a profile returned by facebook API" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,20 @@ class ActiveSupport::TestCase
     Media.any_instance.stubs(:archive_to_archive_is).returns(nil)
     Media.any_instance.stubs(:archive_to_video_vault).returns(nil)
     Media.any_instance.stubs(:archive_to_archive_org).returns(nil)
+    Media.any_instance.unstub(:parse)
+    OpenURI.unstub(:open_uri)
+    Twitter::REST::Client.any_instance.unstub(:user)
+    Twitter::REST::Client.any_instance.unstub(:status)
+    Media.any_instance.unstub(:follow_redirections)
+    Media.any_instance.unstub(:get_canonical_url)
+    Media.any_instance.unstub(:try_https)
+    Airbrake.configuration.unstub(:api_key)
+    Airbrake.unstub(:notify)
+    Media.any_instance.unstub(:url)
+    Media.any_instance.unstub(:original_url)
+    Media.any_instance.unstub(:data_from_page_item)
+    Media.any_instance.unstub(:oembed_get_data_from_url)
+    Media.any_instance.unstub(:doc)
   end
 
   # This will run after any test


### PR DESCRIPTION
Do not use Facebook API anymore to parse Facebook profiles or posts. Instead, use only HTML parsing.