### PR TITLE
Add support for newlines in Instagram fallback title & desc

### DIFF
--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -65,7 +65,7 @@ module Parser
 
     def get_instagram_title_from_og_title
       raw_title = get_metadata_from_tag('og:title')
-      matches = raw_title&.match(/on Instagram:(|\s)"(?<title>.+)"/)
+      matches = raw_title&.match(/on Instagram:(|\s)"(?<title>.+)"/m)
       return if matches.blank?
 
       matches['title']


### PR DESCRIPTION
Previously newlines were breaking our regex for detecting Instagram text. Adding the m modifier to the regex still matches if they are present.