### PR TITLE
Set defaults for unset Open Telemetry config

### DIFF
--- a/lib/pender_open_telemetry_config.rb
+++ b/lib/pender_open_telemetry_config.rb
@@ -31,6 +31,9 @@ module Pender
     end
 
     def configure!(resource_attributes, sampling_config: nil)
+      resource_attributes ||= {}
+      sampling_config ||= {}
+
       configure_exporting!
       sampling_attributes = configure_sampling!(sampling_config)
 
@@ -63,7 +66,7 @@ module Pender
 
     def configure_sampling!(sampling_config)
       additional_attributes = {}
-      if sampling_config && sampling_config[:sampler]
+      if sampling_config[:sampler]
         ENV['OTEL_TRACES_SAMPLER'] = sampling_config[:sampler]
         
         begin

--- a/test/lib/pender_open_telemetry_config_test.rb
+++ b/test/lib/pender_open_telemetry_config_test.rb
@@ -70,6 +70,15 @@ class OpenTelemetryConfigTest < ActiveSupport::TestCase
     env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
   end
 
+  test "gracefully handles unset attributes" do
+    env_var_original_state = cache_and_clear_env
+
+    Pender::OpenTelemetryConfig.new('https://fake.com','foo=bar').configure!(nil)
+    assert ENV['OTEL_RESOURCE_ATTRIBUTES'].blank?
+  ensure
+    env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
+  end
+
   # exporting_disabled?
   test "should disable exporting if any required config missing" do
     assert Pender::OpenTelemetryConfig.new(nil, nil).send(:exporting_disabled?)


### PR DESCRIPTION
Since we load from yml file, we can easily pass nil in for these values. This sets defaults assuming that sometimes we will be passed nil, but we always want a hash.

It's possible we might want more guard rails in future (like, erroring if the passed config doesn't have the shape we want, or passing things in individually, etc) but this seems sufficient to fix current issues with deployment.