### PR TITLE
Normalize all media URLs

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -63,7 +63,8 @@ class Media
     self.original_url = self.url.strip
     self.data = {}.with_indifferent_access
     self.follow_redirections
-    self.url = RequestHelper.normalize_url(self.url) unless self.get_canonical_url
+    self.get_canonical_url
+    self.url = RequestHelper.normalize_url(self.url)
     self.try_https
     self.parser = nil
   end
@@ -177,7 +178,7 @@ class Media
         self.parser = parseable
         self.provider, self.type = self.parser.type.split('_')
         self.data.deep_merge!(self.parser.parse_data(self.doc, self.original_url, self.data.dig('raw', 'json+ld')))
-        self.url = self.parser.url
+        self.url = RequestHelper.normalize_url(self.parser.url)
         self.get_oembed_data
         parsed = true
       end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -41,6 +41,18 @@ class MediaTest < ActiveSupport::TestCase
     end
   end
 
+  test "should normalize the canonical URL consistently, regardless of how determined" do
+    canonical_url = 'http://example.com/canonical/'
+
+    WebMock.enable!
+    WebMock.stub_request(:any, /example.com\/requested/).to_return(body: '<meta property="og:url" content="' + canonical_url + '">', status: 200)
+    WebMock.stub_request(:any, /example.com\/canonical/).to_return(body: '', status: 200)
+
+    m1 = create_media url: 'http://example.com/requested/'
+    m2 = create_media url: canonical_url
+    assert_equal m1.url, m2.url
+  end
+
   test "should follow redirection of relative paths" do
     WebMock.enable!
     WebMock.stub_request(:any, /https?:\/\/www.almasryalyoum.com\/node\/517699/).to_return(body: '', headers: { location: '/editor/details/968' }, status: 302)

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -106,8 +106,8 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     url = 'https://www.facebook.com/groups/memetics.hacking/permalink/1580570905320222/'
     m = Media.new url: url
     data = m.as_json
-    assert_match "memetics.hacking", data['title']
-    assert_match 'permalink/1580570905320222/', data['url']
+    assert_match /(memetics.hacking|exploring belief systems)/, data['title']
+    assert_match 'permalink/1580570905320222', data['url']
     assert_equal 'facebook', data['provider']
     assert_equal 'item', data['type']
   end


### PR DESCRIPTION
Previously we were only running canonical URLs through normalization if they were not found in the HTML. This lead to an edge case where we were returning different URLs for effectively the same item - one if it was parsed in the HMTL (eg with a trailing slash) and a different one if it used the passed URL (which was then run through Postrank::URI.normalize, which stripped trailing /, among other things).

This is a pretty big change since it will mean that many duplicates may be created in Check API (since it asks Pender for a canonical URL when looking up existing Links, and that will change).