### PR TITLE
Make sure we detect the Instagram challenge page as an error

### DIFF
--- a/app/models/concerns/provider_instagram.rb
+++ b/app/models/concerns/provider_instagram.rb
@@ -13,7 +13,7 @@ module ProviderInstagram
           reason: :login_page
         },
         {
-          pattern: /^https:\/\/www\.instagram\.com\/challenge\?/,
+          pattern: /^https:\/\/www\.instagram\.com\/challenge\//,
           reason: :account_challenge_page
         },
         {
@@ -40,7 +40,7 @@ module ProviderInstagram
 
       location = response.header['location']
       if unavailable_reason = ignore_url?(location)
-        raise ApiAuthenticationError.new("Page unreachable, received redirect for #{unavailable_reason} to #{location}")
+        raise ApiAuthenticationError.new("Page unreachable, received redirect for #{unavailable_reason}")
       else
         get_instagram_api_data(location)
       end

--- a/app/models/parser/base.rb
+++ b/app/models/parser/base.rb
@@ -102,12 +102,15 @@ module Parser
     
     def get_metadata_from_tags(select_metatags)
       metadata = {}.with_indifferent_access
-      
       select_metatags.each do |key, value|
-        metatag = (parsed_data['raw']['metatags']).find { |tag| tag['property'] == value || tag['name'] == value }
-        metadata[key] = metatag['content'] if metatag
+        metadata[key] = get_metadata_from_tag(value)
       end
       metadata
+    end
+
+    def get_metadata_from_tag(value)
+      metatag = (parsed_data['raw']['metatags'] || []).find { |tag| tag['property'] == value || tag['name'] == value }
+      metatag['content'] if metatag
     end
 
     def set_raw_metatags(doc)

--- a/app/models/parser/base.rb
+++ b/app/models/parser/base.rb
@@ -103,7 +103,8 @@ module Parser
     def get_metadata_from_tags(select_metatags)
       metadata = {}.with_indifferent_access
       select_metatags.each do |key, value|
-        metadata[key] = get_metadata_from_tag(value)
+        metatag_value = get_metadata_from_tag(value)
+        metadata[key] = metatag_value unless metatag_value.blank?
       end
       metadata
     end

--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -19,25 +19,33 @@ module Parser
     # Main function for class
     def parse_data_for_parser(doc, _original_url, _jsonld)
       id = url.match(INSTAGRAM_ITEM_URL)[3]
-
       @parsed_data.merge!(external_id: id)
-      set_data_field('description', url)
 
       handle_exceptions(StandardError) do
         response_data = get_instagram_api_data("https://www.instagram.com/p/#{id}/?__a=1&__d=a")
         @parsed_data['raw'] = { 'api' => response_data.dig('items', 0) }
 
         username = get_instagram_username_from_data
-        # If we use set_data_field, it won't override the default value above
-        @parsed_data['description'] = get_instagram_item_text_from_data
+        set_data_field('description', get_instagram_item_text_from_data)
         set_data_field('username', username)
         set_data_field('title', get_instagram_item_text_from_data)
         set_data_field('picture', get_instagram_item_picture_from_data)
         set_data_field('author_name', parsed_data.dig('raw', 'api', 'user', 'full_name'))
-        set_data_field('author_url', username.gsub(/^@/, 'https://instagram.com/'))
+        set_data_field('author_url', username&.gsub(/^@/, 'https://instagram.com/'))
         set_data_field('author_picture', parsed_data.dig('raw', 'api', 'user', 'profile_pic_url'))
-        set_data_field('published_at', Time.at(parsed_data.dig('raw', 'api', 'taken_at')))
+        set_data_field('published_at', Time.at(parsed_data.dig('raw', 'api', 'taken_at'))) unless parsed_data.dig('raw', 'api', 'taken_at').blank?
       end
+
+      # Fallbacks from metatags, in case we cannot parse above
+      username = get_instagram_username_from_twitter_title
+      title = get_instagram_title_from_og_title
+      set_data_field('title', title)
+      set_data_field('description', title, url)
+      set_data_field('picture', get_metadata_from_tag('og:image'))
+      set_data_field('username', username)
+      set_data_field('author_name', get_instagram_author_name_from_twitter_title)
+      set_data_field('author_url', username&.gsub(/^@/, 'https://instagram.com/'))
+
       parsed_data
     end
 
@@ -53,6 +61,30 @@ module Parser
     def get_instagram_item_picture_from_data
       parsed_data.dig('raw', 'api', 'image_versions2', 'candidates', 0, 'url') ||
         parsed_data.dig('raw', 'api', 'carousel_media', 0, 'image_versions2', 'candidates', 0, 'url')
+    end
+
+    def get_instagram_title_from_og_title
+      raw_title = get_metadata_from_tag('og:title')
+      matches = raw_title&.match(/on Instagram:(|\s)"(?<title>.+)"/)
+      return if matches.blank?
+
+      matches['title']
+    end
+
+    def get_instagram_username_from_twitter_title
+      raw_username = get_metadata_from_tag('twitter:title')
+      matches = raw_username&.match(/(?<author_name>.*) \(@(?<username>.+)\)/)
+      return if matches.blank?
+
+      matches['username'].prepend('@')
+    end
+
+    def get_instagram_author_name_from_twitter_title
+      raw_username = get_metadata_from_tag('twitter:title')
+      matches = raw_username&.match(/(?<author_name>.*) \(@(?<username>.+)\)/)
+      return if matches.blank?
+
+      matches['author_name']
     end
   end
 end

--- a/app/models/parser/tiktok_profile.rb
+++ b/app/models/parser/tiktok_profile.rb
@@ -22,17 +22,12 @@ module Parser
       base_url = match[0] # Should this be set as canonical_url?
       username = match['username']
 
-      set_data_field('external_id', username)
-      set_data_field('username', username)
-      set_data_field('title', username)
-      set_data_field('author_name', username)
-      set_data_field('description', base_url)
-
       handle_exceptions(StandardError) do
         doc = reparse_if_default_tiktok_page(doc, base_url) || doc
-        select_metatags = { picture: 'og:image', title: 'twitter:creator', description: 'description' }
-        @parsed_data.merge!(get_metadata_from_tags(select_metatags))
-        set_data_field('author_name', parsed_data['title'], username)
+        set_data_field('title', get_metadata_from_tag('twitter:creator'))
+        set_data_field('picture', get_metadata_from_tag('og:image'))
+        set_data_field('description', get_metadata_from_tag('description'))
+        set_data_field('author_name', parsed_data['title'])
         @parsed_data.merge!({
           author_name: parsed_data['title'],
           author_picture: parsed_data['picture'],
@@ -40,6 +35,14 @@ module Parser
           url: base_url
         })
       end
+
+      # Set defaults if above fails
+      set_data_field('external_id', username)
+      set_data_field('username', username)
+      set_data_field('title', username)
+      set_data_field('author_name', username)
+      set_data_field('description', base_url)
+
       parsed_data
     end
 

--- a/test/models/parser/instagram_profile_test.rb
+++ b/test/models/parser/instagram_profile_test.rb
@@ -87,7 +87,7 @@ class InstagramProfileUnitTest < ActiveSupport::TestCase
   end
 
   test "should re-raise a wrapped error when redirected to a page that requires authentication" do
-    WebMock.stub_request(:any, INSTAGRAM_PROFILE_API_REGEX).to_return(body: '', status: 302, headers: { location: 'https://www.instagram.com/challenge?' })
+    WebMock.stub_request(:any, INSTAGRAM_PROFILE_API_REGEX).to_return(body: '', status: 302, headers: { location: 'https://www.instagram.com/challenge/?' })
 
     data = {}
     airbrake_call_count = 0

--- a/test/models/parser/tiktok_profile_test.rb
+++ b/test/models/parser/tiktok_profile_test.rb
@@ -52,6 +52,7 @@ class TiktokProfileUnitTest < ActiveSupport::TestCase
     # Data doesn't seem to actually be assigned to twitter:creator, where we look
     # for it for title and author_name, but is included with the json+ld, which is 
     # set outside of this object before parsing
+    # For now, though, we use the URL
     assert_not_nil data['title']
     assert_not_nil data['author_name']
   end


### PR DESCRIPTION
The URL was slightly incorrect before, and we want to be able to set an alert on any error that would require us rotating the cookies.