### PR TITLE
Use exclusive secrets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,10 +43,10 @@ deploy_qa:
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
     - echo -n "-s qa-pender-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-pender-c.env.args
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-pender-c APP pender -e qa-pender-c DEPLOY_ENV qa -e qa-pender-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-pender-c.env.args`
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 1200 --exclusive-env -e qa-pender-c APP pender -e qa-pender-c DEPLOY_ENV qa -e qa-pender-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-pender-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
     - echo -n "-s qa-pender-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-pender-background.env.args
-    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-pender-background APP pender -e qa-pender-background DEPLOY_ENV qa -e qa-pender-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-pender-background.env.args`
+    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 1200 --exclusive-env -e qa-pender-background APP pender -e qa-pender-background DEPLOY_ENV qa -e qa-pender-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -93,10 +93,10 @@ deploy_live:
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
     - echo -n "-s live-pender-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-pender-c.env.args
-    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-pender-c APP pender -e live-pender-c DEPLOY_ENV live -e live-pender-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-pender-c.env.args`
+    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 1200 --exclusive-env -e live-pender-c APP pender -e live-pender-c DEPLOY_ENV live -e live-pender-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-pender-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
     - echo -n "-s live-pender-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-pender-background.env.args
-    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-pender-background APP pender -e live-pender-background DEPLOY_ENV live -e live-pender-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-pender-background.env.args`
+    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 1200 --exclusive-env -e live-pender-background APP pender -e live-pender-background DEPLOY_ENV live -e live-pender-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - use-exclusive-secrets
 
 deploy_qa:
   image: python:3-alpine
@@ -41,12 +42,13 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-c.env.args`
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-c.env.args`
     - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
-    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-pender-background.env.args`
+    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - use-exclusive-secrets
 
 build_live:
   image: docker:latest
@@ -88,9 +90,9 @@ deploy_live:
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
     - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
-    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-pender-c.env.args`
+    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-c.env.args`
     - rm -f live-pender-background.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
-    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-pender-background.env.args`
+    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,9 +42,9 @@ deploy_qa:
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-c.env.args`
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-pender-c GITHUB_TOKEN null --exclusive-secrets `cat qa-pender-c.env.args`
     - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
-    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-background.env.args`
+    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-pender-background GITHUB_TOKEN null --exclusive-secrets `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -90,9 +90,9 @@ deploy_live:
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
     - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
-    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-c.env.args`
+    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e live-pender-c GITHUB_TOKEN null --exclusive-secrets `cat live-pender-c.env.args`
     - rm -f live-pender-background.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
-    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-background.env.args`
+    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e live-pender-background GITHUB_TOKEN null --exclusive-secrets `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - use-exclusive-secrets
 
 deploy_qa:
   image: python:3-alpine
@@ -50,7 +49,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - use-exclusive-secrets
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,10 +41,12 @@ deploy_qa:
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
-    - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-pender-c GITHUB_TOKEN null --exclusive-secrets `cat qa-pender-c.env.args`
-    - rm -f qa-pender-background.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
-    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-pender-background GITHUB_TOKEN null --exclusive-secrets `cat qa-pender-background.env.args`
+    - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
+    - echo -n "-s qa-pender-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-pender-c.env.args
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-c.env.args`
+    - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
+    - echo -n "-s qa-pender-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-pender-background.env.args
+    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -89,10 +91,12 @@ deploy_live:
     - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
-    - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
-    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e live-pender-c GITHUB_TOKEN null --exclusive-secrets `cat live-pender-c.env.args`
-    - rm -f live-pender-background.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
-    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 -e live-pender-background GITHUB_TOKEN null --exclusive-secrets `cat live-pender-background.env.args`
+    - for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
+    - echo -n "-s live-pender-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-pender-c.env.args
+    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-c.env.args`
+    - for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
+    - echo -n "-s live-pender-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-pender-background.env.args
+    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,8 +16,7 @@ build_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
@@ -37,8 +36,9 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
@@ -64,8 +64,7 @@ build_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
@@ -85,8 +84,9 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
     - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,10 +43,10 @@ deploy_qa:
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
     - echo -n "-s qa-pender-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-pender-c.env.args
-    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-c.env.args`
+    - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-pender-c APP pender -e qa-pender-c DEPLOY_ENV qa -e qa-pender-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-pender-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-background $NAME /qa/pender/$NAME " >> qa-pender-background.env.args; done
     - echo -n "-s qa-pender-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-pender-background.env.args
-    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-pender-background.env.args`
+    - ecs deploy ecs-qa  qa-pender-background --image qa-pender-background $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-pender-background APP pender -e qa-pender-background DEPLOY_ENV qa -e qa-pender-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -93,10 +93,10 @@ deploy_live:
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done
     - echo -n "-s live-pender-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-pender-c.env.args
-    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-c.env.args`
+    - ecs deploy ecs-live  live-pender --image live-pender-c $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-pender-c APP pender -e live-pender-c DEPLOY_ENV live -e live-pender-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-pender-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-pender-background $NAME /live/pender/$NAME " >> live-pender-background.env.args; done
     - echo -n "-s live-pender-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-pender-background.env.args
-    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-pender-background.env.args`
+    - ecs deploy ecs-live  live-pender-background --image live-pender-background $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-pender-background APP pender -e live-pender-background DEPLOY_ENV live -e live-pender-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-pender-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
   only:
     - master


### PR DESCRIPTION
This change updates the GitLab-CI deploy process to use the `--exclusive-secrets` and `--exclusive-env` options to avoid errors deploying when SSM parameters are deprecated. See related issue in Alegre https://meedan.app.opsgenie.com/incident/detail/229ea661-df36-44f9-9989-fa15d86b6727.