### PR TITLE
Add logging for debugging metrics job

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -124,6 +124,7 @@ class Media
       data['webhook_called'] = @webhook_called ? 1 : 0
       Pender::Store.current.write(id, :json, data)
     end
+    data
   end
 
   def self.notify_webhook(type, url, data, settings)
@@ -144,6 +145,8 @@ class Media
         Rails.logger.warn level: 'WARN', message: 'Failed to notify webhook', url: url, type: type, error_class: e.class, error_message: e.message, webhook_url: settings['webhook_url']
         return false
       end
+    else
+      Rails.logger.warn level: 'WARN', message: 'Webhook settings not configured for API key', url: url, type: type, api_key: ApiKey.current&.id
     end
     true
   end

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -14,7 +14,7 @@ class MetricsTest < ActiveSupport::TestCase
       end
       scheduled_job = MetricsWorker.jobs.first
       assert Time.at(scheduled_job['at']) > current_time
-      assert Time.at(scheduled_job['at']) < current_time + 1.minute
+      assert Time.at(scheduled_job['at']) < current_time + 10.minutes
       assert_nil scheduled_job['enqueued_at']
     end
   end


### PR DESCRIPTION
Before we were silently failing when a webhook URL was not
configured for an API key, which we expect to be set in
real environments. This gives us an indication, and also adds
some other logging around the metrics background job to
help with debugging.