### PR TITLE
Check 2457 do not cache failed pender responses

### DIFF
--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -63,7 +63,7 @@ module Api
 
       def render_uncached_media
         render_timeout(false) do
-          (render_url_invalid and return true) unless valid_url?
+          (render_url_invalid and return true) unless RequestHelper.validate_url(@url)
           rescue_block = Proc.new { |_e| render_url_invalid and return true }
           handle_exceptions(OpenSSL::SSL::SSLError, rescue_block, {url: @url, request: request}) do
             @media = Media.new(url: @url, request: request)
@@ -182,10 +182,6 @@ module Api
 
       def should_serve_external_embed?(data)
         !data['html'].blank? && (data['url'] =~ /^https:/ || Rails.env.development?)
-      end
-
-      def valid_url?
-        RequestHelper.validate_url(@url)
       end
 
       def clear_upstream_cache

--- a/app/helpers/medias_helper.rb
+++ b/app/helpers/medias_helper.rb
@@ -85,9 +85,7 @@ module MediasHelper
     data['title'] = url if data['title'].blank?
     code = error_data[:code]
     error_data[:code] = LapisConstants::ErrorCodes::const_get(code)
-    data = data.merge(error: error_data)
-    Pender::Store.current.write(id, :json, data) unless code == 'DUPLICATED'
-    data
+    data.merge(error: error_data)
   end
 
   def get_timeout_data(media, url, id)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -77,12 +77,14 @@ class Media
       handle_exceptions(self, StandardError) { self.parse }
       self.data['title'] = self.url if self.data['title'].blank?
       data = self.data.merge(Media.required_fields(self)).with_indifferent_access
-      Pender::Store.current.write(Media.get_id(self.original_url), :json, cleanup_data_encoding(data))
+      if data[:error].blank?
+        Pender::Store.current.write(Media.get_id(self.original_url), :json, cleanup_data_encoding(data))
+      end
       self.upload_images
     end
     self.archive(options.delete(:archivers))
     Metrics.get_metrics_from_facebook_in_background(self.data, self.original_url, ApiKey.current&.id)
-    Pender::Store.current.read(Media.get_id(self.original_url), :json)
+    Pender::Store.current.read(Media.get_id(self.original_url), :json) || cleanup_data_encoding(data)
   end
 
   PARSERS = [

--- a/lib/pender_store.rb
+++ b/lib/pender_store.rb
@@ -98,7 +98,6 @@ module Pender
       )
     end
 
-
     def write(id, type, content)
       content = JSON.pretty_generate(content) if type == :json
       store_object(key(id, type), content)

--- a/test/helpers/medias_test.rb
+++ b/test/helpers/medias_test.rb
@@ -73,17 +73,12 @@ class MediasHelperTest < ActionView::TestCase
   end
 
   test 'should upload images to s3 and update media data' do
-    urls = %w(
-      https://opensource.globo.com/hacktoberfest/
-      https://hacktoberfest.digitalocean.com/
-    )
-    urls.each do |url|
-      id = Media.get_id(url)
-      m = Media.new url: url
-      data = m.as_json
-      assert_match /#{Pender::Store.current.storage_path('medias')}\/#{id}\/author_picture.(jpg|png)/, data[:author_picture], "Can't get `author_picture` from url #{url}"
-      assert_match /#{Pender::Store.current.storage_path('medias')}\/#{id}\/picture.(jpg|png)/, data[:picture], "Can't get `picture` from url #{url}"
-    end
+    url = 'https://hacktoberfest.com/'
+    id = Media.get_id(url)
+    m = Media.new url: url
+    data = m.as_json
+    assert_match /#{Pender::Store.current.storage_path('medias')}\/#{id}\/author_picture.(jpg|png)/, data[:author_picture], "Can't get `author_picture` from url #{url}"
+    assert_match /#{Pender::Store.current.storage_path('medias')}\/#{id}\/picture.(jpg|png)/, data[:picture], "Can't get `picture` from url #{url}"
   end
 
   test "#cleanup_data_encoding should only encode URLs on raw key" do

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -107,7 +107,7 @@ class MediaTest < ActiveSupport::TestCase
   end
 
   test "should return author picture" do
-    Media.any_instance.stubs(:doc).returns(Nokogiri::HTML("<meta property='og:image' content='https://github.githubassets.com/images/modules/open_graph/github-logo.png'>"))
+    WebMock.stub_request(:get, /github.com/).to_return(status: 200, body: "<meta property='og:image' content='https://github.githubassets.com/images/modules/open_graph/github-logo.png'>")
     url = 'http://github.com'
     id = Media.get_id url
     m = create_media url: url

--- a/test/models/parser/twitter_item_test.rb
+++ b/test/models/parser/twitter_item_test.rb
@@ -44,7 +44,7 @@ class TwitterItemIntegrationTest < ActiveSupport::TestCase
     assert_equal '', PenderConfig.get(:twitter_consumer_key)
     data = m.as_json
     assert_equal m.url, data['title']
-    assert_match "Twitter::Error::Unauthorized", data['raw']['api']['error']['message']
+    assert_match "Twitter::Error::BadRequest", data['raw']['api']['error']['message']
   end
 
   test "should store oembed data of a twitter profile" do


### PR DESCRIPTION
Also addresses unrelated failing test caused by change on Hacktober page