### PR TITLE
Fix tests

### DIFF
--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -792,7 +792,7 @@ class MediasControllerTest < ActionController::TestCase
 
   test "should return error if URL is not safe" do
     authenticate_with_token
-    url = 'http://malware.wicar.org/data/ms14_064_ole_xp.html' # More examples: https://www.wicar.org/test-malware.html
+    url = 'http://malware.wicar.org/data/ms14_064_ole_not_xp.html' # More examples: https://www.wicar.org/test-malware.html
     get :index, url: url, format: 'json'
     response = JSON.parse(@response.body)
     assert_equal 'error', response['type']

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -515,7 +515,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should check if non-ascii URL support video download" do
     Media.unstub(:supported_video?)
-    assert !Media.supported_video?('http://www.facebook.com/pages/category/Musician-Band/चौधरी-कमला-बाड़मेर-108960273957085')
+    assert !Media.supported_video?('http://example.com/pages/category/Musician-Band/चौधरी-कमला-बाड़मेर-108960273957085')
   end
 
   test "should notify if URL was already parsed and has a location on data when archive video" do


### PR DESCRIPTION
- Replaced URL that is not being flagged as `unsafe` anymore
- Use an example URL with non-ascii chars to test youtube-dl call