### PR TITLE
Revert to previous URL normalization patterns

### DIFF
--- a/app/helpers/medias_helper.rb
+++ b/app/helpers/medias_helper.rb
@@ -162,22 +162,8 @@ module MediasHelper
     end
   end
 
-  # This will be replaced once parsers migrated, but 
-  # we need different behavior here for now
   def ignore_url?(url)
     ignore_url = false
-    # Media ignored URLs
-    Media::TYPES.keys.map { |type| type[/(.+)_(item|profile)$/, 1] }.uniq.each do |provider|
-      if self.respond_to?("ignore_#{provider}_urls")
-        self.send("ignore_#{provider}_urls").each do |item|
-          if url.match?(item[:pattern])
-            ignore_url = true
-            self.unavailable_page = item[:reason]
-          end
-        end
-      end
-    end
-    # Parser ignored URLs
     Media::PARSERS.flat_map(&:ignored_urls).uniq.each do |item|
       if url.match?(item[:pattern])
         ignore_url = true

--- a/app/models/concerns/provider_instagram.rb
+++ b/app/models/concerns/provider_instagram.rb
@@ -35,7 +35,7 @@ module ProviderInstagram
 
       request = Net::HTTP::Get.new(uri.request_uri, headers)
       response = http.request(request)
-      raise ApiResponseCodeError.new("#{response.class}: #{response.message}") unless %(200 301 302).include?(response.code)
+      raise ApiResponseCodeError.new("#{response.class}: #{response.message}") unless (RequestHelper::REDIRECT_HTTP_CODES + ['200']).include?(response.code)
       return JSON.parse(response.body) if response.code == '200'
 
       location = response.header['location']

--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -1,4 +1,6 @@
 class RequestHelper
+  REDIRECT_HTTP_CODES = %w(301 302 307 308).freeze
+
   class << self
     LANG = 'en-US;q=0.6,en;q=0.4'
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -218,7 +218,7 @@ class Media
     while attempts < 5 && RequestHelper::REDIRECT_HTTP_CODES.include?(code) && !path.include?(self.url)
       attempts += 1
       path << self.url
-      response = self.request_media_url
+      response = self.request_media_url(self.url)
       code = response.code
 
       if RequestHelper::REDIRECT_HTTP_CODES.include?(code)
@@ -241,10 +241,10 @@ class Media
     redirect_url
   end
 
-  def request_media_url
+  def request_media_url(request_url)
     response = nil
     Retryable.retryable(tries: 3, sleep: 1, :not => [Net::ReadTimeout]) do
-      response = RequestHelper.request_url(url, 'Get')
+      response = RequestHelper.request_url(request_url, 'Get')
     end
     response
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -63,8 +63,7 @@ class Media
     self.original_url = self.url.strip
     self.data = {}.with_indifferent_access
     self.follow_redirections
-    self.get_canonical_url
-    self.url = RequestHelper.normalize_url(self.url)
+    self.url = RequestHelper.normalize_url(self.url) unless self.get_canonical_url
     self.try_https
     self.parser = nil
   end
@@ -178,7 +177,7 @@ class Media
         self.parser = parseable
         self.provider, self.type = self.parser.type.split('_')
         self.data.deep_merge!(self.parser.parse_data(self.doc, self.original_url, self.data.dig('raw', 'json+ld')))
-        self.url = RequestHelper.normalize_url(self.parser.url)
+        self.url = self.parser.url
         self.get_oembed_data
         parsed = true
       end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -215,24 +215,30 @@ class Media
     code = '301'
     path = []
 
-    while attempts < 5 && %w(301 302).include?(code) && !path.include?(self.url)
+    while attempts < 5 && RequestHelper::REDIRECT_HTTP_CODES.include?(code) && !path.include?(self.url)
       attempts += 1
       path << self.url
       response = self.request_media_url
       code = response.code
-      self.set_url_from_location(response, path)
+
+      if RequestHelper::REDIRECT_HTTP_CODES.include?(code)
+        redirect_url = self.url_from_location(response, path)
+        self.url = redirect_url if redirect_url
+      end
     end
   end
 
-  def set_url_from_location(response, path)
-    if %w(301 302).include?(response.code)
-      self.url = response.header['location'] unless self.ignore_url?(response.header['location'])
-      if self.url !~ /^https?:/
-        self.url.prepend('/') unless self.url.match?(/^\//)
-        previous = path.last.match(/^https?:\/\/[^\/]+/)[0]
-        self.url = previous + self.url
-      end
+  def url_from_location(response, path)
+    return unless response.header['location']
+    return if self.ignore_url?(response.header['location'])
+
+    redirect_url = response.header['location']
+    if redirect_url && redirect_url !~ /^https?:/
+      redirect_url.prepend('/') unless redirect_url.match?(/^\//)
+      previous = path.last.match(/^https?:\/\/[^\/]+/)[0]
+      redirect_url = previous + redirect_url
     end
+    redirect_url
   end
 
   def request_media_url

--- a/app/models/oembed_item.rb
+++ b/app/models/oembed_item.rb
@@ -25,7 +25,7 @@ class OembedItem
 
   attr_reader :data, :request_url
 
-  def get_oembed_data_from_url(uri)
+  def get_oembed_data_from_url(uri, attempts: 0)
     response = nil
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == 'https'
@@ -34,8 +34,8 @@ class OembedItem
     request = Net::HTTP::Get.new(uri.request_uri, headers)
     response = http.request(request)
 
-    if RequestHelper::REDIRECT_HTTP_CODES.include?(response.code)
-      response = get_oembed_data_from_url(construct_absolute_path(request_url, response.header['location']))
+    if attempts < 5 && RequestHelper::REDIRECT_HTTP_CODES.include?(response.code)
+      response = get_oembed_data_from_url(construct_absolute_path(request_url, response.header['location']), attempts: attempts + 1)
     end
     response
   end

--- a/app/models/oembed_item.rb
+++ b/app/models/oembed_item.rb
@@ -34,7 +34,7 @@ class OembedItem
     request = Net::HTTP::Get.new(uri.request_uri, headers)
     response = http.request(request)
 
-    if %w(301 302).include?(response.code)
+    if RequestHelper::REDIRECT_HTTP_CODES.include?(response.code)
       response = get_oembed_data_from_url(construct_absolute_path(request_url, response.header['location']))
     end
     response

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -41,18 +41,6 @@ class MediaTest < ActiveSupport::TestCase
     end
   end
 
-  test "should normalize the canonical URL consistently, regardless of how determined" do
-    canonical_url = 'http://example.com/canonical/'
-
-    WebMock.enable!
-    WebMock.stub_request(:any, /example.com\/requested/).to_return(body: '<meta property="og:url" content="' + canonical_url + '">', status: 200)
-    WebMock.stub_request(:any, /example.com\/canonical/).to_return(body: '', status: 200)
-
-    m1 = create_media url: 'http://example.com/requested/'
-    m2 = create_media url: canonical_url
-    assert_equal m1.url, m2.url
-  end
-
   test "should follow redirection of relative paths" do
     WebMock.enable!
     WebMock.stub_request(:any, /https?:\/\/www.almasryalyoum.com\/node\/517699/).to_return(body: '', headers: { location: '/editor/details/968' }, status: 302)

--- a/test/models/oembed_item_test.rb
+++ b/test/models/oembed_item_test.rb
@@ -100,4 +100,11 @@ class OembedItemUnitTest < ActiveSupport::TestCase
     assert_nil item.oembed_uri
     assert item.get_data[:raw][:oembed].blank?
   end
+
+  test "should not explode if infinite redirect" do
+    WebMock.stub_request(:get, /example.com/).and_return(status: 308, body: '', headers: { location: 'http://example.com/original'} )
+
+    item = OembedItem.new('http://example.com/original', 'http://example.com/oembed')
+    assert !item.get_data.blank?
+  end
 end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -106,8 +106,8 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     url = 'https://www.facebook.com/groups/memetics.hacking/permalink/1580570905320222/'
     m = Media.new url: url
     data = m.as_json
-    assert_match /(memetics.hacking|exploring belief systems)/, data['title']
-    assert_match 'permalink/1580570905320222', data['url']
+    assert_match "memetics.hacking", data['title']
+    assert_match 'permalink/1580570905320222/', data['url']
     assert_equal 'facebook', data['provider']
     assert_equal 'item', data['type']
   end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -106,8 +106,8 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     url = 'https://www.facebook.com/groups/memetics.hacking/permalink/1580570905320222/'
     m = Media.new url: url
     data = m.as_json
-    assert_match "memetics.hacking", data['title']
-    assert_match 'permalink/1580570905320222/', data['url']
+    assert_match /(memetics.hacking|exploring belief systems)/, data['title']
+    assert_match /permalink\/1580570905320222/, data['url']
     assert_equal 'facebook', data['provider']
     assert_equal 'item', data['type']
   end

--- a/test/models/parser/youtube_item_test.rb
+++ b/test/models/parser/youtube_item_test.rb
@@ -29,8 +29,8 @@ class YoutubeItemIntegrationTest < ActiveSupport::TestCase
     response = ''
     response.stubs(:code).returns('302')
     response.stubs(:header).returns({ 'location' => consent_page })
-    Media.any_instance.stubs(:request_media_url).returns(response)
     url = 'https://www.youtube.com/watch?v=bEAdvXRJ9mU'
+    Media.any_instance.stubs(:request_media_url).with(url).returns(response)
     m = create_media url: url
     data = m.as_json
     assert_equal 'item', data['type']
@@ -40,7 +40,6 @@ class YoutubeItemIntegrationTest < ActiveSupport::TestCase
     assert_equal 'https://www.youtube.com/channel/UCKyn6nCR9fXFhDL-WeeyOzQ', data['author_url']
     assert !data['html'].blank?
     assert_equal 'https://www.youtube.com/watch?v=bEAdvXRJ9mU', m.url
-    Media.any_instance.unstub(:request_media_url)
   end
 end
 


### PR DESCRIPTION
Returns to how we were normalizing URLs before, since it is both deterministic
and gets us the most successful results. This also adds in a few refactors that
were done during the bug exploration: 1) expanding the redirect codes we look
for to include ones we see less frequently (308 for The Atlantic, for example),
and 2) trying to reduce dependencies and alteration of internal state where
possible, instead preferring explicit passing and return of dependencies for
internal helper functions.