### PR TITLE
Normalize SSM parameter names to lower case.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -39,10 +39,10 @@ deploy_qa:
     - pip install docutils==0.16
     - pip install awscli==1.18.188
     - pip install ecs-deploy==1.11.0
-    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /QA/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/QA/pender/##' > env.qa.names
-    - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /QA/pender/$NAME " >> qa-pender-c.env.args; done
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
+    - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-c.env.args`
-    - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /QA/pender/$NAME " >> qa-pender-background.env.args; done
+    - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
     - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
@@ -86,10 +86,10 @@ deploy_live:
     - pip install docutils==0.16
     - pip install awscli==1.18.188
     - pip install ecs-deploy==1.11.0
-    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /Live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/Live/pender/##' > env.live.names
-    - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /Live/pender/$NAME " >> live-pender-c.env.args; done
+    - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
+    - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
     - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-pender-c.env.args`
-    - rm -f live-pender-background.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /Live/pender/$NAME " >> live-pender-background.env.args; done
+    - rm -f live-pender-background.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
     - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:


### PR DESCRIPTION
This is one of a couple pull requests to normalize SSM parameter prefixes to lowercase. This better matches the format in use in Terraform and AWS.

Live and QA configuration has been updated as per the [SSM import branch of configurator](https://github.com/meedan/configurator/tree/ssm-migration/ssm_import).

This change can be merged when convenient; the existing configuration lives along side the new format to ensure a seamless migration.  The deprecated settings can be deleted once the migration is complete. (This will be a separate sysops ticket.)