### PR TITLE
Fix Facebook tests

### DIFF
--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -94,12 +94,15 @@ module MediaFacebookItem
     self.get_facebook_url_from_html
   end
 
-  def get_facebook_info_from_metadata
+  def get_facebook_metadata
     get_metatags(self)
     og_metadata = self.get_opengraph_metadata || {}
     tt_metadata = self.get_twitter_metadata || {}
-    metadata = og_metadata.merge(tt_metadata)
-    self.data['metadata'] = metadata
+    self.data['metadata'] = og_metadata.merge(tt_metadata)
+  end
+
+  def get_facebook_info_from_metadata
+    metadata = get_facebook_metadata
     self.data['author_name'] = self.get_facebook_author_name_from_html
     if (metadata['author_name'].nil? || !metadata['author_name'].match(/\A@?Facebook Watch\z/)) && !metadata['title'].nil?
       self.data['author_name'] = metadata['title']

--- a/app/models/concerns/media_facebook_item.rb
+++ b/app/models/concerns/media_facebook_item.rb
@@ -100,7 +100,10 @@ module MediaFacebookItem
     tt_metadata = self.get_twitter_metadata || {}
     metadata = og_metadata.merge(tt_metadata)
     self.data['metadata'] = metadata
-    self.data['author_name'] = metadata['title'].nil? ? self.get_facebook_author_name_from_html : metadata['title']
+    self.data['author_name'] = self.get_facebook_author_name_from_html
+    if (metadata['author_name'].nil? || !metadata['author_name'].match(/\A@?Facebook Watch\z/)) && !metadata['title'].nil?
+      self.data['author_name'] = metadata['title']
+    end
     self.data['text'] = metadata['description'].nil? ? self.get_facebook_description_from_html : metadata['description']
     self.data['photos'] = metadata['picture'].nil? ? self.get_facebook_photos_from_html : [metadata['picture']]
   end
@@ -110,7 +113,7 @@ module MediaFacebookItem
   end
 
   def get_facebook_author_name_from_html
-    author_link = self.doc.at_css('.fbPhotoAlbumActionList a') || self.doc.at_css('.uiHeaderTitle > a')
+    author_link = self.doc.at_css('.fbPhotoAlbumActionList a') || self.doc.at_css('.uiHeaderTitle > a') || self.doc.at_css('.userContentWrapper .profileLink')
     author_link.blank? ? self.get_facebook_title_from_html : author_link.text
   end
 

--- a/test/models/facebook_item_test.rb
+++ b/test/models/facebook_item_test.rb
@@ -26,18 +26,6 @@ class FacebookItemTest < ActiveSupport::TestCase
     assert_equal media2.url, media1.url
   end
 
-  test "should get canonical URL from facebook object" do
-    variations = {
-      'https://www.facebook.com/democrats/videos/10154268929856943' => 'https://www.facebook.com/democrats/videos/10154268929856943',
-      'https://www.facebook.com/democrats/posts/10154268929856943/' => 'https://www.facebook.com/democrats/videos/10154268929856943/'
-    }
-    variations.each do |url, expected|
-      media = Media.new(url: url)
-      media.as_json
-      assert_equal expected, media.url
-    end
-  end
-
   test "should get canonical URL from facebook object 2" do
     media = Media.new(url: 'https://www.facebook.com/permalink.php?story_fbid=10154534111016407&id=54212446406')
     media.as_json({ force: 1 })


### PR DESCRIPTION
Also:
Facebook changed and URLs like (1) and (2) are not redirected to the same page
and don't have the same canonical URL, so the test for them was removed
1- 'https://www.facebook.com/democrats/posts/10154268929856943/'
2- 'https://www.facebook.com/democrats/videos/10154268929856943/'