### PR TITLE
Fix stack level too deep bug caused by Airbrake & Open Telemetry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ group :test do
 end
 gem 'logstash-logger'
 gem 'railroady'
-gem 'airbrake', '11.0.0'
+gem 'airbrake', '~>13.0.0'
 gem 'responders'
 gem 'yt', '~> 0.25.5'
 gem 'rswag-api'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,9 +62,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    airbrake (11.0.0)
-      airbrake-ruby (~> 5.0)
-    airbrake-ruby (5.2.1)
+    airbrake (13.0.3)
+      airbrake-ruby (~> 6.0)
+    airbrake-ruby (6.2.0)
       rbtree3 (~> 0.5)
     ansi (1.5.0)
     arel (9.0.0)
@@ -522,7 +522,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (= 11.0.0)
+  airbrake (~> 13.0.0)
   awesome_print
   aws-sdk-s3
   byebug

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ If you would like to see data reported from your local machine, do the following
 
 **Local console**
 1. Make sure that the `otlp` prefixed values are set in `config.yml` following `config.yml.example`. The values provided in `config.yml.example` can be used since we don't need a real API key.
-1. In `initializers/open_telemetry.rb`, uncomment the line setting exporter to 'console'. Warning: this is noisy!
+1. In `lib/pender_open_telemetry_config.rb`, uncomment the line setting exporter to 'console'. Warning: this is noisy!
 1. Restart the server
 1. View output in local server logs
 

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -1,3 +1,5 @@
+require 'pender_exceptions'
+
 module Metrics
   class << self
     RETRYABLE_FACEBOOK_ERROR_CODES = [

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -120,7 +120,7 @@ development: &default
   # Open Telemetry configuration, for reporting to Honeycomb
   # See initializers/open_telemetry.rb for usage.
   #
-  # OPTIONAL
+  # OPTIONAL (set to report to Honeycomb Dev environment from local)
   #
   otel_exporter_otlp_endpoint: # "https://api.honeycomb.io"
   otel_exporter_otlp_headers: # "x-honeycomb-team=<DEV API KEY>"
@@ -135,6 +135,9 @@ test:
   storage_video_bucket:
   storage_video_asset_path:
   storage_medias_asset_path: 'http://localhost:9000/check-test/medias'
+  otel_exporter_otlp_endpoint:
+  otel_exporter_otlp_headers:
+  airbrake_host:
 
 production:
   <<: *default

--- a/config/initializers/load_cookies.rb
+++ b/config/initializers/load_cookies.rb
@@ -1,1 +1,3 @@
+require 'cookie_loader'
+
 CookieLoader.load_from(PenderConfig.get('cookies_file_path') || 'config/cookies.txt')

--- a/config/initializers/open_telemetry.rb
+++ b/config/initializers/open_telemetry.rb
@@ -1,32 +1,9 @@
-require 'opentelemetry/sdk'
-require 'opentelemetry/exporter/otlp'
-require 'opentelemetry/instrumentation/all'
+require 'pender_open_telemetry_config'
 
-if PenderConfig.get('otel_exporter_otlp_endpoint') && PenderConfig.get('otel_exporter_otlp_headers')
-  # Set OpenTelemetry automatic instrumentation config in environment
-  # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md
-  ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = PenderConfig.get('otel_exporter_otlp_endpoint')
-  ENV['OTEL_EXPORTER_OTLP_HEADERS'] = PenderConfig.get('otel_exporter_otlp_headers')
-  ENV['OTEL_RESOURCE_ATTRIBUTES'] = (PenderConfig.get('otel_resource_attributes') || {}).map{ |k, v| "#{k}=#{v}"}.join(',')
-  
-  # Below can be uncommented to see traces logged locally rather than reported remotely
-  # ENV['OTEL_TRACES_EXPORTER'] = 'console'
-
-  OpenTelemetry::SDK.configure do |c|
-    c.service_name = PenderConfig.get('otel_service_name') || 'pender'
-  
-    c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
-    c.use 'OpenTelemetry::Instrumentation::Rack'
-    c.use 'OpenTelemetry::Instrumentation::ActionPack'
-    c.use 'OpenTelemetry::Instrumentation::ActiveJob'
-    c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
-    c.use 'OpenTelemetry::Instrumentation::ActionView'
-    c.use 'OpenTelemetry::Instrumentation::AwsSdk'
-    c.use 'OpenTelemetry::Instrumentation::HTTP'
-    c.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
-    c.use 'OpenTelemetry::Instrumentation::Net::HTTP'
-    c.use 'OpenTelemetry::Instrumentation::Rails'
-    c.use 'OpenTelemetry::Instrumentation::Redis'
-    c.use 'OpenTelemetry::Instrumentation::Sidekiq'
-  end
-end
+Pender::OpenTelemetryConfig.new(
+  PenderConfig.get('otel_exporter_otlp_endpoint'),
+  PenderConfig.get('otel_exporter_otlp_headers'),
+  ENV['PENDER_SKIP_HONEYCOMB']
+).configure!(
+  PenderConfig.get('otel_resource_attributes')
+)

--- a/lib/pender_open_telemetry_config.rb
+++ b/lib/pender_open_telemetry_config.rb
@@ -1,0 +1,61 @@
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+require 'opentelemetry/instrumentation/all'
+
+module Pender
+  class OpenTelemetryConfig
+    ENV_CONFIG = %w(OTEL_TRACES_EXPORTER OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_HEADERS OTEL_RESOURCE_ATTRIBUTES)
+
+    def initialize(endpoint, headers, is_disabled = nil)
+      @endpoint = endpoint
+      @headers = headers
+      @is_disabled = !!is_disabled
+    end
+
+    def configure!(resource_attributes)
+      if exporting_disabled?
+        ENV['OTEL_TRACES_EXPORTER'] = 'none'
+        Rails.logger.info(message: '[otel] Open Telemetry exporting is disabled. To change this, set both otel_exporter_otlp_endpoint and otel_exporter_otlp_headers in config')
+      else
+        ENV['OTEL_TRACES_EXPORTER'] = 'otlp'
+        ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = @endpoint
+        ENV['OTEL_EXPORTER_OTLP_HEADERS'] = @headers
+      end
+      ENV['OTEL_RESOURCE_ATTRIBUTES'] = format_attributes(resource_attributes)
+
+      # The line below can be uncommented to log traces to console rather than report them remotely
+      # It will override the exporter above. Intended to be used only for debugging
+      # ENV['OTEL_TRACES_EXPORTER'] = 'console'
+
+      ::OpenTelemetry::SDK.configure do |c|
+        c.service_name = PenderConfig.get('otel_service_name') || 'pender'
+
+        c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
+        c.use 'OpenTelemetry::Instrumentation::Rack'
+        c.use 'OpenTelemetry::Instrumentation::ActionPack'
+        c.use 'OpenTelemetry::Instrumentation::ActiveJob'
+        c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
+        c.use 'OpenTelemetry::Instrumentation::ActionView'
+        c.use 'OpenTelemetry::Instrumentation::AwsSdk'
+        c.use 'OpenTelemetry::Instrumentation::HTTP'
+        c.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
+        c.use 'OpenTelemetry::Instrumentation::Net::HTTP'
+        c.use 'OpenTelemetry::Instrumentation::Rails'
+        c.use 'OpenTelemetry::Instrumentation::Redis'
+        c.use 'OpenTelemetry::Instrumentation::Sidekiq'
+      end
+    end
+
+    private
+
+    def exporting_disabled?
+      @endpoint.blank? || @headers.blank? || @is_disabled
+    end
+
+    def format_attributes(hash)
+      return unless hash
+
+      hash.map{ |k, v| "#{k}=#{v}"}.join(',')
+    end
+  end
+end

--- a/test/lib/pender_open_telemetry_test.rb
+++ b/test/lib/pender_open_telemetry_test.rb
@@ -1,0 +1,66 @@
+require_relative '../test_helper'
+require_relative '../../lib/pender_open_telemetry_config'
+
+class OpenTelemetryConfigTest < ActiveSupport::TestCase
+  def setup
+    isolated_setup
+  end
+
+  def teardown
+    isolated_teardown
+  end
+
+  test "configures open telemetry to report remotely when exporting enabled" do
+    env_var_original_state = {}
+    Pender::OpenTelemetryConfig::ENV_CONFIG.map do|env_var|
+      return unless ENV[env_var]
+      env_var_original_state[env_var] = ENV.delete(env_var)
+    end
+
+    Pender::OpenTelemetryConfig.new('https://fake.com','foo=bar').configure!({'developer.name' => 'piglet'})
+
+    assert_equal 'otlp', ENV['OTEL_TRACES_EXPORTER']
+    assert_equal 'https://fake.com', ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+    assert_equal 'foo=bar', ENV['OTEL_EXPORTER_OTLP_HEADERS']
+    assert_equal 'developer.name=piglet', ENV['OTEL_RESOURCE_ATTRIBUTES']
+  ensure
+    env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
+  end
+
+  test "configures open telemetry to have nil exporter when exporting disabled, and leaves other exporter settings blank" do
+    env_var_original_state = {}
+    Pender::OpenTelemetryConfig::ENV_CONFIG.map do|env_var|
+      return unless ENV[env_var]
+      env_var_original_state[env_var] = ENV.delete(env_var)
+    end
+
+    Pender::OpenTelemetryConfig.new('','').configure!({'developer.name' => 'piglet'})
+
+    assert ENV['OTEL_TRACES_EXPORTER'].nil?
+    assert_empty ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+    assert_empty ENV['OTEL_EXPORTER_OTLP_HEADERS']
+    assert_equal 'developer.name=piglet', ENV['OTEL_RESOURCE_ATTRIBUTES']
+  ensure
+    env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
+  end
+
+  # exporting_disabled?
+  test "should disable exporting if any required config missing" do
+    assert Pender::OpenTelemetryConfig.new(nil, nil).send(:exporting_disabled?)
+    assert Pender::OpenTelemetryConfig.new('https://fake.com', '').send(:exporting_disabled?)
+
+    assert !Pender::OpenTelemetryConfig.new('https://fake.com', 'foo=bar').send(:exporting_disabled?)
+  end
+
+  test "should disable exporting if override set" do
+    assert Pender::OpenTelemetryConfig.new('https://fake.com', 'foo=bar', 'true').send(:exporting_disabled?)
+  end
+
+  # format_attributes
+  test "should format attributes from hash to string, if present" do
+    assert !Pender::OpenTelemetryConfig.new(nil,nil).send(:format_attributes, nil)
+
+    attr_string = Pender::OpenTelemetryConfig.new(nil,nil).send(:format_attributes, {'developer.name' => 'piglet', 'favorite.food' => 'ham'})
+    assert_equal "developer.name=piglet,favorite.food=ham", attr_string
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,4 +118,12 @@ class ActiveSupport::TestCase
       fixture_body
     end
   end
+
+  # Supplement Open Telemetry config to capture spans in test
+  # https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/.instrumentation_generator/templates/test/test_helper.rb
+  exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+  span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter)
+  OpenTelemetry::SDK.configure do |c|
+    c.add_span_processor span_processor
+  end
 end


### PR DESCRIPTION
Confirmed in test and development, including dev reporting externally to Honeycomb.

Caio and Dani, would love either of you to look at this if you have the time! Particularly interested in thoughts on how we set and override Open Telemetry config values, since it's kind of complex.

**Context:**
We recently enabled reporting to Honeycomb via Open Telemetry; however,
we were avoiding configuring OT with the instrumentation gems in dev and
test to reduce noise. Once deployed, we found that we were getting a
stack level too deep error when the Twitter gem made requests using the
underlying http gem, which wasn't happening in development or test
since it was caused by an interaction between the Open Telemetry and
Airbrake gems.

More on the specific problem here:
https://github.com/airbrake/airbrake/issues/1161

This was resolved by upgrading the Airbrake gem to 12.0, and then for
good measure I went ahead and upgraded it to 13.

This commit also aims to make sure we capture this sooner in the future
by making our dev and test environments more like deployed environments,
and configuring all of the instrumentation libraries we use. The only
difference now between test and other environments are:
* We use the InMemorySpanExporter, which allows us to rewind and test
spans if we want to - and doesn't output or report any information
* We, at least by default, don't provide an endpoint or headers,
which we only use to connect to remote services

Development also now configures the , but by default does not report
it anywhere. If we felt useful, we could change this to in-memory
exporter in the future. I assume if we need to debug, though, we will
either print to console (by uncommenting the line in the pender_open_telemetry.rb)
or send development information to Honeycomb by providing credentials.

**Also**
Does some small cleanup I had sitting on a branch:
* Manually import Pender exceptions into standalone metrics class (to avoid race import condition seen locally)
* Hardcode Honeycomb and Airbrake values to nil in test environment (so we don't accidentally get any values accidentally set by developers in development)