### PR TITLE
Add ability to sample traces in Open Telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,23 +430,30 @@ We can also run performance tests. It calculates the amount of time taken to val
 
 ## Observability
 
-We use Honeycomb for monitoring information about our application. It is currently configured to report to suppress Honeycomb
-reporting when the open telemetry required config is unset, which we would expect in development and test environments; however it is
-possible to report data from your local environment to either console or remotely to Honeycomb for troubleshooting purposes.
+We use Honeycomb for monitoring information about our application. It is currently configured to suppress Honeycomb reporting when the Open Telemetry required config is unset, which we would expect in development; however it is possible to report data from your local environment to either console or remotely to Honeycomb for troubleshooting purposes.
 
 If you would like to see data reported from your local machine, do the following:
 
 **Local console**
-1. Make sure that the `otlp` prefixed values are set in `config.yml` following `config.yml.example`. The values provided in `config.yml.example` can be used since we don't need a real API key.
+1. Make sure that the `otlp_exporter` prefixed values are set in `config.yml` following `config.yml.example`. The values provided in `config.yml.example` can be used since we don't need a real API key.
 1. In `lib/pender_open_telemetry_config.rb`, uncomment the line setting exporter to 'console'. Warning: this is noisy!
 1. Restart the server
 1. View output in local server logs
 
 **On Honeycomb**
-1. Make sure that the `otlp` prefixed values are set in `config.yml` following `config.yml.example`
+1. Make sure that the `otlp_exporter` prefixed values are set in `config.yml` following `config.yml.example`
 1. In the config key `otel_exporter_otlp_headers`, set `x-honeycomb-team` to a Honeycomb API key for the Development environment (a sandbox where we put anything). This can be found in the [Honeycomb web interface](https://ui.honeycomb.io/meedan/environments/dev/api_keys). To track your own reported info, be sure to set the `otel_resource_attributes.developer.name` key in `config.yml` to your own name or unique identifier (e.g. `christa`). You will need this to filter information on Honeycomb.
 1. Restart the server
 1. See reported information in Development environment on Honeycomb
+
+### Configuring sampling
+
+To enable sampling for Honeycomb, set the following configuration (either in `config.yml` locally, or via environment for deployments):
+
+* `otel_traces_sampler` to a supported sampler. See the Open Telemetry documentaiton for supported values.
+* `otel_custom_sampling_rate` to an integer value. This will be used to calculate and set OTEL_TRACES_SAMPLER_ARG (1 / `<sample_rate>`) and to append sampler-related value to `OTEL_RESOURCE_ATTRIBUTES` (as `SampleRate=<sample_rate>`).
+
+**Note**: If sampling behavior is changed in Pender, we will also need to update the behavior to match in any other application reporting to Honeycomb. More [here](https://docs.honeycomb.io/getting-data-in/opentelemetry/ruby/#sampling)
 
 ## Credits
 

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -121,6 +121,8 @@ development: &default
   # See initializers/open_telemetry.rb for usage.
   #
   # OPTIONAL (set to report to Honeycomb Dev environment from local)
+  # Note: any values prefixed with `otel_custom` are our own configuration,
+  # which will be used to programmatically set otel-supported env vars
   #
   otel_exporter_otlp_endpoint: # "https://api.honeycomb.io"
   otel_exporter_otlp_headers: # "x-honeycomb-team=<DEV API KEY>"
@@ -128,6 +130,8 @@ development: &default
   otel_resource_attributes:
     # developer.name: <DEVELOPER_NAME>
   otel_log_level: info
+  otel_traces_sampler:
+  otel_custom_sampling_rate:
 
 test:
   <<: *default
@@ -136,9 +140,8 @@ test:
   storage_video_bucket:
   storage_video_asset_path:
   storage_medias_asset_path: 'http://localhost:9000/check-test/medias'
-  otel_exporter_otlp_endpoint:
-  otel_exporter_otlp_headers:
   otel_log_level: error
+  otel_traces_sampler:
   airbrake_host:
 
 production:

--- a/config/initializers/zz_open_telemetry.rb
+++ b/config/initializers/zz_open_telemetry.rb
@@ -11,7 +11,11 @@ unless Rails.env.test?
     PenderConfig.get('otel_exporter_otlp_headers'),
     ENV['PENDER_SKIP_HONEYCOMB']
   ).configure!(
-    PenderConfig.get('otel_resource_attributes')
+    PenderConfig.get('otel_resource_attributes'),
+    sampling_config: {
+      sampler: PenderConfig.get('otel_traces_sampler'),
+      rate: PenderConfig.get('otel_custom_sampling_rate')
+    }
   )
 else
   Pender::OpenTelemetryTestConfig.configure!

--- a/lib/pender_open_telemetry_config.rb
+++ b/lib/pender_open_telemetry_config.rb
@@ -4,7 +4,25 @@ require 'opentelemetry/instrumentation/all'
 
 module Pender
   class OpenTelemetryConfig
-    ENV_CONFIG = %w(OTEL_TRACES_EXPORTER OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_HEADERS OTEL_RESOURCE_ATTRIBUTES)
+    class << self
+      # For configuring instrumentation the same across environments,
+      # including Pender::OpenTelemetryTestConfig
+      def configure_instrumentation!(config)
+        config.use 'OpenTelemetry::Instrumentation::ActiveSupport'
+        config.use 'OpenTelemetry::Instrumentation::Rack'
+        config.use 'OpenTelemetry::Instrumentation::ActionPack'
+        config.use 'OpenTelemetry::Instrumentation::ActiveJob'
+        config.use 'OpenTelemetry::Instrumentation::ActiveRecord'
+        config.use 'OpenTelemetry::Instrumentation::ActionView'
+        config.use 'OpenTelemetry::Instrumentation::AwsSdk'
+        config.use 'OpenTelemetry::Instrumentation::HTTP'
+        config.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
+        config.use 'OpenTelemetry::Instrumentation::Net::HTTP'
+        config.use 'OpenTelemetry::Instrumentation::Rails'
+        config.use 'OpenTelemetry::Instrumentation::Redis'
+        config.use 'OpenTelemetry::Instrumentation::Sidekiq'
+      end
+    end
 
     def initialize(endpoint, headers, is_disabled = nil)
       @endpoint = endpoint
@@ -12,41 +30,55 @@ module Pender
       @is_disabled = !!is_disabled
     end
 
-    def configure!(resource_attributes)
-      if exporting_disabled?
-        ENV['OTEL_TRACES_EXPORTER'] = 'none'
-        Rails.logger.info(message: '[otel] Open Telemetry exporting is disabled. To change this, set both otel_exporter_otlp_endpoint and otel_exporter_otlp_headers in config')
-      else
-        ENV['OTEL_TRACES_EXPORTER'] = 'otlp'
-        ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = @endpoint
-        ENV['OTEL_EXPORTER_OTLP_HEADERS'] = @headers
-      end
-      ENV['OTEL_RESOURCE_ATTRIBUTES'] = format_attributes(resource_attributes)
+    def configure!(resource_attributes, sampling_config: nil)
+      configure_exporting!
+      sampling_attributes = configure_sampling!(sampling_config)
 
-      # The line below can be uncommented to log traces to console rather than report them remotely
-      # It will override the exporter above. Intended to be used only for debugging
-      # ENV['OTEL_TRACES_EXPORTER'] = 'console'
+      ENV['OTEL_RESOURCE_ATTRIBUTES'] = format_attributes(resource_attributes.merge(sampling_attributes))
 
       ::OpenTelemetry::SDK.configure do |c|
         c.service_name = PenderConfig.get('otel_service_name') || 'pender'
 
-        c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
-        c.use 'OpenTelemetry::Instrumentation::Rack'
-        c.use 'OpenTelemetry::Instrumentation::ActionPack'
-        c.use 'OpenTelemetry::Instrumentation::ActiveJob'
-        c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
-        c.use 'OpenTelemetry::Instrumentation::ActionView'
-        c.use 'OpenTelemetry::Instrumentation::AwsSdk'
-        c.use 'OpenTelemetry::Instrumentation::HTTP'
-        c.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
-        c.use 'OpenTelemetry::Instrumentation::Net::HTTP'
-        c.use 'OpenTelemetry::Instrumentation::Rails'
-        c.use 'OpenTelemetry::Instrumentation::Redis'
-        c.use 'OpenTelemetry::Instrumentation::Sidekiq'
+        self.class.configure_instrumentation!(c)
       end
     end
 
     private
+    
+    def configure_exporting!
+      if exporting_disabled?
+        ENV['OTEL_TRACES_EXPORTER'] = 'none'
+        Rails.logger.info('[otel] Open Telemetry exporting is disabled. To change this, check app configuration')
+      else
+        ENV['OTEL_TRACES_EXPORTER'] = 'otlp'
+        ENV['OTEL_EXPORTER_OTLP_ENDPOINT'] = @endpoint
+        ENV['OTEL_EXPORTER_OTLP_HEADERS'] = @headers
+        Rails.logger.info("[otel] Open Telemetry configured to export to #{@endpoint}")
+      end
+
+      # The line below can be uncommented to log traces to console rather than report them remotely
+      # It will override the exporter above. Intended to be used only for debugging
+      # ENV['OTEL_TRACES_EXPORTER'] = 'console'
+    end
+
+    def configure_sampling!(sampling_config)
+      additional_attributes = {}
+      if sampling_config && sampling_config[:sampler]
+        ENV['OTEL_TRACES_SAMPLER'] = sampling_config[:sampler]
+        
+        begin
+          rate_as_ratio = (1 / Float(sampling_config[:rate])).to_s
+          additional_attributes.merge!('SampleRate' => sampling_config[:rate])
+          ENV['OTEL_TRACES_SAMPLER_ARG'] = rate_as_ratio
+          Rails.logger.info("[otel] Sampling traces with SampleRate #{sampling_config[:rate]} | #{rate_as_ratio}")
+        rescue ArgumentError, ZeroDivisionError => e
+          Rails.logger.warn("[otel] Attempt to set sampling rate for #{sampling_config[:rate]} failed with #{e}; using defaults")
+        end
+      else
+        Rails.logger.info('[otel] Open Telemetry sampling not configured; using defaults')
+      end
+      additional_attributes
+    end
 
     def exporting_disabled?
       @endpoint.blank? || @headers.blank? || @is_disabled

--- a/lib/pender_open_telemetry_test_config.rb
+++ b/lib/pender_open_telemetry_test_config.rb
@@ -9,27 +9,16 @@ module Pender
       
         # By default this discards spans. To enable recording for test purposes, 
         # set the following in the test setup block:
-        # 
-        # Pender::OpenTelemetryTestConfig.current_exporter.recording = true
+        #     Pender::OpenTelemetryTestConfig.current_exporter.recording = true
         @exporter = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new(recording: false)
         OpenTelemetry::SDK.configure do |c|
+          c.service_name = 'test-pender'
           c.add_span_processor(OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(@exporter))
-      
-          # Keep this list in sync with Pender::OpenTelemetryConfig, to make sure we track
-          # any potential issues coming from instrumentation libraries
-          c.use 'OpenTelemetry::Instrumentation::ActiveSupport'
-          c.use 'OpenTelemetry::Instrumentation::Rack'
-          c.use 'OpenTelemetry::Instrumentation::ActionPack'
-          c.use 'OpenTelemetry::Instrumentation::ActiveJob'
-          c.use 'OpenTelemetry::Instrumentation::ActiveRecord'
-          c.use 'OpenTelemetry::Instrumentation::ActionView'
-          c.use 'OpenTelemetry::Instrumentation::AwsSdk'
-          c.use 'OpenTelemetry::Instrumentation::HTTP'
-          c.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
-          c.use 'OpenTelemetry::Instrumentation::Net::HTTP'
-          c.use 'OpenTelemetry::Instrumentation::Rails'
-          c.use 'OpenTelemetry::Instrumentation::Redis'
-          c.use 'OpenTelemetry::Instrumentation::Sidekiq'
+
+          # Keep Open Telemetry instrumentation in sync across environments,
+          # so that we can catch any problems arising from instrumentation libraries
+          # and configuration
+          Pender::OpenTelemetryConfig.configure_instrumentation!(c)
         end
         @exporter
       end

--- a/test/lib/pender_open_telemetry_config_test.rb
+++ b/test/lib/pender_open_telemetry_config_test.rb
@@ -11,13 +11,27 @@ class OpenTelemetryConfigTest < ActiveSupport::TestCase
     isolated_teardown
   end
 
-  test "configures open telemetry to report remotely when exporting enabled" do
-    env_var_original_state = {}
-    Pender::OpenTelemetryConfig::ENV_CONFIG.map do|env_var|
-      return unless ENV[env_var]
-      env_var_original_state[env_var] = ENV.delete(env_var)
-    end
+  ENV_CONFIG_TO_RESET = %w(
+    OTEL_TRACES_EXPORTER
+    OTEL_EXPORTER_OTLP_ENDPOINT
+    OTEL_EXPORTER_OTLP_HEADERS
+    OTEL_RESOURCE_ATTRIBUTES
+    OTEL_TRACES_SAMPLER
+    OTEL_TRACES_SAMPLER_ARG
+  )
 
+  def cache_and_clear_env
+    {}.tap do |original_state|
+      ENV_CONFIG_TO_RESET.each do|env_var|
+        next unless ENV[env_var]
+        original_state[env_var] = ENV.delete(env_var)
+      end
+    end
+  end
+
+  test "configures open telemetry to report remotely when exporting enabled" do
+    env_var_original_state = cache_and_clear_env
+    
     Pender::OpenTelemetryConfig.new('https://fake.com','foo=bar').configure!({'developer.name' => 'piglet'})
 
     assert_equal 'otlp', ENV['OTEL_TRACES_EXPORTER']
@@ -29,18 +43,29 @@ class OpenTelemetryConfigTest < ActiveSupport::TestCase
   end
 
   test "configures open telemetry to have nil exporter when exporting disabled, and leaves other exporter settings blank" do
-    env_var_original_state = {}
-    Pender::OpenTelemetryConfig::ENV_CONFIG.map do|env_var|
-      return unless ENV[env_var]
-      env_var_original_state[env_var] = ENV.delete(env_var)
-    end
+    env_var_original_state = cache_and_clear_env
 
     Pender::OpenTelemetryConfig.new('','').configure!({'developer.name' => 'piglet'})
 
-    assert ENV['OTEL_TRACES_EXPORTER'].nil?
-    assert_empty ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
-    assert_empty ENV['OTEL_EXPORTER_OTLP_HEADERS']
+    assert_equal 'none', ENV['OTEL_TRACES_EXPORTER']
+    assert_nil ENV['OTEL_EXPORTER_OTLP_ENDPOINT']
+    assert_nil ENV['OTEL_EXPORTER_OTLP_HEADERS']
     assert_equal 'developer.name=piglet', ENV['OTEL_RESOURCE_ATTRIBUTES']
+  ensure
+    env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
+  end
+
+  test "sets provided sampling config in the environment" do
+    env_var_original_state = cache_and_clear_env
+
+    Pender::OpenTelemetryConfig.new('https://fake.com','foo=bar').configure!(
+      {'developer.name' => 'piglet' },
+      sampling_config: { sampler: 'traceidratio', rate: '2' }
+    )
+
+    assert_equal 'traceidratio', ENV['OTEL_TRACES_SAMPLER']
+    assert_equal '0.5', ENV['OTEL_TRACES_SAMPLER_ARG']
+    assert_equal 'developer.name=piglet,SampleRate=2', ENV['OTEL_RESOURCE_ATTRIBUTES']
   ensure
     env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
   end

--- a/test/lib/pender_open_telemetry_test_config_test.rb
+++ b/test/lib/pender_open_telemetry_test_config_test.rb
@@ -1,5 +1,4 @@
 require_relative '../test_helper'
-require_relative '../../lib/pender_open_telemetry_config'
 
 # Verifying we can use our test-specific open telemetry config --
 # not to be confused with OpenTelemetryConfigTest, which


### PR DESCRIPTION
To start out, we want to send all information to Honeycomb. But, depending on the volume of traces generated, we may want to reduce the amount of traces that we send. This commit enables that: sending all data by default, and setting a sampler with sample rate in the case that we want to limit.

To use, we would need to set the following in config.yml:
* `otel_traces_sampler` - should be a Open Telemetry supported value, like traceidratio
* `otel_custom_sampling_rate` - this should be a number, ideally an integer, representing the amount we want to sample. It will be set as the relevant config for Open Telemetry (e.g. if 5 if set, then SampleRate=5 will be sent as an attribute, and OTEL_TRACES_SAMPLER_ARG will be set in environment to 0.2

This commit also consolidates instrumentation into one method that is used across all environments, so that we have less of a chance of our test and real environments diverging in enabled instrumentation and configuration. Ideally we would move this full configuration to only run in *some* integration tests in the future, but for now we run on everything to be safe.

In general, the complexity happening in Pender::OpenTelemetryConfig is attempting to put some guard rails in configuring Open Telemetry, since there are many pieces that need to be set to specific values for everything to run as expected.