### PR TITLE
Delay initial metrics request

### DIFF
--- a/app/models/concerns/media_facebook_engagement_metrics.rb
+++ b/app/models/concerns/media_facebook_engagement_metrics.rb
@@ -3,11 +3,7 @@ require 'pender_exceptions'
 module MediaFacebookEngagementMetrics
   extend ActiveSupport::Concern
 
-  included do
-    Media.declare_metrics('facebook')
-  end
-
-  def get_metrics_from_facebook
+  def get_metrics_from_facebook_in_background
     facebook_id = self.data['uuid'] if is_a_facebook_post?
     # Delaying a bit to prevent race condition where initial request that creates
     # record on Check API beats our metrics reporting

--- a/app/models/concerns/media_facebook_engagement_metrics.rb
+++ b/app/models/concerns/media_facebook_engagement_metrics.rb
@@ -9,7 +9,9 @@ module MediaFacebookEngagementMetrics
 
   def get_metrics_from_facebook
     facebook_id = self.data['uuid'] if is_a_facebook_post?
-    MetricsWorker.perform_async(self.original_url, ApiKey.current&.id, 0, facebook_id)
+    # Delaying a bit to prevent race condition where initial request that creates
+    # record on Check API beats our metrics reporting
+    MetricsWorker.perform_in(10.seconds, self.original_url, ApiKey.current&.id, 0, facebook_id)
   end
 
   def is_a_facebook_post?

--- a/app/models/concerns/media_metrics.rb
+++ b/app/models/concerns/media_metrics.rb
@@ -1,17 +1,7 @@
 module MediaMetrics
   extend ActiveSupport::Concern
 
-  METRICS = []
-
-  def get_metrics
-    METRICS.each { |name| self.send("get_metrics_from_#{name}") }
-  end
-
   module ClassMethods
-    def declare_metrics(name)
-      METRICS << name
-    end
-
     def notify_webhook_and_update_metrics_cache(url, name, value, key_id)
       return if value.nil?
       settings = Media.api_key_settings(key_id)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -80,7 +80,7 @@ class Media
       self.upload_images
     end
     self.archive(options.delete(:archivers))
-    self.get_metrics
+    self.get_metrics_from_facebook_in_background
     Pender::Store.current.read(Media.get_id(self.original_url), :json)
   end
 

--- a/app/workers/metrics_worker.rb
+++ b/app/workers/metrics_worker.rb
@@ -5,4 +5,3 @@ class MetricsWorker
     Media.get_metrics_from_facebook(url, key_id, count, facebook_id)
   end
 end
-

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -614,7 +614,7 @@ class MediasControllerTest < ActionController::TestCase
 
   test "should enqueue, parse and notify with error when timeout" do
     Sidekiq::Testing.fake!
-    Media.any_instance.stubs(:get_metrics)
+    Media.any_instance.stubs(:get_metrics_from_facebook_in_background)
     webhook_info = { 'webhook_url' => 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token' => 'test' }
     a = create_api_key application_settings: webhook_info.merge(config: { timeout: '0.001' })
     authenticate_with_token(a)
@@ -633,7 +633,7 @@ class MediasControllerTest < ActionController::TestCase
     assert_nil Pender::Store.current.read(id, :json)
     MediaParserWorker.drain
     assert_equal timeout_error, Pender::Store.current.read(id, :json)['error']
-    Media.any_instance.unstub(:get_metrics)
+    Media.any_instance.unstub(:get_metrics_from_facebook_in_background)
   end
 
   test "should return data with error message if can't parse" do

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -490,7 +490,7 @@ class ArchiverTest < ActiveSupport::TestCase
   test "should return false and add error to data when video archiving is not supported" do
     Media.unstub(:supported_video?)
     Media.any_instance.stubs(:parse)
-    Media.any_instance.stubs(:get_metrics)
+    Media.any_instance.stubs(:get_metrics_from_facebook_in_background)
     a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
 
     Media.stubs(:system).returns(`(exit 0)`)
@@ -512,7 +512,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal '1 Unsupported URL', media_data.dig('archives', 'video_archiver', 'error', 'message')
 
     Media.any_instance.unstub(:parse)
-    Media.any_instance.unstub(:get_metrics)
+    Media.any_instance.unstub(:get_metrics_from_facebook_in_background)
     Media.any_instance.unstub(:system)
   end
 

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -10,7 +10,7 @@ class MetricsTest < ActiveSupport::TestCase
     Sidekiq::Testing.fake! do
       m = create_media url: 'http://example.com'
       assert_difference 'MetricsWorker.jobs.size', 1 do
-        m.get_metrics
+        m.get_metrics_from_facebook_in_background
       end
       scheduled_job = MetricsWorker.jobs.first
       assert Time.at(scheduled_job['at']) > current_time
@@ -27,7 +27,7 @@ class MetricsTest < ActiveSupport::TestCase
     
     Sidekiq::Testing.fake! do
       m = create_media url: 'http://example.com'
-      m.get_metrics
+      m.get_metrics_from_facebook_in_background
       MetricsWorker.perform_one
 
       # Perform one removes the first, immediately enqueued background job

--- a/test/workers/archiver_worker_test.rb
+++ b/test/workers/archiver_worker_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 class ArchiverWorkerTest < ActiveSupport::TestCase
 
   test "should update cache when video archiving fails the max retries" do
-    Media.any_instance.stubs(:get_metrics)
+    Media.any_instance.stubs(:get_metrics_from_facebook_in_background)
     url = 'https://twitter.com/meedan/status/1202732707597307905'
     m = create_media url: url
     data = m.as_json
@@ -13,7 +13,7 @@ class ArchiverWorkerTest < ActiveSupport::TestCase
     data = m.as_json
     assert_equal LapisConstants::ErrorCodes::const_get('ARCHIVER_FAILURE'), data.dig('archives', 'video_archiver', 'error', 'code')
     assert_equal 'Test Archiver', data.dig('archives', 'video_archiver', 'error', 'message')
-    Media.any_instance.unstub(:get_metrics)
+    Media.any_instance.unstub(:get_metrics_from_facebook_in_background)
   end
 
   test "should update cache when Archive.org fails the max retries" do


### PR DESCRIPTION
We were seeing a race condition where the metrics update
returned before the intiial request created the record on the
Check API-side. Since Check API doesn't currently return a
different status if the Media with URL isn't present in the
database, we want to just delay the initial call to try to
ensure that the record is created before we try to update it.