### PR TITLE
Don't overwrite raw metatags with raw API data in IG item parser

### DIFF
--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -23,7 +23,7 @@ module Parser
 
       handle_exceptions(StandardError) do
         response_data = get_instagram_api_data("https://www.instagram.com/p/#{id}/?__a=1&__d=a")
-        @parsed_data['raw'] = { 'api' => response_data.dig('items', 0) }
+        @parsed_data['raw']['api'] = response_data.dig('items', 0)
 
         username = get_instagram_username_from_data
         set_data_field('description', get_instagram_item_text_from_data)

--- a/test/models/parser/instagram_item_test.rb
+++ b/test/models/parser/instagram_item_test.rb
@@ -150,4 +150,12 @@ class InstagramItemUnitTest < ActiveSupport::TestCase
     assert_match /scontent-sjc3-1.cdninstagram.com\/v\/t51.2885-19\/275782436_803363541058120_8527469417809134606_n.jpg/, data['author_picture']
     assert_equal Time.new(2022,8,23,16,51,41), data['published_at']
   end  
+
+  test "should preserve all raw data, without overwriting" do
+    WebMock.stub_request(:any, INSTAGRAM_ITEM_API_REGEX).to_return(body: graphql, status: 200)
+    
+    data = Parser::InstagramItem.new('https://www.instagram.com/p/fake-post').parse_data(doc)
+    assert data['raw']['metatags'].present?
+    assert data['raw']['api'].present?
+  end
 end


### PR DESCRIPTION
We were accidentally overwriting everything in the raw key when setting the api data, which was causing problems when we tried setting fallback values from the metatag data.

Also did a visual pass to make sure that we weren't doing this anywhere else obvious in other parsers.