### PR TITLE
Allow setting Pender cookies from file on S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: minimal
 before_install:
 - openssl aes-256-cbc -K $encrypted_ac629ad7371a_key -iv $encrypted_ac629ad7371a_iv -in config/config.yml.enc -out config/config.yml -d
-- openssl aes-256-cbc -K $encrypted_0e2838254faa_key -iv $encrypted_0e2838254faa_iv -in config/cookies.txt.enc -out config/cookies.txt -d
 - cp config/database.yml.example config/database.yml
 - cp config/sidekiq.yml.example config/sidekiq.yml
 - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Open http://localhost:3200/api-docs/index.html to access Pender API directly.
 
 ### Setting Cookies
 
-We send cookies with certain requests that require logged-in users (e.g. Instagram, TikTok). To provide these for development and tests, log in on your browser and copy the cookie information to `config/cookies.txt`.
+We send cookies with certain requests that require logged-in users (e.g. Instagram, TikTok). To provide these for development and tests, log in on your browser and copy the cookie information to `config/cookies.txt`. The location of this file can also be configured as `cookies_file_path` in `config.yml`
 
 To do this easily in Chrome:
 1. Install the [Get cookies.txt](https://chrome.google.com/webstore/detail/get-cookiestxt/bgaddhkoddajcdgocldbbfleckgcbcid) browser extension
@@ -66,11 +66,8 @@ To do this easily in Chrome:
 **Note**: If you do install this extension, consider doing it on a limited Chrome profile since it requires read and write permission for all websites.
 
 #### Rotating cookies in CI
-1. Follow steps for Setting Cookies above
-1. Re-encrypt the new cookies file: `travis encrypt-file config/cookies.txt -o config/cookies.txt.enc --pro`
-1. Copy the resulting decrypt command and replace the corresponding line in `.travis.yml`
 
-**Note**: Deployed environment cookies should be set in [configurator](https://github.com/meedan/configurator).
+Deployed environment cookies should be updated in the respective cookies file in S3. The path to this file can be found for each environment in [SSM](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1126694913/How+to+get+and+set+configuration+values+and+secrets+on+SSM).
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ $ docker-compose up --abort-on-container-exit
 ```
 Open http://localhost:3200/api-docs/index.html to access Pender API directly.
 
-### Setting Cookies
+### Setting Cookies for Requests
 
-We send cookies with certain requests that require logged-in users (e.g. Instagram, TikTok). To provide these for development and tests, log in on your browser and copy the cookie information to `config/cookies.txt`. The location of this file can also be configured as `cookies_file_path` in `config.yml`
+We send cookies with certain requests that require logged-in users (e.g. Instagram, TikTok).
+
+**In development**
+To provide these for development, log in on your browser and copy the cookie information to `config/cookies.txt`. The location of this file can also be configured as `cookies_file_path` in `config.yml`
 
 To do this easily in Chrome:
 1. Install the [Get cookies.txt](https://chrome.google.com/webstore/detail/get-cookiestxt/bgaddhkoddajcdgocldbbfleckgcbcid) browser extension
@@ -65,9 +68,8 @@ To do this easily in Chrome:
 
 **Note**: If you do install this extension, consider doing it on a limited Chrome profile since it requires read and write permission for all websites.
 
-#### Rotating cookies in CI
-
-Deployed environment cookies should be updated in the respective cookies file in S3. The path to this file can be found for each environment in [SSM](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1126694913/How+to+get+and+set+configuration+values+and+secrets+on+SSM).
+**In deployed environments**
+Deployed environment cookies are stored in S3. To update them, use steps 1-3 above and then update the remote file in AWS. The path to this file can be found for each environment in [SSM](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1126694913/How+to+get+and+set+configuration+values+and+secrets+on+SSM).
 
 ## API
 

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -21,14 +21,24 @@ development: &default
   storage_video_asset_path: 'http://localhost:9000/pender-video/video'
   storage_medias_asset_path: 'http://localhost:9000/pender-dev/medias'
 
+  # Location for cookies to send with requests, on S3 or local filesystem
+  #
+  # REQUIRED for deployed environments
+  # OPTIONAL for development; defaults to `config/cookies.txt` on local filesystem
+  #
+  # Any S3 links will be authenticated with storage_access_key, storage_secret_key,
+  # and storage_bucket_region via Pender::AwsS3Client
+  # Example: cookies_file_path: 's3://<BUCKET NAME>/<FILE NAME>'
+  cookies_file_path: 'config/cookies.txt'
+
   # Exception reporting using Airbrake or API equivalent https://airbrake.io/
   #
   # OPTIONAL
   #
-  aribrake_host: # '<AIRBRAKE HOST>'
-  aribrake_port: # '<AIRBRAKE PORT>'
-  aribrake_project_key: # '<AIRBRAKE PROJECT KEY>'
-  aribrake_environment: # '<AIRBRAKE ENVIRONMENT>'
+  airbrake_host: # '<AIRBRAKE HOST>'
+  airbrake_port: # '<AIRBRAKE PORT>'
+  airbrake_project_key: # '<AIRBRAKE PROJECT KEY>'
+  airbrake_environment: # '<AIRBRAKE ENVIRONMENT>'
 
   # Google API
   #

--- a/config/initializers/load_cookies.rb
+++ b/config/initializers/load_cookies.rb
@@ -1,11 +1,1 @@
-COOKIES_PATH = 'config/cookies.txt'
-
-PenderConfig.set('cookies', {}) if PenderConfig.get('cookies').nil?
-if File.file?(COOKIES_PATH)
-  File.readlines(COOKIES_PATH).each do |line|
-    data = line.split("\t")
-    next if data[0].start_with?('#')
-    CONFIG['cookies'][data[0]] ||= {}
-    CONFIG['cookies'][data[0]][data[5]] = data[6].strip if data[6]
-  end
-end
+CookieLoader.load_from(PenderConfig.get('cookies_file_path') || 'config/cookies.txt')

--- a/lib/aws_s3_client.rb
+++ b/lib/aws_s3_client.rb
@@ -1,0 +1,19 @@
+
+require 'aws-sdk-s3'
+
+module Pender
+  class AwsS3Client
+    class << self
+      def get_client
+        config = {
+          endpoint: PenderConfig.get('storage_endpoint'),
+          access_key_id: PenderConfig.get('storage_access_key'),
+          secret_access_key: PenderConfig.get('storage_secret_key'),
+          force_path_style: true,
+          region: PenderConfig.get('storage_bucket_region'),
+        }
+        Aws::S3::Client.new(config)
+      end
+    end
+  end
+end

--- a/lib/cookie_loader.rb
+++ b/lib/cookie_loader.rb
@@ -1,0 +1,42 @@
+require 'aws_s3_client'
+
+class CookieLoader
+  class FilePathError < StandardError; end
+  class S3DownloadError < StandardError; end
+
+  class << self
+    def load_from(cookies_path)
+      CONFIG['cookies'] = {} if CONFIG['cookies'].nil?
+      begin
+        raise FilePathError.new('Path not provided') unless cookies_path
+
+        tmpfile = nil
+        if cookies_path.start_with?('s3://')
+          parts = cookies_path.gsub('s3://',  '').split('/')
+          raise FilePathError.new('S3 path unparseable') unless parts.length == 2
+          
+          tmpfile = Tempfile.new('cookies.txt')
+          response = Pender::AwsS3Client.get_client.get_object(bucket: parts[0], key: parts[1], response_target: tmpfile.path)
+          raise S3DownloadError.new('Unsuccessful response from S3') unless response.successful?
+          raise S3DownloadError.new('Downloaded file from S3 is empty') unless tmpfile.size > 0
+        end
+        raise FilePathError.new('No file found at path') unless File.file?(tmpfile&.path || cookies_path)
+
+        File.readlines(tmpfile&.path || cookies_path).each do |line|
+          data = line.split("\t")
+          next if data[0].start_with?('#')
+          CONFIG['cookies'][data[0]] ||= {}
+          CONFIG['cookies'][data[0]][data[5]] = data[6].strip if data[6]
+        end
+        CONFIG['cookies']
+      rescue StandardError => error
+        PenderAirbrake.notify(error, provided_path: cookies_path)
+        Rails.logger.warn(message: 'Problem setting cookies', provided_path: cookies_path, error_class: error.class, error_message: error.message)
+        false
+      ensure
+        tmpfile.close if tmpfile
+        tmpfile.unlink if tmpfile
+      end
+    end
+  end
+end

--- a/lib/pender_store.rb
+++ b/lib/pender_store.rb
@@ -21,14 +21,7 @@ module Pender
         @storage[key] = PenderConfig.get("storage_#{key}")
       end
 
-      config = {
-        endpoint: @storage.dig('endpoint'),
-        access_key_id: @storage.dig('access_key'),
-        secret_access_key: @storage.dig('secret_key'),
-        force_path_style: true,
-        region: @storage.dig('bucket_region')
-      }
-      @client = Aws::S3::Client.new(config)
+      @client = Pender::AwsS3Client.get_client
       @resource = Aws::S3::Resource.new(client: @client)
       create_buckets
     end

--- a/test/lib/cookie_loader_test.rb
+++ b/test/lib/cookie_loader_test.rb
@@ -1,0 +1,156 @@
+require 'test_helper'
+require_relative '../../lib/cookie_loader'
+
+class CookieLoaderTest < ActiveSupport::TestCase
+  def cookie_contents
+    <<~STRING
+      # HTTP Cookie File downloaded with cookies.txt by Genuinous @genuinous
+      # This file can be used by wget, curl, aria2c and other standard compliant tools.
+      # Usage Examples:
+      #   1) wget -x --load-cookies cookies.txt "https://www.washingtonpost.com/politics/winter-is-coming-allies-fear-trump-isnt-prepared-for-gathering-legal-storm/2018/08/29/b07fc0a6-aba0-11e8-b1da-ff7faa680710_story.html?utm_term=.520dc8c63ae1"
+      #   2) curl --cookie cookies.txt "https://www.washingtonpost.com/politics/winter-is-coming-allies-fear-trump-isnt-prepared-for-gathering-legal-storm/2018/08/29/b07fc0a6-aba0-11e8-b1da-ff7faa680710_story.html?utm_term=.520dc8c63ae1"
+      #   3) aria2c --load-cookies cookies.txt "https://www.washingtonpost.com/politics/winter-is-coming-allies-fear-trump-isnt-prepared-for-gathering-legal-storm/2018/08/29/b07fc0a6-aba0-11e8-b1da-ff7faa680710_story.html?utm_term=.520dc8c63ae1"
+      #
+      # .ignoredurl.com	TRUE	/	FALSE	1234567890	sessionid	555
+      .example.com	TRUE	/	FALSE	1538248063	wp_devicetype	0
+      .anotherexample.com	TRUE	/	FALSE	1538248063	piglet	dog
+    STRING
+  end
+
+  def cookies_file
+    return @cookies_file if @cookies_file
+    @cookies_file = Tempfile.new('fake-cookies.txt')
+    @cookies_file.write(cookie_contents)
+    @cookies_file.rewind
+    @cookies_file
+  end
+
+  def setup
+    isolated_setup
+
+    # We're currently loading the application before running these tests,
+    # which calls CookieLoader as part of initialization. Because of that
+    # we'll want to make sure and check existing state before setting our expectations
+    # and limit the scope of any mocks.
+    @existing_cookies = CONFIG['cookies']
+    CONFIG['cookies'] = nil
+  end
+
+  def teardown
+    isolated_teardown
+    CONFIG['cookies'] = @existing_cookies
+  end
+
+  # Success cases:
+  test 'loads cookies into CONFIG from local file system if local filepath provided, ignoring commented lines' do
+    assert PenderConfig.get('cookies').blank?
+
+    CookieLoader.load_from(cookies_file.path)
+    PenderConfig.load('cookies')
+    
+    cookies = PenderConfig.get('cookies')
+    assert_equal 2, cookies.length
+    assert_equal cookies['.example.com']['wp_devicetype'], '0'
+    assert_equal cookies['.anotherexample.com']['piglet'], 'dog'
+  ensure
+    cookies_file.close
+    cookies_file.unlink
+  end
+  
+  test 'requests file from S3 if file path begins S3 and loads result into config' do
+    mocked_cookie_response = MiniTest::Mock.new
+    def mocked_cookie_response.successful?; true; end
+
+    mocked_s3_client = MiniTest::Mock.new
+    mocked_s3_client.expect(:get_object, mocked_cookie_response) do |args|
+      File.open(args[:response_target], 'w') { |file| file.write(cookie_contents) }
+      args[:bucket] == 'fake-bucket' && args[:key] == 'fake-cookies.txt' && args[:response_target].present?
+    end
+    
+    Aws::S3::Client.stub(:new, mocked_s3_client) do
+      CookieLoader.load_from('s3://fake-bucket/fake-cookies.txt')
+
+      mocked_s3_client.verify
+    end
+
+    PenderConfig.load('cookies')
+    cookies = PenderConfig.get('cookies')
+    assert_equal 2, cookies.length
+    assert_equal cookies['.example.com']['wp_devicetype'], '0'
+    assert_equal cookies['.anotherexample.com']['piglet'], 'dog'
+  end
+
+  # Error cases:
+  test 'keeps cookies as empty and reports error if file path not provided' do
+    mocked_airbrake = MiniTest::Mock.new
+    mocked_airbrake.expect :call, :return_value do |error, args|
+      error.class.to_s.match(/FilePathError/) && 
+        error.message.match(/Path not provided/) &&
+        args[:provided_path].nil?
+    end
+
+    PenderAirbrake.stub(:notify, mocked_airbrake) do
+      CookieLoader.load_from(nil)
+      mocked_airbrake.verify
+    end
+    
+    PenderConfig.load('cookies')
+    assert_equal PenderConfig.get('cookies'), {}
+  end
+
+  test 'keeps cookies as empty and reports error if file path does not exist' do
+    mocked_airbrake = MiniTest::Mock.new
+    mocked_airbrake.expect :call, :return_value do |error, args|
+      error.class.to_s.match(/FilePathError/) && 
+        error.message.match(/No file found at path/) &&
+        args[:provided_path] == 'totally/fake/path.txt'
+    end
+
+    PenderAirbrake.stub(:notify, mocked_airbrake) do
+      CookieLoader.load_from('totally/fake/path.txt')
+      mocked_airbrake.verify
+    end
+
+    PenderConfig.load('cookies')
+    assert_equal PenderConfig.get('cookies'), {}
+  end
+
+  test 'keeps cookies as empty and reports problem downloading from S3' do
+    mocked_airbrake = MiniTest::Mock.new
+    mocked_airbrake.expect :call, :return_value do |error, args|
+      error.class.to_s.match(/S3DownloadError/) && 
+        error.message.match(/Unsuccessful response from S3/) &&
+        args[:provided_path] == 's3://fake-bucket/fake-cookies.txt'
+    end
+
+    Aws::S3::Client.any_instance.stubs(:get_object).returns(OpenStruct.new(successful?: false))
+
+    PenderAirbrake.stub(:notify, mocked_airbrake) do
+      CookieLoader.load_from('s3://fake-bucket/fake-cookies.txt')
+      mocked_airbrake.verify
+    end
+
+    PenderConfig.load('cookies')
+    assert_equal PenderConfig.get('cookies'), {}
+  end
+
+  test 'keeps cookies as empty and reports problem if file downloaded from S3 is empty' do
+    mocked_airbrake = MiniTest::Mock.new
+    mocked_airbrake.expect :call, :return_value do |error, args|
+      error.class.to_s.match(/S3DownloadError/) && 
+        error.message.match(/Downloaded file from S3 is empty/) &&
+        args[:provided_path] == 's3://fake-bucket/fake-cookies.txt'
+    end
+
+    # Below returns success, but does not write to the tmpfile
+    Aws::S3::Client.any_instance.stubs(:get_object).returns(OpenStruct.new(successful?: true))
+
+    PenderAirbrake.stub(:notify, mocked_airbrake) do
+      CookieLoader.load_from('s3://fake-bucket/fake-cookies.txt')
+      mocked_airbrake.verify
+    end
+
+    PenderConfig.load('cookies')
+    assert_equal PenderConfig.get('cookies'), {}
+  end
+end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -310,7 +310,9 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'success', RequestHelper.request_url(url, 'Get')
   end
 
-  test "should add cookie from cookie.txt on header if domain matches" do
+  test "should add cookie from config on header if domain matches" do
+    stub_configs(cookies: { '.example.com' => { 'wp_devicetype' => '0' } })
+
     url_no_cookie = 'https://www.istqb.org/'
     assert_equal "", RequestHelper.html_options(url_no_cookie)['Cookie']
     url_with_cookie = 'https://example.com/politics/winter-is-coming-allies-fear-trump-isnt-prepared-for-gathering-legal-storm/2018/08/29/b07fc0a6-aba0-11e8-b1da-ff7faa680710_story.html'
@@ -324,6 +326,8 @@ class MediaTest < ActiveSupport::TestCase
   end
 
   test "should use cookies from api key config if present" do
+    stub_configs(cookies: { '.example.com' => { 'wp_devicetype' => '0' } })
+
     api_key = create_api_key
     uri = RequestHelper.parse_url('http://example.com')
 


### PR DESCRIPTION
We're moving away from using Configurator, which means that we need a way to include cookies that aligns with how we now treat other secrets. This commit moves toward us setting an S3 file path in `config.yml`, which would point to a file in an S3 bucket that contains the required cookies. This request will be authenticated with the credentials we already use for storage-related S3 items.

The config setting is `cookies_file_path`, and can point to the local filesystem (for development and, if needed, test) or to a file on S3.

If no `cookies_file_path` is provided in the config, it defaults to what we previously used: `config/cookies.txt`.

Also:
* Removes cookies.txt from the Travis CI file (since we won't have it available). Removes dependencies on that file being present locally in test, instead opting for stubbing
* Fixes some typos in the config.example file.