### PR TITLE
Ticket #8132: Re-enable Archive.org

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -2,7 +2,7 @@ module MediaArchiveOrgArchiver
   extend ActiveSupport::Concern
 
   included do
-    Media.declare_archiver('archive_org', [/^.*$/], :only, false)
+    Media.declare_archiver('archive_org', [/^.*$/], :only)
   end
 
   def archive_to_archive_org
@@ -18,19 +18,26 @@ module MediaArchiveOrgArchiver
     def send_to_archive_org(url, key_id, attempts = 1, response = nil)
       Media.give_up('archive_org', url, key_id, attempts, response) and return
 
-      encoded_uri = URI.encode(URI.decode(url))
-      uri = URI.parse("https://web.archive.org/save/#{encoded_uri}")
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      request = Net::HTTP::Get.new(uri.request_uri)
-      response = http.request(request)
-      Rails.logger.info "[Archiver Archive.org] Sending #{url} to Archive.org: Code: #{response.code}"
+      begin
+        encoded_uri = URI.encode(URI.decode(url))
+        uri = URI.parse("https://web.archive.org/save/#{encoded_uri}")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        request = Net::HTTP::Get.new(uri.request_uri)
+        response = http.request(request)
+        Rails.logger.info "[Archiver Archive.org] Sending #{url} to Archive.org: Code: #{response.code}"
 
-      if response['content-location']
-        data = { location: 'https://web.archive.org' + response['content-location'] }
+        if location = response['content-location'] || response['location']
+          data = { location: 'https://web.archive.org' + location }
+          Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
+        else
+          Media.delay_for(3.minutes).send_to_archive_org(url, key_id, attempts + 1, {code: response.code, message: response.message})
+        end
+      rescue StandardError => e
+        Media.delay_for(24.hours).send_to_archive_org(url, key_id, attempts + 1, {code: 5, message: e.message})
+        Rails.logger.info "[Archiver Archive.org] Could not archive: #{e.message}"
+        data = { error: { message: I18n.t(:could_not_archive, error_message: e.message), code: 5 }}
         Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
-      else
-        Media.delay_for(3.minutes).send_to_archive_org(url, key_id, attempts + 1, {code: response.code, message: response.message})
       end
     end
   end

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -27,7 +27,7 @@ module MediaArchiveOrgArchiver
         response = http.request(request)
         Rails.logger.info "[Archiver Archive.org] Sending #{url} to Archive.org: Code: #{response.code}"
 
-        if location = response['content-location'] || response['location']
+        if location = (response['content-location'] || response['location'])
           data = { location: 'https://web.archive.org' + location }
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         else

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -27,7 +27,8 @@ module MediaArchiveOrgArchiver
         response = http.request(request)
         Rails.logger.info "[Archiver Archive.org] Sending #{url} to Archive.org: Code: #{response.code}"
 
-        if location = (response['content-location'] || response['location'])
+        location = response['content-location'] || response['location']
+        if location
           data = { location: 'https://web.archive.org' + location }
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         else

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -130,6 +130,37 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive)
   end
 
+  test "should update media with error when reques to Archive.org fails" do
+    WebMock.enable!
+    allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
+    WebMock.disable_net_connect!(allow: allowed_sites)
+    Media.any_instance.stubs(:follow_redirections)
+    Media.any_instance.stubs(:get_canonical_url).returns(true)
+    Media.any_instance.stubs(:try_https)
+    Media.any_instance.stubs(:parse)
+    Media.any_instance.stubs(:archive)
+
+    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    url = 'https://example.com'
+
+    assert_nothing_raised do
+      m = Media.new url: url
+      data = m.as_json
+      assert m.data.dig('archives', 'archive_org').nil?
+      WebMock.stub_request(:any, /web.archive.org/).to_raise(Net::ReadTimeout)
+      Media.send_to_archive_org(url, a.id)
+      media_data = Pender::Store.read(Media.get_id(url), :json)
+      assert_match /Could not archive/, media_data.dig('archives', 'archive_org', 'error', 'message')
+    end
+
+    WebMock.disable!
+    Media.any_instance.unstub(:follow_redirections)
+    Media.any_instance.unstub(:get_canonical_url)
+    Media.any_instance.unstub(:try_https)
+    Media.any_instance.unstub(:parse)
+    Media.any_instance.unstub(:archive)
+  end
+
   test "should not raise error and update media when unexpected response from Archive.is" do
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'archive.is' }


### PR DESCRIPTION
Handle errors when can't reach Archive.org
Accept archived link on response's header `location`
Re-enable Archive.org