### PR TITLE
Temporarily disable a few failing integration tests

### DIFF
--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 class KwaiIntegrationTest < ActiveSupport::TestCase
   test "should parse Kwai URL" do
+    skip "Kwai parsing is not currently working; pending until we look into"
+
     m = create_media url: 'https://s.kw.ai/p/1mCb9SSh'
     data = m.as_json
     assert_equal 'Reginaldo Silva2871', data['username']

--- a/test/models/parser/tiktok_item_test.rb
+++ b/test/models/parser/tiktok_item_test.rb
@@ -15,6 +15,8 @@ class TiktokItemIntegrationTest < ActiveSupport::TestCase
   end
 
   test "should parse short TikTok link" do
+    skip "the shortlink below is no longer resolving, and we need to make sure shortlinks are still supported"
+
     m = create_media url: 'https://vt.tiktok.com/ZSduCHt6g/?k=1'
     data = m.as_json
     assert_equal 'item', data['type']


### PR DESCRIPTION
We have two integration tests that are failing and blocking CI; this PR temporarily disables them until we can look further into.

1. I created a bug for the one with Kwai, since it's currently broken, (https://meedan.atlassian.net/browse/CHECK-2735).
2. I need more information on whether the TikTok test is just failing because our link no longer works or if shortlinks are no longer supported by TikTok at all, in which case we may want to just remove the test. I couldn't find a shortlink that would resolve to a TikTok video in the real world.