### PR TITLE
Ticket #7776: Disable Perma.cc archiver if config is not present

### DIFF
--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -54,7 +54,7 @@ module MediaArchiver
 
     def api_key_settings(key_id)
       key = ApiKey.where(id: key_id).last
-      key ? key.application_settings.with_indifferent_access : {}
+      key && key.application_settings ? key.application_settings.with_indifferent_access : {}
     end
 
     def notify_webhook_and_update_cache(archiver, url, data, key_id)

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -2,7 +2,7 @@ module MediaPermaCcArchiver
   extend ActiveSupport::Concern
 
   included do
-    Media.declare_archiver('perma_cc', [/^.*$/], :only)
+    Media.declare_archiver('perma_cc', [/^.*$/], :only) unless CONFIG.dig('perma_cc_key').blank?
   end
 
   def archive_to_perma_cc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -58,7 +58,6 @@ class ActiveSupport::TestCase
     Media.any_instance.unstub(:oembed_get_data_from_url)
     Media.any_instance.unstub(:doc)
     Media::ARCHIVERS['archive_is'][:enabled] = true
-    Media::ARCHIVERS['perma_cc'][:enabled] = true
     clear_bucket(create: true)
   end
 
@@ -74,7 +73,6 @@ class ActiveSupport::TestCase
     Media.any_instance.unstub(:archive_to_archive_org)
     Media.any_instance.unstub(:archive_to_perma_cc)
     Media::ARCHIVERS['archive_is'][:enabled] = false
-    Media::ARCHIVERS['perma_cc'][:enabled] = false
     CONFIG.unstub(:[])
     clear_bucket
   end


### PR DESCRIPTION
Also avoid crash when API key have `nil` on application_settings