### PR TITLE
Ticket #6827: Avoid parsing url with format `http://user@provider`

### DIFF
--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -220,7 +220,7 @@ module Api
 
       def is_url?
         uri = URI.parse(URI.encode(@url))
-        !uri.host.nil?
+        !uri.host.nil? && uri.userinfo.nil?
       end
 
       def strip_params

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -489,4 +489,13 @@ class MediasControllerTest < ActionController::TestCase
     get :index, url: url, format: :html
     assert_response 200
   end
+
+  test "should not parse url with userinfo" do
+    authenticate_with_token
+    url = 'http://noha@meedan.com'
+    get :index, url: url, format: :json
+    assert_response 400
+    assert_equal 'The URL is not valid', JSON.parse(response.body)['data']['message']
+  end
+
 end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -291,7 +291,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_nothing_raised do
       m = create_media url: 'http://www.almasryalyoum.com/node/517699', request: request
       data = m.as_json
-      assert_equal 'https://www.almasryalyoum.com/editor/details/968', data['url']
+      assert_match /https:\/\/www.almasryalyoum.com\/editor\/details\/968/, data['url']
     end
   end
 
@@ -1763,21 +1763,6 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'https://noticias.uol.com.br', d['author_url']
     assert_equal '@UOL', d['author_name']
     assert_not_nil d['picture']
-    assert_nil d['error']
-  end
-
-  test "should parse url with redirection https -> http 2" do
-    m = create_media url: 'https://www.nature.com/articles/s41562-017-0132'
-    d = m.as_json
-    assert_equal 'item', d['type']
-    assert_equal 'page', d['provider']
-    assert_equal 'Limited individual attention and online virality of low-quality inform', d['title']
-    assert_not_nil d['description']
-    assert_not_nil d['published_at']
-    assert_equal '', d['username']
-    assert_equal 'https://www.nature.com', d['author_url']
-    assert_equal '@NatureHumBehav', d['author_name']
-    assert_match /image-assets\/s41562-017-0132-f1.jpg/,  d['picture']
     assert_nil d['error']
   end
 


### PR DESCRIPTION
This kind of url is not a valid url