### PR TITLE
Ticket #7617: Store the `oembed` data on `raw` as it comes from parsing

### DIFF
--- a/test/models/facebook_item_test.rb
+++ b/test/models/facebook_item_test.rb
@@ -397,18 +397,17 @@ class FacebookItemTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.facebook.com/profile.php?id=100008161175765&fref=ts'
     data = m.as_json
 
-    assert data['raw']['oembed'].is_a? Hash
-    assert_equal 'Tico-Santa-Cruz', data['raw']['oembed']['author_name']
-    assert_equal 'Tico Santa Cruz', data['raw']['oembed']['title']
+    assert_nil data['raw']['oembed']
+    assert_equal 'Tico-Santa-Cruz', data['oembed']['author_name']
+    assert_equal 'Tico Santa Cruz', data['oembed']['title']
   end
 
   test "should store oembed data of a facebook page" do
     m = create_media url: 'https://www.facebook.com/pages/Meedan/105510962816034?fref=ts'
     data = m.as_json
-
-    assert data['raw']['oembed'].is_a? Hash
-    assert_equal 'Meedan', data['raw']['oembed']['author_name']
-    assert_equal 'Meedan', data['raw']['oembed']['title']
+    assert_nil data['raw']['oembed']
+    assert_equal 'Meedan', data['oembed']['author_name']
+    assert_equal 'Meedan', data['oembed']['title']
   end
 
   test "should create Facebook post from page post URL without login" do

--- a/test/models/facebook_profile_test.rb
+++ b/test/models/facebook_profile_test.rb
@@ -106,8 +106,12 @@ class FacebookProfileTest < ActiveSupport::TestCase
     assert_equal 'https://www.facebook.com/teste637621352/', data['author_url']
     assert_equal 'Facebook', data['provider_name']
     assert_equal 'https://www.facebook.com', data['provider_url']
-    assert_equal 552, data['width']
-    assert data['height'].nil?
+    assert_equal 300, data['width']
+    assert_equal 150, data['height']
+
+    json = Pender::Store.read(Media.get_id(url), :json)
+    assert_equal 552, json[:raw][:oembed][:width]
+    assert_nil json[:raw][:oembed][:height]
   end
 
   test "should parse Facebook with numeric id" do

--- a/test/models/youtube_test.rb
+++ b/test/models/youtube_test.rb
@@ -114,9 +114,9 @@ class YoutubeTest < ActiveSupport::TestCase
     m = create_media url: 'https://www.youtube.com/channel/UCaisXKBdNOYqGr2qOXCLchQ'
     data = m.as_json
 
-    assert data['raw']['oembed'].is_a? Hash
-    assert_equal 'ironmaiden', data['raw']['oembed']['author_name']
-    assert_equal 'Iron Maiden', data['raw']['oembed']['title']
+    assert_nil data['raw']['oembed']
+    assert_equal 'ironmaiden', data['oembed']['author_name']
+    assert_equal 'Iron Maiden', data['oembed']['title']
   end
 
   test "should get all thumbnails available and set the highest resolution as picture for item" do


### PR DESCRIPTION
Also:
- Includes error key and message on `raw[:oembed]` when there's an error
- Add new key `oembed` to store the page `oembed` (if available) or the default oembed