### PR TITLE
Send ApiKey id to Honeycomb

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   skip_before_action :verify_authenticity_token
+  before_action :add_info_to_trace
 
   def process_action(*)
     if PenderConfig.get('memory_report', false).to_s == 'true'
@@ -8,5 +9,11 @@ class ApplicationController < ActionController::Base
     else
       super
     end
+  end
+
+  def add_info_to_trace
+    TracingService.add_attributes_to_current_span(
+      'app.api_key' => ApiKey.current&.id,
+    )
   end
 end

--- a/lib/tracing_service.rb
+++ b/lib/tracing_service.rb
@@ -1,0 +1,15 @@
+# A convenience wrapper class for Open Telemetry
+class TracingService
+  class << self
+    def add_attributes_to_current_span(attributes)
+      current_span = OpenTelemetry::Trace.current_span
+      current_span.add_attributes(format_attributes(attributes))
+    end
+
+    private
+
+    def format_attributes(attributes)
+      attributes.compact
+    end
+  end
+end

--- a/test/controllers/base_api_controller_test.rb
+++ b/test/controllers/base_api_controller_test.rb
@@ -41,4 +41,16 @@ class BaseApiControllerTest < ActionController::TestCase
     assert_equal 'Keep', response['data']['name']
     MemoryProfiler::Results.any_instance.unstub(:pretty_print)
   end
+
+  test "should send basic tracing information for api key" do
+    api_key = create_api_key
+    authenticate_with_token(api_key)
+
+
+    TracingService.expects(:add_attributes_to_current_span).with({
+      'app.api_key' => api_key.id
+    })
+
+    get :about, params: { format: :json }
+  end
 end

--- a/test/lib/tracing_service_test.rb
+++ b/test/lib/tracing_service_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class TracingServiceTest < ActiveSupport::TestCase
+  test "#add_attributes_to_current_span should set attributes via open telemetry" do
+    fake_span = MiniTest::Mock.new
+    fake_span.expect :add_attributes, nil, [{'foo' => 'bar'}]
+
+    OpenTelemetry::Trace.stub(:current_span, fake_span) do
+      TracingService.add_attributes_to_current_span({'foo' => 'bar'})
+    end
+
+    fake_span.verify
+  end
+
+  test "#add_attributes_to_current_span discards empty values in hash" do
+    fake_span = MiniTest::Mock.new
+    fake_span.expect :add_attributes, nil, [{'bar' => 'baz'}]
+
+    OpenTelemetry::Trace.stub(:current_span, fake_span) do
+      TracingService.add_attributes_to_current_span({'foo' => nil, 'bar' => 'baz'})
+    end
+
+    fake_span.verify
+  end
+end


### PR DESCRIPTION
Will help us troubleshoot in traces, and uses the same approach as is currently in Check API.