### PR TITLE
Fix gitlab ci deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-cenv.args`
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-c.env.args`
     - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /QA/pender/$NAME " >> qa-pender-background.env.args; done
     - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ deploy_qa:
     - pip install awscli==1.18.188
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
-    - rf -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
+    - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-cenv.args`
     - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /QA/pender/$NAME " >> qa-pender-background.env.args; done
     - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-background.env.args`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,9 @@ stages:
   - deploy
 
 build_qa:
-  image: docker:latest
+  image: docker:rc
   services:
-    - docker:dind
+    - docker:rc-dind
   tags:
     - meedan
     - meedan-labs
@@ -18,8 +18,6 @@ build_qa:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/QA/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.qa.local
-    - docker build -f production/Dockerfile --env-file=env.qa.local -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
@@ -45,9 +43,9 @@ deploy_qa:
     - develop
 
 build_live:
-  image: docker:latest
+  image: docker:rc
   services:
-    - docker:dind
+    - docker:rc-dind
   tags:
     - meedan
     - meedan-labs
@@ -60,8 +58,7 @@ build_live:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/Live/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.production.local
-    - docker build -f production/Dockerfile --env-file=env.production.local -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
+    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,8 @@ build_qa:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"  .
+    - aws ssm get-parameters-by-path --region $REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/QA/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.qa.local
+    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" --env-file=env.qa.local .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -58,7 +59,8 @@ build_live:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
+    - aws ssm get-parameters-by-path --region $REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/Live/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.production.local
+    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" --env-file=env.production.local .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,9 +3,9 @@ stages:
   - deploy
 
 build_qa:
-  image: docker:rc
+  image: docker:latest
   services:
-    - docker:rc-dind
+    - docker:dind
   tags:
     - meedan
     - meedan-labs
@@ -49,9 +49,9 @@ deploy_qa:
     - develop
 
 build_live:
-  image: docker:rc
+  image: docker:latest
   services:
-    - docker:rc-dind
+    - docker:dind
   tags:
     - meedan
     - meedan-labs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,8 +18,7 @@ build_qa:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/QA/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.qa.local
-    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" --env-file=env.qa.local .
+    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -37,8 +36,10 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install ecs-deploy==1.7.0
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600
+    - pip install ecs-deploy==1.11.0
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
+    - for NAME in `cat env.qa.names`; do echo -n "-s $NAME /QA/pender/$NAME " >> env.args; done
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat env.args`
     - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
@@ -61,8 +62,7 @@ build_live:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/Live/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.production.local
-    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" --env-file=env.production.local .
+    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master
@@ -80,7 +80,7 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install ecs-deploy==1.7.0
+    - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,10 +40,10 @@ deploy_qa:
     - pip install awscli
     - pip install ecs-deploy
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
-    - for NAME in `cat env.qa.names`; do echo -n "-s $NAME /QA/pender/$NAME " >> env.args; done
-    - cat env.args
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat env.args`
-    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600
+    - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-cenv.args`
+    - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /QA/pender/$NAME " >> qa-pender-background.env.args; done
+    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,7 @@ deploy_qa:
     - pip install ecs-deploy
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s $NAME /QA/pender/$NAME " >> env.args; done
+    - cat env.args
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat env.args`
     - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
+    - pip install awscli==1.16.201
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s $NAME /QA/pender/$NAME " >> env.args; done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-gitlab-ci-deploy
 
 deploy_qa:
   image: python:3-alpine
@@ -48,7 +47,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-gitlab-ci-deploy
 
 build_live:
   image: docker:rc
@@ -88,8 +86,11 @@ deploy_live:
     - pip install docutils==0.16
     - pip install awscli==1.18.188
     - pip install ecs-deploy==1.11.0
-    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
-    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/Live/pender/##' > env.live.names
+    - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /Live/pender/$NAME " >> live-pender-c.env.args; done
+    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-pender-c.env.args`
+    - rm -f live-pender-background.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /Live/pender/$NAME " >> live-pender-background.env.args; done
+    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,7 +39,7 @@ deploy_qa:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install docutils==0.16
     - pip install awscli==1.18.188
-    - pip install ecs-deploy=1.11.0
+    - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
     - rf -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-cenv.args`
@@ -87,7 +87,7 @@ deploy_live:
     - apk add --no-cache curl jq python3 py3-pip git
     - pip install docutils==0.16
     - pip install awscli==1.18.188
-    - pip install ecs-deploy=1.11.0
+    - pip install ecs-deploy==1.11.0
     - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,6 +36,7 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
+    - pip install docutils==0.14
     - pip install awscli==1.16.201
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,10 +13,11 @@ build_qa:
   variables:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.14
-    - pip install awscli==1.16.201
+    - pip install docutils==0.16
+    - pip install awscli==1.18.188
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
@@ -36,13 +37,13 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils
-    - pip install awscli
-    - pip install ecs-deploy
+    - pip install docutils==0.16
+    - pip install awscli==1.18.188
+    - pip install ecs-deploy=1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
-    - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
+    - rf -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-cenv.args`
-    - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /QA/pender/$NAME " >> qa-pender-background.env.args; done
+    - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /QA/pender/$NAME " >> qa-pender-background.env.args; done
     - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
@@ -60,10 +61,11 @@ build_live:
   variables:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.14
-    - pip install awscli==1.16.201
+    - pip install docutils==0.16
+    - pip install awscli==1.18.188
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
@@ -83,7 +85,9 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install ecs-deploy==1.11.0
+    - pip install docutils==0.16
+    - pip install awscli==1.18.188
+    - pip install ecs-deploy=1.11.0
     - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ build_qa:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - aws ssm get-parameters-by-path --region $REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/QA/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.qa.local
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/QA/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.qa.local
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" --env-file=env.qa.local .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
@@ -61,7 +61,7 @@ build_live:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - aws ssm get-parameters-by-path --region $REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/Live/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.production.local
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/Live/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.production.local
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" --env-file=env.production.local .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,9 +36,9 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.14
-    - pip install awscli==1.16.201
-    - pip install ecs-deploy==1.11.0
+    - pip install docutils
+    - pip install awscli
+    - pip install ecs-deploy
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s $NAME /QA/pender/$NAME " >> env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat env.args`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-gitlab-ci-deploy
 
 deploy_qa:
   image: python:3-alpine
@@ -42,6 +43,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-gitlab-ci-deploy
 
 build_live:
   image: docker:rc

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,8 @@ build_qa:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/QA/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.qa.local
+    - docker build -f production/Dockerfile --env-file=env.qa.local -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
@@ -58,7 +60,8 @@ build_live:
     - pip install docutils==0.14
     - pip install awscli==1.16.201
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-    - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name,Value]" | sed -E 's#/Live/pender/([^[:space:]]*)[[:space:]]*#\1=#' > env.production.local
+    - docker build -f production/Dockerfile --env-file=env.production.local -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"  .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master


### PR DESCRIPTION
This change adds support for environment configuration using the SSM parameter store for Pender and Pender background tasks deployed via GitLab-CI.