### PR TITLE
Use same Otel instrumentaiton in test as in other envs

### DIFF
--- a/config/initializers/open_telemetry.rb
+++ b/config/initializers/open_telemetry.rb
@@ -1,9 +1,14 @@
 require 'pender_open_telemetry_config'
+require 'pender_open_telemetry_test_config'
 
-Pender::OpenTelemetryConfig.new(
-  PenderConfig.get('otel_exporter_otlp_endpoint'),
-  PenderConfig.get('otel_exporter_otlp_headers'),
-  ENV['PENDER_SKIP_HONEYCOMB']
-).configure!(
-  PenderConfig.get('otel_resource_attributes')
-)
+unless Rails.env.test?
+  Pender::OpenTelemetryConfig.new(
+    PenderConfig.get('otel_exporter_otlp_endpoint'),
+    PenderConfig.get('otel_exporter_otlp_headers'),
+    ENV['PENDER_SKIP_HONEYCOMB']
+  ).configure!(
+    PenderConfig.get('otel_resource_attributes')
+  )
+else
+  Pender::OpenTelemetryTestConfig.configure!
+end

--- a/lib/pender_open_telemetry_test_config.rb
+++ b/lib/pender_open_telemetry_test_config.rb
@@ -1,0 +1,42 @@
+module Pender
+  class OpenTelemetryTestConfig
+    class << self
+      def configure!
+        raise StandardError.new("[otel] Test config being used in non-test environment") unless Rails.env.test?
+
+        # Supplement Open Telemetry config in initializer to capture spans in test
+        # https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/.instrumentation_generator/templates/test/test_helper.rb
+      
+        # By default this discards spans. To enable recording for test purposes, 
+        # set the following in the test setup block:
+        # 
+        # Pender::OpenTelemetryTestConfig.current_exporter.recording = true
+        @exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new(recording: false)
+        OpenTelemetry::SDK.configure do |c|
+          c.add_span_processor(OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(@exporter))
+      
+          # Keep this list in sync with Pender::OpenTelemetryConfig, to make sure we track
+          # any potential issues coming from instrumentation libraries
+          c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
+          c.use 'OpenTelemetry::Instrumentation::Rack'
+          c.use 'OpenTelemetry::Instrumentation::ActionPack'
+          c.use 'OpenTelemetry::Instrumentation::ActiveJob'
+          c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
+          c.use 'OpenTelemetry::Instrumentation::ActionView'
+          c.use 'OpenTelemetry::Instrumentation::AwsSdk'
+          c.use 'OpenTelemetry::Instrumentation::HTTP'
+          c.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
+          c.use 'OpenTelemetry::Instrumentation::Net::HTTP'
+          c.use 'OpenTelemetry::Instrumentation::Rails'
+          c.use 'OpenTelemetry::Instrumentation::Redis'
+          c.use 'OpenTelemetry::Instrumentation::Sidekiq'
+        end
+        @exporter
+      end
+
+      def current_exporter
+        @exporter || configure!
+      end
+    end
+  end
+end

--- a/test/lib/pender_open_telemetry_test.rb
+++ b/test/lib/pender_open_telemetry_test.rb
@@ -1,6 +1,7 @@
 require_relative '../test_helper'
 require_relative '../../lib/pender_open_telemetry_config'
 
+# Testing the real config
 class OpenTelemetryConfigTest < ActiveSupport::TestCase
   def setup
     isolated_setup

--- a/test/lib/pender_open_telemetry_test_config_test.rb
+++ b/test/lib/pender_open_telemetry_test_config_test.rb
@@ -1,0 +1,32 @@
+require_relative '../test_helper'
+require_relative '../../lib/pender_open_telemetry_config'
+
+# Verifying we can use our test-specific open telemetry config --
+# not to be confused with OpenTelemetryConfigTest, which
+# tests our actual configuration used in non-test environments
+class OpenTelemetryTestConfigTest < ActiveSupport::TestCase
+  def setup
+    isolated_setup
+  end
+
+  def teardown
+    isolated_teardown
+  end
+
+  # This is both a test to make sure our test helpers work,
+  # and also an example of how they might be used
+  test 'can be used to record reported spans' do
+    exporter = Pender::OpenTelemetryTestConfig.current_exporter
+    exporter.recording = false
+    exporter.export(['fake thing'])
+
+    assert exporter.finished_spans.blank?
+    
+    exporter.recording = true
+    exporter.export(['another fake thing'])
+    
+    assert exporter.finished_spans.length > 0
+  ensure
+    exporter.recording = false
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -118,12 +118,4 @@ class ActiveSupport::TestCase
       fixture_body
     end
   end
-
-  # Supplement Open Telemetry config to capture spans in test
-  # https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/.instrumentation_generator/templates/test/test_helper.rb
-  exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
-  span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(exporter)
-  OpenTelemetry::SDK.configure do |c|
-    c.add_span_processor span_processor
-  end
 end


### PR DESCRIPTION
Previously we were just adding a span_processor, which the documentation suggests. However, we want to use tests to help identify any bugs resulting from the enabled instrumentation, and running OpenTelemetry.configure overwrites the existing configuration at app start, meaning that no instrumentation was enabled when tests were running. This means that if bugs were introduced, we still wouldn't see them in a test environment.

Instead, this enables all instrumentation we currently use in dev/deployed environments, and creates a helper to let us selectively turn on recording for use in test environments. By default recording is disabled, which means that no spans will persist in memory.