### PR TITLE
Add privacy check URL to list of problematic Instagram URLs

### DIFF
--- a/app/models/concerns/media_instagram_item.rb
+++ b/app/models/concerns/media_instagram_item.rb
@@ -83,6 +83,7 @@ module MediaInstagramItem
     [
       { pattern: /^https:\/\/www\.instagram\.com\/accounts\/login/, reason: :login_page },
       { pattern: /^https:\/\/www\.instagram\.com\/challenge\?/, reason: :account_challenge_page },
+      { pattern: /^https:\/\/www\.instagram\.com\/privacy\/checks/, reason: :privacy_check_page },
     ]
   end
 end 


### PR DESCRIPTION
Running into this is another sign we are running into problems
with the Instagram API, so we want to send to Errbit.

CHECK-1201