### PR TITLE
Always strip " | Facebook" from Facebook titles

### DIFF
--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -96,6 +96,12 @@ module ProviderFacebook
     return unless title
     return if NONUNIQUE_TITLES.include?(title.downcase)
 
-    title.gsub(' | Facebook', '')
+    title
+  end
+
+  def strip_facebook_from_title!
+    return unless @parsed_data['title']
+
+    @parsed_data['title'].gsub!(' | Facebook', '')
   end
 end

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -70,6 +70,8 @@ module Parser
         set_data_field('author_picture', jsonld.dig('creator', 'image'))
         set_data_field('picture', jsonld.dig('thumbnailUrl'))
 
+        strip_facebook_from_title!
+
         @parsed_data['html'] = html_for_facebook_post(parsed_data.dig('username'), doc, url) || ''
       end
 

--- a/app/models/parser/facebook_profile.rb
+++ b/app/models/parser/facebook_profile.rb
@@ -50,6 +50,9 @@ module Parser
         set_data_field('author_url', parseable_url)
         set_facebook_privacy_error(doc, unavailable_page)
       end
+
+      strip_facebook_from_title!
+
       @parsed_data['published_at'] = ''
       parsed_data
     end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -374,10 +374,17 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
   test "should strip '| Facebook' from page titles" do
     WebMock.stub_request(:any, /api.crowdtangle.com\/post/).to_return(status: 200, body: {}.to_json)
 
+    parser = Parser::FacebookItem.new('https://www.facebook.com/fakeaccount/posts/12345')
     doc = Nokogiri::HTML(<<~HTML)
       <title>Piglet the Dog's post | Facebook</title>
     HTML
-    data = Parser::FacebookItem.new('https://www.facebook.com/fakeaccount/posts/12345').parse_data(doc, throwaway_url)
+    data = parser.parse_data(doc, throwaway_url)
+    assert_equal "Piglet the Dog's post", data['title']
+    
+    doc = Nokogiri::HTML(<<~HTML)
+      <meta property="og:title" content="Piglet the Dog's post | Facebook" />
+    HTML
+    data = parser.parse_data(doc, throwaway_url)
     assert_equal "Piglet the Dog's post", data['title']
   end
 

--- a/test/models/parser/facebook_profile_test.rb
+++ b/test/models/parser/facebook_profile_test.rb
@@ -265,11 +265,18 @@ class FacebookProfileUnitTest < ActiveSupport::TestCase
   end
 
   test "should strip '| Facebook' from page titles" do
+    parser = Parser::FacebookProfile.new('https://www.facebook.com/fakeaccount')
     doc = Nokogiri::HTML(<<~HTML)
-      <title>Piglet the Dog | Facebook</title>
+      <title>Piglet the Dog's post | Facebook</title>
     HTML
-    data = Parser::FacebookProfile.new('https://www.facebook.com/fakeaccount').parse_data(doc, throwaway_url)
-    assert_equal "Piglet the Dog", data['title']
+    data = parser.parse_data(doc, throwaway_url)
+    assert_equal "Piglet the Dog's post", data['title']
+    
+    doc = Nokogiri::HTML(<<~HTML)
+      <meta property="og:title" content="Piglet the Dog's post | Facebook" />
+    HTML
+    data = parser.parse_data(doc, throwaway_url)
+    assert_equal "Piglet the Dog's post", data['title']
   end
 
   test 'sets description from og:description metatag if present' do


### PR DESCRIPTION
Previously we were only stripping if it came through a specific method, but there are multiple ways we might set title. This moves stripping to a cleanup step at the end of each provider.