### PR TITLE
Use cookies to parse Instagram and TikTok links

### DIFF
--- a/app/models/concerns/media_instagram_item.rb
+++ b/app/models/concerns/media_instagram_item.rb
@@ -19,26 +19,25 @@ module MediaInstagramItem
       self.set_data_field('description', self.get_instagram_text_from_data)
       self.set_data_field('title', self.get_instagram_text_from_data)
       self.set_data_field('picture', self.get_instagram_picture_from_data)
-      self.set_data_field('author_name', data.dig('raw', 'graphql', 'shortcode_media', 'owner', 'full_name'))
-      self.set_data_field('author_picture', data.dig('raw', 'graphql', 'shortcode_media', 'owner', 'profile_pic_url'))
+      self.set_data_field('author_name', data.dig('raw', 'graphql', 'user', 'full_name'))
+      self.set_data_field('author_picture', data.dig('raw', 'graphql', 'user', 'profile_pic_url'))
       self.data.merge!({ external_id: id })
     end
   end
 
   def get_instagram_username_from_data
     username = get_info_from_data('crowdtangle', self.data, 'handle')
-    username = username.blank? ? (data.dig('raw', 'graphql', 'shortcode_media', 'owner', 'username') || '' ) : username
+    username = username.blank? ? data.dig('raw', 'graphql', 'user', 'username').to_s : username
     username.prepend('@') unless username.blank?
   end
 
   def get_instagram_text_from_data
-    text = self.data.dig('raw', 'graphql', 'shortcode_media', 'edge_media_to_caption', 'edges')
-    (!text.blank? && text.is_a?(Array)) ? text.first.dig('node', 'text') : ''
+    self.data.dig('raw', 'graphql', 'caption', 'text').to_s
   end
 
   def get_instagram_picture_from_data
     picture = get_info_from_data('api', self.data, 'thumbnail_url')
-    picture.blank? ? self.data.dig('raw', 'graphql', 'shortcode_media', 'display_url') : picture
+    picture.blank? ? self.data.dig('raw', 'graphql', 'user', 'profile_pic_url') : picture
   end
 
   def get_instagram_data(id)
@@ -55,11 +54,11 @@ module MediaInstagramItem
     uri = URI.parse(url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
-    headers = { 'User-Agent' => Media.html_options(uri)['User-Agent'] }
+    headers = Media.extended_headers(uri)
     request = Net::HTTP::Get.new(uri.request_uri, headers)
     response = http.request(request)
     raise StandardError.new("#{response.class}: #{response.message}") unless %(200 301 302).include?(response.code)
-    return JSON.parse(response.body)['graphql'] if response.code == '200'
+    return JSON.parse(response.body)['items'][0] if response.code == '200'
     location = response.header['location']
     self.ignore_url?(location) ? (raise StandardError.new('Login required')) : self.get_instagram_graphql_data(location)
   end

--- a/app/models/concerns/media_tiktok_item.rb
+++ b/app/models/concerns/media_tiktok_item.rb
@@ -28,7 +28,8 @@ module MediaTiktokItem
     uri = URI.parse(self.tiktok_oembed_url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
-    request = Net::HTTP::Get.new(uri.request_uri)
+    headers = Media.extended_headers(uri)
+    request = Net::HTTP::Get.new(uri.request_uri, headers)
     response = http.request(request)
     self.data['raw'] ||= {}
     self.data['raw']['oembed'] = self.data['raw']['api'] = JSON.parse(response.body)

--- a/config/cookies.txt.example
+++ b/config/cookies.txt.example
@@ -2,5 +2,5 @@
 # This file will be used to parse pages that have limit of access
 # To include new cookies, append the cookies data to the end of file
 # The format must be compatible with wget, curl, aria2 and similar
-
+# Please set cookies for at least TikTok and Instagram
 .example.com	TRUE	/	FALSE	1538248063	wp_devicetype	0

--- a/test/models/instagram_test.rb
+++ b/test/models/instagram_test.rb
@@ -114,10 +114,18 @@ class InstagramTest < ActiveSupport::TestCase
 
   test "should parse when only graphql returns data" do
     Media.stubs(:get_crowdtangle_data).with(:instagram).returns(nil)
-    graphql_response = { 'graphql' => {
-      "shortcode_media"=>{"display_url"=>"https://instagram.net/v/29_n.jpg",
-      "edge_media_to_caption"=>{"edges"=>[{"node"=>{"text"=>"Verify misinformation on WhatsApp"}}]},
-      "owner"=>{"profile_pic_url"=>"https://instagram.net/v/56_n.jpg", "username"=>"c.afpfact", "full_name"=>"AFP Fact Check"}}}}
+    graphql_response = {
+      'graphql' => {
+        'user' => {
+          'profile_pic_url' => 'https://instagram.net/v/29_n.jpg',
+          'username' => 'c.afpfact',
+          'full_name' => 'AFP Fact Check' 
+        },
+        'caption' => {
+          'text' => 'Verify misinformation on WhatsApp'
+        }
+      }
+    }
     Media.any_instance.stubs(:get_instagram_graphql_data).returns(graphql_response['graphql'])
     m = create_media url: 'https://www.instagram.com/p/B6_wqMHgQ12/'
     data = m.as_json
@@ -149,14 +157,12 @@ class InstagramTest < ActiveSupport::TestCase
   end
 
   test "should parse Instagram link for real" do
-    # if PenderConfig.get('crowdtangle_instagram_token')
-    #   url = 'https://www.instagram.com/p/CdOk-lLKmyH/'
-    #   m = Media.new url: url
-    #   data = m.as_json
-    #   assert_equal 'item', data['type']
-    #   assert_equal '@ironmaiden', data['username']
-    #   assert_match 'Iron Maiden', data['author_name']
-    #   assert_match 'When and where was your last Maiden show?', data['title']
-    # end
+    # url = 'https://www.instagram.com/p/CdOk-lLKmyH/'
+    # m = Media.new url: url
+    # data = m.as_json
+    # assert_equal 'item', data['type']
+    # assert_equal '@ironmaiden', data['username']
+    # assert_match 'Iron Maiden', data['author_name']
+    # assert_match 'When and where was your last Maiden show?', data['title']
   end
 end 


### PR DESCRIPTION
Cookies must be set in `config/cookies.txt`.

Fixes CHECK-1843 and CHECK-1201.