### PR TITLE
Better URL parsing for Kwai URLs.

### DIFF
--- a/app/models/concerns/media_kwai_item.rb
+++ b/app/models/concerns/media_kwai_item.rb
@@ -1,0 +1,30 @@
+module MediaKwaiItem
+  extend ActiveSupport::Concern
+
+  KWAI_URL = /^https?:\/\/([^.]+\.)?(kwai\.com|kw\.ai)\//
+
+  included do
+    Media.declare('kwai_item', [KWAI_URL])
+  end
+
+  def data_from_kwai_item
+    handle_exceptions(self, StandardError) do
+      self.data_from_oembed_item
+      self.doc ||= self.get_html({ allow_redirections: :all })
+      title = self.get_kwai_text_from_tag('.info .title')
+      name = self.get_kwai_text_from_tag('.name')
+      data = {
+        title: title,
+        description: title,
+        author_name: name,
+        username: name
+      }
+      self.data ||= {}
+      self.data.merge!(data)
+    end
+  end
+
+  def get_kwai_text_from_tag(selector)
+    self.doc&.at_css(selector)&.text&.to_s.strip
+  end
+end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -85,7 +85,7 @@ class Media
   end
 
   # Parsers and archivers
-  [MediaYoutubeProfile, MediaYoutubeItem, MediaTwitterProfile, MediaTwitterItem, MediaFacebookProfile, MediaFacebookItem, MediaInstagramItem, MediaInstagramProfile, MediaDropboxItem, MediaTiktokItem, MediaTiktokProfile, MediaPageItem, MediaOembedItem, MediaArchiveIsArchiver, MediaArchiveOrgArchiver, MediaHtmlPreprocessor, MediaSchemaOrg, MediaPermaCcArchiver, MediaVideoArchiver, MediaFacebookEngagementMetrics, MediaCrowdtangleItem].each { |concern| include concern }
+  [MediaYoutubeProfile, MediaYoutubeItem, MediaTwitterProfile, MediaTwitterItem, MediaFacebookProfile, MediaFacebookItem, MediaInstagramItem, MediaInstagramProfile, MediaDropboxItem, MediaTiktokItem, MediaTiktokProfile, MediaKwaiItem, MediaPageItem, MediaOembedItem, MediaArchiveIsArchiver, MediaArchiveOrgArchiver, MediaHtmlPreprocessor, MediaSchemaOrg, MediaPermaCcArchiver, MediaVideoArchiver, MediaFacebookEngagementMetrics, MediaCrowdtangleItem].each { |concern| include concern }
 
   def self.minimal_data(instance)
     data = {}

--- a/test/models/kwai_test.rb
+++ b/test/models/kwai_test.rb
@@ -1,0 +1,15 @@
+require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'test_helper')
+
+class KwaiTest < ActiveSupport::TestCase
+  test "should parse Kwai URL" do
+    m = create_media url: 'https://s.kw.ai/p/1mCb9SSh'
+    data = m.as_json
+    assert_equal 'Reginaldo Silva2871', data['username']
+    assert_equal 'item', data['type']
+    assert_equal 'kwai', data['provider']
+    assert_equal 'Reginaldo Silva2871', data['author_name']
+    assert_equal 'F. Francisco', data['title']
+    assert_equal 'F. Francisco', data['description']
+    assert_nil data['error']
+  end
+end


### PR DESCRIPTION
We didn't have a specific parser for Kwai URLs, so it was falling back to oEmbed information and metatags, but it means that the title and description are the same for all shared URLs from Kwai. This change add a specific parser that is able to extract the user who shared the video and the user who created the video, and use that information to fill some of the Pender data fields.

Reference: CHECK-1806.