### PR TITLE
Ticket #7298: Get all thumbnails available from Youtube API

### DIFF
--- a/app/models/concerns/media_youtube_item.rb
+++ b/app/models/concerns/media_youtube_item.rb
@@ -10,7 +10,7 @@ module MediaYoutubeItem
       description
       title
       published_at
-      thumbnail_url
+      thumbnails
       embed_html
       channel_title
       channel_id
@@ -19,10 +19,11 @@ module MediaYoutubeItem
 
   def data_from_youtube_item
     video = Yt::Video.new url: self.url
+    video_data = video.snippet.data
 
     self.data[:raw][:api] = {}
     self.youtube_item_direct_attributes.each do |attr|
-      self.data[:raw][:api][attr] = video.send(attr)
+      self.data[:raw][:api][attr] = video_data.dig(attr.camelize(:lower)) || video.send(attr)
     end
 
     data = self.data
@@ -31,13 +32,20 @@ module MediaYoutubeItem
       username: data[:raw][:api]['channel_title'],
       description: data[:raw][:api]['description'],
       title: data[:raw][:api]['title'],
-      picture: data[:raw][:api]['thumbnail_url'],
+      picture: self.get_youtube_thumbnail,
       html: data[:raw][:api]['embed_html'],
       author_name: data[:raw][:api]['channel_title'],
       author_picture: self.get_youtube_item_author_picture, 
       author_url: 'https://www.youtube.com/channel/' + data[:raw][:api]['channel_id'],
       published_at: data[:raw][:api]['published_at']
     })
+  end
+
+  def get_youtube_thumbnail
+    thumbnails = self.get_info_from_data('api', data, 'thumbnails')
+    ['maxres', 'standard', 'high', 'medium', 'default'].each do |size|
+      return thumbnails.dig(size, 'url') unless thumbnails.dig(size).nil?
+    end
   end
 
   def get_youtube_item_author_picture

--- a/test/models/youtube_test.rb
+++ b/test/models/youtube_test.rb
@@ -72,7 +72,7 @@ class YoutubeTest < ActiveSupport::TestCase
     assert_equal data[:raw][:api]['channel_title'], data['username']
     assert_equal data[:raw][:api]['description'], data['description']
     assert_equal data[:raw][:api]['title'], data['title']
-    assert_equal data[:raw][:api]['thumbnail_url'], data['picture']
+    assert_equal data[:raw][:api]['thumbnails']['maxres']['url'], data['picture']
     assert_equal data[:raw][:api]['embed_html'], data['html']
     assert_equal data[:raw][:api]['channel_title'], data['author_name']
     assert_equal 'https://www.youtube.com/channel/' + data[:raw][:api]['channel_id'], data['author_url']
@@ -118,4 +118,32 @@ class YoutubeTest < ActiveSupport::TestCase
     assert_equal 'ironmaiden', data['raw']['oembed']['author_name']
     assert_equal 'Iron Maiden', data['raw']['oembed']['title']
   end
+
+  test "should get all thumbnails available and set the highest resolution as picture for item" do
+    urls = {
+      'https://www.youtube.com/watch?v=yyougTzksw8' => { available: ['default', 'high', 'medium'], best: 'high' },
+      'https://www.youtube.com/watch?v=8Rd5diO16yM' => { available: ['default', 'high', 'medium', 'standard'], best: 'standard' },
+      'https://www.youtube.com/watch?v=WxnN05vOuSM' => { available: ['default', 'high', 'medium', 'standard', 'maxres'], best: 'maxres' }
+    }
+    urls.each_pair do |url, thumbnails|
+      m = create_media url: url
+      data = m.as_json
+      assert_equal thumbnails[:available].sort, data[:raw][:api]['thumbnails'].keys.sort
+      assert_equal data[:raw][:api]['thumbnails'][thumbnails[:best]]['url'], data['picture']
+    end
+  end
+
+  test "should get all thumbnails available and set the highest resolution as picture for profile" do
+    urls = {
+      'https://www.youtube.com/channel/UCaisXKBdNOYqGr2qOXCLchQ' => { available: ['default', 'high', 'medium'], best: 'high' },
+      'https://www.youtube.com/channel/UCZbgt7KIEF_755Xm14JpkCQ' => { available: ['default', 'high', 'medium'], best: 'high' }
+    }
+    urls.each_pair do |url, thumbnails|
+      m = create_media url: url
+      data = m.as_json
+      assert_equal thumbnails[:available].sort, data[:raw][:api]['thumbnails'].keys.sort
+      assert_equal data[:raw][:api]['thumbnails'][thumbnails[:best]]['url'], data['picture']
+    end
+  end
+
 end


### PR DESCRIPTION
Ǵet all data from Youtube in one request
Set the data `picture` following the order of thumbnails size: maxres => standard => high => medium => default