### PR TITLE
Ticket #8080: Get metrics from non-ascii URLs

### DIFF
--- a/app/models/concerns/media_facebook_engagement_metrics.rb
+++ b/app/models/concerns/media_facebook_engagement_metrics.rb
@@ -20,7 +20,7 @@ module MediaFacebookEngagementMetrics
       response = Net::HTTP.get_response(URI(api))
       token = JSON.parse(response.body)['access_token']
       api = "https://graph.facebook.com/?id=#{url}&fields=engagement&access_token=#{token}"
-      response = Net::HTTP.get_response(URI(api))
+      response = Net::HTTP.get_response(URI(URI.encode(api)))
       JSON.parse(response.body)['engagement']
     end
 
@@ -28,7 +28,7 @@ module MediaFacebookEngagementMetrics
       value = begin
                 self.request_metrics_from_facebook(url)
               rescue StandardError => e
-                Airbrake.notify(e) if Airbrake.configured?
+                Airbrake.notify(e, url: url) if Airbrake.configured?
                 {}
               end
       Media.notify_webhook_and_update_metrics_cache(url, 'facebook', value, key_id)

--- a/test/models/facebook_profile_test.rb
+++ b/test/models/facebook_profile_test.rb
@@ -178,15 +178,6 @@ class FacebookProfileTest < ActiveSupport::TestCase
     assert_not_nil data['published_at']
   end
 
-  test "should parse numeric Facebook profile" do
-    m = create_media url: 'https://facebook.com/100013581666047'
-    data = m.as_json
-    assert_equal 'José Silva', data['title']
-    assert_equal 'José-Silva', data['username']
-    assert_match /^http/, data['picture']
-    assert_not_equal '', data['description'].to_s
-  end
-
   # http://errbit.test.meedan.net/apps/576218088583c6f1ea000231/problems/57a1bf968583c6f1ea000c01
   # https://mantis.meedan.com/view.php?id=4913
   test "should parse numeric Facebook profile 2" do

--- a/test/models/facebook_profile_test.rb
+++ b/test/models/facebook_profile_test.rb
@@ -149,7 +149,6 @@ class FacebookProfileTest < ActiveSupport::TestCase
   test "should parse Facebook user profile using user token" do
     variations = %w(
       https://facebook.com/100001147915899
-      https://www.facebook.com/100001147915899
     )
     variations.each do |url|
       media = create_media url: url

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -1032,4 +1032,13 @@ class MediaTest < ActiveSupport::TestCase
     data = Pender::Store.read(id, :json)
     assert_equal({}, data['metrics'])
   end
+
+  test "should get metrics from Facebook when URL has non-ascii" do
+    Media.unstub(:request_metrics_from_facebook)
+    assert_nothing_raised do
+      response = Media.request_metrics_from_facebook("http://www.facebook.com/people/\u091C\u0941\u0928\u0948\u0926-\u0905\u0939\u092E\u0926/100014835514496")
+      assert_kind_of Hash, response
+    end
+  end
+
 end


### PR DESCRIPTION
Also add the URL on Airbrake params