### PR TITLE
Ticket #7324: Notify Errbit and finish the job when can't archive to …

### DIFF
--- a/app/models/concerns/media_archive_is_archiver.rb
+++ b/app/models/concerns/media_archive_is_archiver.rb
@@ -34,7 +34,6 @@ module MediaArchiveIsArchiver
         Airbrake.notify(StandardError.new('Unexpected response from archive.is'), parameters: {url: url, archiver: 'archive.is', error_code: response.code, error_message: response.message, error_body: response.body}) if Airbrake.configuration.api_key && !response.nil?
         data = { error: { message: I18n.t(:could_not_archive, error_message: response.message), code: response.code }}
         Media.notify_webhook_and_update_cache('archive_is', url, data, key_id)
-        raise "Unexpected response from archive.is with code #{response.code}: #{response.body}"
       end
     end
   end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -63,7 +63,7 @@ class ArchiverTest < ActiveSupport::TestCase
       data = m.as_json
     end
 
-    assert_raises RuntimeError do
+    assert_nothing_raised do
       WebMock.stub_request(:any, 'http://archive.is/submit/').to_return(body: '')
       m = create_media url: urls[2], key: a
       data = m.as_json
@@ -153,7 +153,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive)
   end
 
-  test "should raise error and update media when unexpected response from Archive.is" do
+  test "should not raise error and update media when unexpected response from Archive.is" do
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'archive.is' }
     WebMock.disable_net_connect!(allow: allowed_sites)
@@ -170,15 +170,16 @@ class ArchiverTest < ActiveSupport::TestCase
     urls = ['http://www.unexistent-page.html', 'http://localhost:3333/unreachable-url']
 
     urls.each do |url|
-      assert_raise RuntimeError do
+      assert_nothing_raised do
         m = Media.new url: url
         m.as_json
         assert m.data.dig('archives', 'archive_is').nil?
-        WebMock.stub_request(:any, 'http://archive.is/submit/').to_return(body: '', status: ['200', 'OK'], headers: {})
+        response = { code: '200', message: 'OK' }
+        WebMock.stub_request(:any, 'http://archive.is/submit/').to_return(body: '', status: [response[:code], response[:message]], headers: {})
         Media.send_to_archive_is(url.to_s, a.id, 20)
         id = Media.get_id(url)
         media_data = Rails.cache.read(id)
-        assert_equal({"message"=>I18n.t(:could_not_archive, error_message: data[:message]), "code"=>data[:code]}, media_data.dig('archives', 'archive_is', 'error'))
+        assert_equal({"message"=>I18n.t(:could_not_archive, error_message: response[:message]), "code"=> response[:code]}, media_data.dig('archives', 'archive_is', 'error'))
       end
     end
 
@@ -287,7 +288,7 @@ class ArchiverTest < ActiveSupport::TestCase
       m = create_media url: url, key: a
       m.as_json(archivers: archivers.join(','))
       cached = Rails.cache.read(id)[:archives]
-      assert_equal(archivers, cached.keys)
+      assert_equal archivers, cached.keys
       archivers.each do |archiver|
         assert_equal(archived[archiver], cached[archiver])
       end


### PR DESCRIPTION
…Archive.is

When a job throw an error it is rescheduled over and over. Removing the `raise`
will let the job finish