### PR TITLE
Fixing Instagram parser

### DIFF
--- a/app/models/concerns/media_crowdtangle_item.rb
+++ b/app/models/concerns/media_crowdtangle_item.rb
@@ -1,7 +1,8 @@
 module MediaCrowdtangleItem
   extend ActiveSupport::Concern
 
-  def get_crowdtangle_id(resource)
+  # "resource" is currently only Facebook
+  def get_crowdtangle_id(_resource)
     self.data.dig('uuid')
   end
 

--- a/app/models/concerns/media_crowdtangle_item.rb
+++ b/app/models/concerns/media_crowdtangle_item.rb
@@ -2,16 +2,12 @@ module MediaCrowdtangleItem
   extend ActiveSupport::Concern
 
   def get_crowdtangle_id(resource)
-    if resource == :instagram
-      media_info = self.data.dig('raw', 'graphql', 'shortcode_media')
-      media_info.nil? ? nil : "#{media_info['id']}_#{media_info['owner']['id']}"
-    else
-      self.data.dig('uuid')
-    end
+    self.data.dig('uuid')
   end
 
   def get_crowdtangle_data(resource)
     id = self.get_crowdtangle_id(resource)
+    puts "ID: #{id}"
     self.data['raw']['crowdtangle'] = { error: { message: 'Unknown ID', code: LapisConstants::ErrorCodes::const_get('UNKNOWN') }} and return if id.blank?
     crowdtangle_data = Media.crowdtangle_request(resource, id).with_indifferent_access
     result = crowdtangle_data.dig('result')
@@ -21,15 +17,6 @@ module MediaCrowdtangleItem
     end
     self.data['raw']['crowdtangle'] = result
     self.send("get_crowdtangle_#{resource}_result", post_info)
-  end
-
-  def get_crowdtangle_instagram_result(post_info)
-    self.data[:author_name] = post_info.dig('account', 'name')
-    self.data[:username] = '@' + post_info.dig('account', 'handle')
-    self.data[:author_url] = post_info.dig('account', 'url')
-    self.data[:description] = self.data[:title] = post_info.dig('description')
-    self.data[:picture] = post_info.dig('media').first['url'] if post_info.dig('media')
-    self.data[:published_at] = post_info.dig('date')
   end
 
   def get_crowdtangle_facebook_result(post_info)

--- a/app/models/concerns/media_crowdtangle_item.rb
+++ b/app/models/concerns/media_crowdtangle_item.rb
@@ -8,7 +8,6 @@ module MediaCrowdtangleItem
 
   def get_crowdtangle_data(resource)
     id = self.get_crowdtangle_id(resource)
-    puts "ID: #{id}"
     self.data['raw']['crowdtangle'] = { error: { message: 'Unknown ID', code: LapisConstants::ErrorCodes::const_get('UNKNOWN') }} and return if id.blank?
     crowdtangle_data = Media.crowdtangle_request(resource, id).with_indifferent_access
     result = crowdtangle_data.dig('result')

--- a/test/helpers/medias_test.rb
+++ b/test/helpers/medias_test.rb
@@ -166,9 +166,6 @@ class MediasHelperTest < ActionView::TestCase
 
     m.stubs(:data).returns(data[:facebook])
     assert_equal 'facebook_id', m.get_crowdtangle_id(:facebook)
-
-    m.stubs(:data).returns(data[:instagram])
-    assert_equal '111111_222222', m.get_crowdtangle_id(:instagram)
   end
 
   test 'should decode url' do

--- a/test/models/instagram_test.rb
+++ b/test/models/instagram_test.rb
@@ -2,25 +2,6 @@ require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'test_helper')
 require 'cc_deville'
 
 class InstagramTest < ActiveSupport::TestCase
-  test "should parse Instagram post" do
-    post_id = '1328722959803788109_343260652'
-    Media.any_instance.stubs(:get_crowdtangle_id).returns(post_id)
-    data = {"result"=>{"posts"=>[{"platformId"=>post_id,"description"=>"Peace Sells✌💲#vicrattlehead #megadeth #dystopiaworldtour #mexicocity","account"=>{"id"=>529101, "name"=>"Megadeth", "handle"=>"megadeth"}}]}}
-    Media.stubs(:crowdtangle_request).returns(data)
-    m = create_media url: 'https://www.instagram.com/p/BJwkn34AqtN/'
-    data = m.as_json
-    assert data['raw']['crowdtangle'].is_a? Hash
-    assert !data['raw']['crowdtangle'].empty?
-    assert_equal '@megadeth',data['username']
-    assert_equal 'item',data['type']
-    assert_match 'megadeth',data['author_name'].downcase
-    assert_match /Peace Sells/, data[:description]
-    assert_match /Peace Sells/, data[:title]
-    assert_not_nil data['picture']
-    Media.unstub(:crowdtangle_request)
-    Media.any_instance.unstub(:get_crowdtangle_id)
-  end
-
   test "should parse Instagram profile" do
     Media.any_instance.stubs(:doc).returns(Nokogiri::HTML("<meta property='og:title' content='megadeth'><meta property='og:image' content='https://www.instagram.com/megadeth.png'>"))
     m = create_media url: 'https://www.instagram.com/megadeth'
@@ -40,35 +21,6 @@ class InstagramTest < ActiveSupport::TestCase
     assert_match /https:\/\/www.instagram.com\/p\/CAdW7PMlTWc/, media2.url
   end
 
-  test "should store crowdtangle data of a instagram post" do
-    Media.any_instance.stubs(:get_crowdtangle_id).returns('2326406115734344979_3076818846')
-    m = create_media url: 'https://www.instagram.com/p/CBJDglTpFUT/'
-    data = m.as_json
-
-    assert data['raw']['crowdtangle'].is_a? Hash
-    assert !data['raw']['crowdtangle'].empty?
-    assert_equal 'item',data['type']
-    post_info = data['raw']['crowdtangle']['posts'].first
-    assert_match 'theintercept', post_info['account']['handle']
-    assert_match 'The Intercept', post_info['account']['name']
-    assert_match /It was a week/, post_info['description']
-    Media.any_instance.unstub(:get_crowdtangle_id)
-  end
-
-  test "should use username as author_name on Instagram profile when a full name is not available" do
-    Media.any_instance.stubs(:get_instagram_author_name).returns(nil)
-    m = create_media url: 'https://www.instagram.com/emeliiejanssonn/'
-    data = m.as_json
-    assert_match 'emeliiejanssonn', data['author_name']
-    Media.any_instance.unstub(:get_instagram_author_name)
-  end
-
-  test "should not have the subkey json+ld if the tag is not present on page" do
-    m = create_media url: 'https://www.instagram.com/emeliiejanssonn/'
-    data = m.as_json
-    assert data['raw']['json+ld'].nil?
-  end
-
   test "should have external id for post" do
     Media.any_instance.stubs(:doc).returns(Nokogiri::HTML("<meta property='og:url' content='https://www.instagram.com/p/BxxBzJmiR00/'>"))
     m = create_media url: 'https://www.instagram.com/p/BxxBzJmiR00/'
@@ -85,20 +37,6 @@ class InstagramTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:doc)
   end
 
-  test "should parse IGTV link as item" do
-    post_id = '2178435889592963183_3651758'
-    Media.any_instance.stubs(:get_crowdtangle_id).returns(post_id)
-    data = {"result"=>{"posts"=>[{"platformId":post_id,"description"=>"Vejam que lindo o Lula sendo recebido com todo amor e carinho","account"=>{"id"=>6506893, "name"=>"Bia Kicis \u{1F9FF}", "handle"=>"biakicis"}}]}}
-    Media.stubs(:crowdtangle_request).returns(data)
-    m = create_media url: 'https://www.instagram.com/tv/B47W-ZVJpBv/?igshid=l5tx0fnl421e'
-    data = m.as_json
-    assert_equal 'item', data['type']
-    assert_equal '@biakicis', data['username']
-    assert_match /kicis/, data['author_name'].downcase
-    Media.unstub(:crowdtangle_request)
-    Media.any_instance.unstub(:get_crowdtangle_id)
-  end
-
   test "should return error on data when can't get info from graphql" do
     id = 'B6_wqMHgQ12'
     Media.any_instance.stubs(:get_instagram_graphql_data).raises('Net::HTTPNotFound: Not Found')
@@ -113,13 +51,17 @@ class InstagramTest < ActiveSupport::TestCase
   end
 
   test "should parse when only graphql returns data" do
-    Media.stubs(:get_crowdtangle_data).with(:instagram).returns(nil)
     graphql_response = {
       'graphql' => {
         'user' => {
           'profile_pic_url' => 'https://instagram.net/v/29_n.jpg',
           'username' => 'c.afpfact',
           'full_name' => 'AFP Fact Check' 
+        },
+        'image_versions2' => {
+          'candidates' => [
+            { 'url' => 'https://instagram.net/v/28_n.jpg' } 
+          ],
         },
         'caption' => {
           'text' => 'Verify misinformation on WhatsApp'
@@ -136,7 +78,6 @@ class InstagramTest < ActiveSupport::TestCase
     assert_match /misinformation/, data['title']
     assert !data['picture'].blank?
     assert !data['author_picture'].blank?
-    Media.unstub(:get_crowdtangle_data)
     Media.any_instance.unstub(:get_instagram_graphql_data)
   end
 
@@ -157,12 +98,13 @@ class InstagramTest < ActiveSupport::TestCase
   end
 
   test "should parse Instagram link for real" do
-    # url = 'https://www.instagram.com/p/CdOk-lLKmyH/'
-    # m = Media.new url: url
-    # data = m.as_json
-    # assert_equal 'item', data['type']
-    # assert_equal '@ironmaiden', data['username']
-    # assert_match 'Iron Maiden', data['author_name']
-    # assert_match 'When and where was your last Maiden show?', data['title']
+    url = 'https://www.instagram.com/p/CdOk-lLKmyH/'
+    m = Media.new url: url
+    data = m.as_json
+    assert_equal 'item', data['type']
+    assert_equal '@ironmaiden', data['username']
+    assert_match 'Iron Maiden', data['author_name']
+    assert_match 'When and where was your last Maiden show?', data['title']
+    assert_equal 'https://instagram.com/ironmaiden', data['author_url']
   end
 end 

--- a/test/models/instagram_test.rb
+++ b/test/models/instagram_test.rb
@@ -98,13 +98,13 @@ class InstagramTest < ActiveSupport::TestCase
   end
 
   test "should parse Instagram link for real" do
-    url = 'https://www.instagram.com/p/CdOk-lLKmyH/'
-    m = Media.new url: url
-    data = m.as_json
-    assert_equal 'item', data['type']
-    assert_equal '@ironmaiden', data['username']
-    assert_match 'Iron Maiden', data['author_name']
-    assert_match 'When and where was your last Maiden show?', data['title']
-    assert_equal 'https://instagram.com/ironmaiden', data['author_url']
+    # url = 'https://www.instagram.com/p/CdOk-lLKmyH/'
+    # m = Media.new url: url
+    # data = m.as_json
+    # assert_equal 'item', data['type']
+    # assert_equal '@ironmaiden', data['username']
+    # assert_match 'Iron Maiden', data['author_name']
+    # assert_match 'When and where was your last Maiden show?', data['title']
+    # assert_equal 'https://instagram.com/ironmaiden', data['author_url']
   end
 end 


### PR DESCRIPTION
Now the Instagram parser gets more fields, like author URL, picture and published date.

Also, removing dependency on Crowdtandle - the GraphQL endpoint contains all the data we need.

Reference: CHECK-1201.