### PR TITLE
Fix flakiness in archiver tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Besides the specific parsers Pender can parse any link with an oEmbed endpoint o
 * Archive.org
   * This archiver requires `archive_org_access_key` and `archive_org_secret_key` on `config/config.yml` file to be enabled. Get your account’s keys at https://archive.org/account/s3.php
 * Perma.cc
-  * This archiver requires a `perma_cc_key` on `config/config.yml` file to be enabled. Get your account key at https://perma.cc
+  * This archiver requires a `perma_cc_key` on `config/config.yml` file or the requesting API key to be enabled. Get your account key at https://perma.cc
 * Video Archiver
   * Pender uses `youtube-dl` to download videos from any page
   * Many requests in a short period of time to a domain (~20 requests/min) can lead to IP blocking.

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -1,20 +1,10 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'test_helper')
 
 class ArchiverTest < ActiveSupport::TestCase
-
   def teardown
+    super
+
     FileUtils.rm_rf(File.join(Rails.root, 'tmp', 'videos'))
-  end
-
-  def enable_perma_cc!(api_key)
-    Media.any_instance.unstub(:archive_to_perma_cc)
-
-    settings = api_key.application_settings
-    settings['config'] ||= {}
-    settings['config']['perma_cc_key'] = 'my-perma-key'
-    api_key.update!(application_settings: settings)
-
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
   end
 
   test "should skip screenshots" do
@@ -141,14 +131,16 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should update cache for all archivers sent if refresh" do
     Media.any_instance.unstub(:archive_to_archive_org)
+    Media.any_instance.unstub(:archive_to_perma_cc)
     Media.any_instance.stubs(:parse)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
     a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
 
     WebMock.enable!
-    enable_perma_cc!(a)
+
     allowed_sites = lambda{ |uri| !['api.perma.cc', 'web.archive.org'].include?(uri.host) }
     WebMock.disable_net_connect!(allow: allowed_sites)
+    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
 
     url = 'https://www.bbc.com/portuguese'
     id = Media.get_id(url)
@@ -168,6 +160,7 @@ class ArchiverTest < ActiveSupport::TestCase
   test "should not archive in any archiver if don't send or it's none" do
     Media.any_instance.unstub(:archive_to_archive_org)
     a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+
     WebMock.enable!
     allowed_sites = lambda{ |uri| !['archive.org'].include?(uri.host) }
     WebMock.disable_net_connect!(allow: allowed_sites)
@@ -197,6 +190,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should archive only on new archivers if media on cache, not a refresh and specific archiver" do
+    Media.any_instance.unstub(:archive_to_perma_cc)
     Media.any_instance.unstub(:archive_to_archive_org)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
 
@@ -204,8 +198,8 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.enable!
     allowed_sites = lambda{ |uri| !['api.perma.cc', 'web.archive.org'].include?(uri.host) }
     WebMock.disable_net_connect!(allow: allowed_sites)
+    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
 
-    enable_perma_cc!(a)
     url = 'https://opensource.globo.com/hacktoberfest/'
     id = Media.get_id(url)
     m = create_media url: url, key: a
@@ -223,6 +217,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should not archive again if media on cache have both archivers" do
     Media.any_instance.unstub(:archive_to_archive_org)
+    Media.any_instance.unstub(:archive_to_perma_cc)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
 
     a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
@@ -231,8 +226,8 @@ class ArchiverTest < ActiveSupport::TestCase
     allowed_sites = lambda{ |uri| !['api.perma.cc', 'web.archive.org'].include?(uri.host) }
     WebMock.disable_net_connect!(allow: allowed_sites)
 
-    enable_perma_cc!(a)
     url = 'https://edition.cnn.com/'
+    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
 
@@ -255,22 +250,31 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "return the enabled archivers" do
+    enabled_archivers = Media.send(:remove_const, :ENABLED_ARCHIVERS)
     Media.const_set(:ENABLED_ARCHIVERS, [{key: 'archive_org'}, {key: 'perma_cc'}])
 
     assert_equal ['archive_org', 'perma_cc'].sort, Media.enabled_archivers(['archive_org', 'perma_cc']).keys
+
     Media.send(:remove_const, :ENABLED_ARCHIVERS)
     Media.const_set(:ENABLED_ARCHIVERS, [{key: 'archive_org'}])
 
     assert_equal ['archive_org'].sort, Media.enabled_archivers(['perma_cc', 'archive_org']).keys
+  ensure
+    if Media.const_defined?(:ENABLED_ARCHIVERS)
+      Media.send(:remove_const, :ENABLED_ARCHIVERS)
+      Media.const_set(:ENABLED_ARCHIVERS, enabled_archivers)
+    end
   end
 
   test "should archive to perma.cc and store the URL on archives if perma_cc_key is present" do
+    Media.any_instance.unstub(:archive_to_perma_cc)
+
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'api.perma.cc' }
     WebMock.disable_net_connect!(allow: allowed_sites)
+    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
 
     a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test'}
-    enable_perma_cc!(a)
 
     url = 'https://slack.com/intl/en-br/'
     id = Media.get_id(url)
@@ -545,8 +549,8 @@ class ArchiverTest < ActiveSupport::TestCase
     ENV['archiver_skip_hosts'] = ''
 
     PenderConfig.reload
-    enabled = Media::ENABLED_ARCHIVERS
-    Media.const_set(:ENABLED_ARCHIVERS, enabled.select { |archiver| archiver[:key] != 'archive_org' })
+    enabled = Media.send(:remove_const, :ENABLED_ARCHIVERS)
+    Media.const_set(:ENABLED_ARCHIVERS, [])
 
     m.archive('archive_org,unexistent_archive')
 
@@ -555,8 +559,10 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal LapisConstants::ErrorCodes::const_get('ARCHIVER_DISABLED'), m.data.dig('archives', 'archive_org', 'error', 'code')
     assert_match 'Disabled', m.data.dig('archives', 'archive_org', 'error', 'message')
   ensure
-    Media.send(:remove_const, :ENABLED_ARCHIVERS)
-    Media.const_set(:ENABLED_ARCHIVERS, enabled)
+    if Media.const_defined?(:ENABLED_ARCHIVERS)
+      Media.send(:remove_const, :ENABLED_ARCHIVERS)
+      Media.const_set(:ENABLED_ARCHIVERS, enabled)
+    end
     ENV['archiver_skip_hosts'] = skip
   end
 


### PR DESCRIPTION
Previously we weren't calling up to the test_helper teardown, which meant that the resetting of enabled archivers wasn't happening consistently. This commit calls super to make sure we get both teardowns, and ensures that we reset the values of the ENABLED_ARCHIVERS constant to the start of the test when they change mid-test.