### PR TITLE
Fix botocore version pins to avoid incompatibility in ecs-deploy utility

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-botocore-version-pins
 
 deploy_qa:
   image: python:3-alpine
@@ -48,7 +47,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - fix-botocore-version-pins
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,13 +16,13 @@ build_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-botocore-version-pins
 
 deploy_qa:
   image: python:3-alpine
@@ -36,8 +36,9 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
@@ -47,6 +48,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - fix-botocore-version-pins
 
 build_live:
   image: docker:latest
@@ -62,8 +64,7 @@ build_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/live/pender/api:$CI_COMMIT_SHA"
@@ -83,8 +84,9 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names
     - rm -f live-pender-c.env.args; for NAME in `cat env.live.names`; do echo -n "-s live-pender-c $NAME /live/pender/$NAME " >> live-pender-c.env.args; done


### PR DESCRIPTION
This change updates the boto3 and botocore version pins in the GitLab-CI deploy to avoid an incompatibility in the ecs-deploy utility. Fixes deployment errors in develop.