### PR TITLE
Reduce number of retries in test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'sidekiq/testing'
 require 'minitest/retry'
 require 'minitest/mock'
 
-Minitest::Retry.use!(retry_count: 15)
+Minitest::Retry.use!(retry_count: 5)
 
 Minitest::Retry.on_failure do |_klass, _test_name|
   sleep 10


### PR DESCRIPTION
We don't think we need to retry so much since we no longer have
a flaky Facebook parser, and retrying so many times increases the
amount of time it takes to get a truly failling test run.