### PR TITLE
Replace tests against Meedan website

### DIFF
--- a/test/helpers/medias_test.rb
+++ b/test/helpers/medias_test.rb
@@ -105,7 +105,6 @@ class MediasHelperTest < ActionView::TestCase
 
   test 'should upload images to s3 and update media data' do
     urls = %w(
-      https://meedan.com
       https://opensource.globo.com/hacktoberfest/
       https://hacktoberfest.digitalocean.com/
     )

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -86,12 +86,12 @@ class MediaTest < ActiveSupport::TestCase
   end
 
   test "should parse opengraph metatags" do
-    m = create_media url: 'https://meedan.com/en/check/'
+    m = create_media url: 'https://hacktoberfest.digitalocean.com/'
     m.as_json
     data = m.get_opengraph_metadata
-    assert_match 'Product', data['title']
-    assert_match(/Engage your audience/, data['description'])
-    assert_match 'Meedan', data['author_name']
+    assert_match "Hacktoberfest '21", data['title']
+    assert_match(/Open source/, data['description'])
+    assert_match 'Hacktoberfest presented by DigitalOcean', data['author_name']
     assert_not_nil data['picture']
   end
   


### PR DESCRIPTION
With the Meedan site redesign, we seem to no longer have social tags
in the header. As a result, the tests in Pender we use to validate
some parsing behavior (on author and opengraph metadata) is failing.

To address this for now, I went ahead and updated the tests to read
from other URLs that have the data we're looking for. We should
consider doing two things longer term:
1. Add social metadata to Meedan.com, and possibly add the Meedan.com
tests back in here or elsewhere, since they seem useful to tell us
about our own site even if it wasn't the specific intention of these
tests
2. Consider testing against fixtures instead of live websites