### PR TITLE
Re-queue webhook notification job when webhook returns an errored response

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -11,7 +11,7 @@ module MediaArchiveOrgArchiver
 
   module ClassMethods
     def send_to_archive_org_in_background(url, key_id)
-      ArchiverWorker.perform_async(url, :archive_org, key_id)
+      ArchiverWorker.perform_in(30.seconds, url, :archive_org, key_id)
     end
 
     def send_to_archive_org(url, key_id, _supported = nil)

--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -69,8 +69,8 @@ module MediaArchiver
 
     def notify_webhook_and_update_cache(archiver, url, data, key_id)
       settings = Media.api_key_settings(key_id)
-      Media.notify_webhook(archiver, url, data, settings)
       Media.update_cache(url, { archives: { archiver => data } })
+      Media.notify_webhook(archiver, url, data, settings)
     end
 
     def available_archivers(archivers, media = nil)

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -11,7 +11,7 @@ module MediaPermaCcArchiver
 
   module ClassMethods
     def send_to_perma_cc_in_background(url, key_id)
-      ArchiverWorker.perform_async(url, :perma_cc, key_id)
+      ArchiverWorker.perform_in(30.seconds, url, :perma_cc, key_id)
     end
 
     def send_to_perma_cc(url, key_id, _supported = nil)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -156,10 +156,12 @@ class Media
         # returns nil (terribly named method, imo). This is a way to raise that
         # exception if request failed and still return a successful response if present.
         response.value || response
+      rescue Net::HTTPExceptions => e
+        raise Pender::RetryLater
       rescue StandardError => e
         PenderAirbrake.notify(e, url: url, type: type, webhook_url: settings['webhook_url'])
         Rails.logger.warn level: 'WARN', message: 'Failed to notify webhook', url: url, type: type, error_class: e.class, error_message: e.message, webhook_url: settings['webhook_url']
-        raise(e)
+        return false
       end
     else
       Rails.logger.warn level: 'WARN', message: 'Webhook settings not configured for API key', url: url, type: type, api_key: ApiKey.current&.id

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -99,8 +99,8 @@ module Metrics
       return if value.nil?
       settings = Media.api_key_settings(key_id)
       data = { 'metrics' => { name => value } }
-      Media.notify_webhook('metrics', url, data, settings)
       Media.update_cache(url, data)
+      Media.notify_webhook('metrics', url, data, settings)
     end
   end
 end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -19,7 +19,8 @@ class ArchiverTest < ActiveSupport::TestCase
   test "should skip screenshots" do
     stub_configs({'archiver_skip_hosts' => '' })
 
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key
+
     url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390'
     id = Media.get_id(url)
     m = create_media url: url, key: a
@@ -36,15 +37,16 @@ class ArchiverTest < ActiveSupport::TestCase
   test "should archive to Archive.org" do
     Media.any_instance.unstub(:archive_to_archive_org)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
     url = 'https://g1.globo.com/'
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
     WebMock.disable_net_connect!(allow: allowed_sites)
 
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
 
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     m = create_media url: url, key: a
     data = m.as_json(archivers: 'archive_org')
     assert_equal "https://web.archive.org/web/timestamp/#{url}", data['archives']['archive_org']['location']
@@ -54,15 +56,17 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should archive Arabics url to Archive.org" do
     Media.any_instance.unstub(:archive_to_archive_org)
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+
     url = 'http://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
     WebMock.disable_net_connect!(allow: allowed_sites)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
 
     assert_nothing_raised do
-      WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-      WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
       m = create_media url: url, key: a
       data = m.as_json
     end
@@ -74,6 +78,8 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
     WebMock.disable_net_connect!(allow: allowed_sites)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
     Media.any_instance.stubs(:try_https)
@@ -83,7 +89,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Airbrake.stubs(:configured?).returns(true)
     Airbrake.stubs(:notify)
 
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.facebook.com/permalink.php?story_fbid=1649526595359937&id=100009078379548'
 
     assert_raises Pender::RetryLater do
@@ -98,7 +104,6 @@ class ArchiverTest < ActiveSupport::TestCase
       assert_equal LapisConstants::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'archive_org', 'error', 'code')
       assert_equal "#{data[:code]} #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
     end
-
   ensure
     WebMock.disable!
   end
@@ -107,6 +112,8 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
     WebMock.disable_net_connect!(allow: allowed_sites)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
     Media.any_instance.stubs(:try_https)
@@ -116,7 +123,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Airbrake.stubs(:configured?).returns(true)
     Airbrake.stubs(:notify)
 
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     urls = {
       'http://localhost:3333/unreachable-url' => {status_ext: 'error:invalid-url-syntax', message: 'URL syntax is not valid'},
       'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html' => {status_ext: 'error:invalid-host-resolution', message: 'Cannot resolve host'},
@@ -143,13 +150,14 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive_to_perma_cc)
     Media.any_instance.stubs(:parse)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
-    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
 
     WebMock.enable!
 
     allowed_sites = lambda{ |uri| !['api.perma.cc', 'web.archive.org'].include?(uri.host) }
     WebMock.disable_net_connect!(allow: allowed_sites)
     WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     url = 'https://www.bbc.com/portuguese'
     id = Media.get_id(url)
@@ -168,7 +176,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should not archive in any archiver if don't send or it's none" do
     Media.any_instance.unstub(:archive_to_archive_org)
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
 
     WebMock.enable!
     allowed_sites = lambda{ |uri| !['archive.org'].include?(uri.host) }
@@ -176,6 +184,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
     WebMock.stub_request(:any, /web.archive.org\/save/).to_return(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'archive-timestamp'}.to_json)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     url = 'https://health-desk.org/'
     id = Media.get_id(url)
@@ -203,13 +212,14 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive_to_archive_org)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
 
-    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
     WebMock.enable!
     allowed_sites = lambda{ |uri| !['api.perma.cc', 'web.archive.org'].include?(uri.host) }
     WebMock.disable_net_connect!(allow: allowed_sites)
     WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    url = 'https://opensource.globo.com/hacktoberfest/'
+    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    url = 'https://hacktoberfest.com/'
     id = Media.get_id(url)
     m = create_media url: url, key: a
     m.as_json(archivers: 'perma_cc')
@@ -229,7 +239,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive_to_perma_cc)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
 
-    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
 
     WebMock.enable!
     allowed_sites = lambda{ |uri| !['api.perma.cc', 'web.archive.org'].include?(uri.host) }
@@ -239,6 +249,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     id = Media.get_id(url)
     m = create_media url: url, key: a
@@ -256,6 +267,8 @@ class ArchiverTest < ActiveSupport::TestCase
     m.as_json(archivers: 'none')
     assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
     assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
+  ensure
+    WebMock.disable!
   end
 
   test "return the enabled archivers" do
@@ -278,12 +291,12 @@ class ArchiverTest < ActiveSupport::TestCase
     allowed_sites = lambda{ |uri| uri.host != 'api.perma.cc' }
     WebMock.disable_net_connect!(allow: allowed_sites)
     WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
-
-    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test'}
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     url = 'https://slack.com/intl/en-br/'
     id = Media.get_id(url)
 
+    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     m = Media.new url: url, key: a
     m.as_json(archivers: 'perma_cc')
 
@@ -295,7 +308,10 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should not try to archive on Perma.cc if already archived on it" do
-    a = create_api_key application_settings: { config: { perma_cc_key: 'perma_key'}, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.washingtonpost.com/'
     m = Media.new url: url, key: a
     m.as_json
@@ -305,16 +321,21 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.stubs(:notify_webhook_and_update_cache).with('perma_cc', url, { location: 'http://perma.cc/AUA8-QNGH'}, a.id).never
 
     m.archive_to_perma_cc
+  ensure
+    WebMock.disable!
   end
 
   test "should update media with error when archive to Perma.cc fails" do
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
     Media.any_instance.stubs(:try_https)
     Media.any_instance.stubs(:parse)
     Media.any_instance.stubs(:archive)
 
-    a = create_api_key application_settings: { config: { perma_cc_key: 'perma_key'}, 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'http://example.com'
 
     assert_raises Pender::RetryLater do
@@ -326,6 +347,8 @@ class ArchiverTest < ActiveSupport::TestCase
       assert_equal LapisConstants::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'perma_cc', 'error', 'code')
       assert_equal "401 Unauthorized", media_data.dig('archives', 'perma_cc', 'error', 'message')
     end
+  ensure
+    WebMock.disable!
   end
 
   test "should add disabled Perma.cc archiver error message if perma_key is not present" do
@@ -343,7 +366,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should return api key settings" do
-    key1 = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    key1 = create_api_key application_settings: {'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     key2 = create_api_key application_settings: {}
     key3 = create_api_key
     [key1.id, key2.id, key3.id, -1].each do |id|
@@ -354,8 +377,12 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should call youtube-dl and call video upload when archive video" do
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
     Media.any_instance.unstub(:archive_to_video)
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.bbc.com/news/av/world-us-canada-57176620'
     m = Media.new url: url, key: a
     m.as_json
@@ -367,13 +394,18 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.stubs(:system).returns(`(exit 0)`)
     assert_equal 'store_video_folder', Media.send_to_video_archiver(url, a.id)
     assert_nil Media.send_to_video_archiver(url, a.id, false)
+  ensure
+    WebMock.disable!
   end
 
   test "should return false and add error to data when video archiving is not supported" do
     Media.unstub(:supported_video?)
     Media.any_instance.stubs(:parse)
     Metrics.stubs(:get_metrics_from_facebook_in_background)
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
 
     Media.stubs(:system).returns(`(exit 0)`)
     url = 'https://www.folha.uol.com.br/'
@@ -392,6 +424,8 @@ class ArchiverTest < ActiveSupport::TestCase
     media_data = Pender::Store.current.read(Media.get_id(url), :json)
     assert_equal LapisConstants::ErrorCodes::const_get('ARCHIVER_NOT_SUPPORTED_MEDIA'), media_data.dig('archives', 'video_archiver', 'error', 'code')
     assert_equal '1 Unsupported URL', media_data.dig('archives', 'video_archiver', 'error', 'message')
+  ensure
+    WebMock.disable!
   end
 
   test "should check if non-ascii URL support video download" do
@@ -400,7 +434,10 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should notify if URL was already parsed and has a location on data when archive video" do
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.bbc.com/news/av/world-us-canada-57176620'
 
     Pender::Store.any_instance.stubs(:read).with(Media.get_id(url), :json).returns(nil)
@@ -415,11 +452,16 @@ class ArchiverTest < ActiveSupport::TestCase
     Pender::Store.any_instance.stubs(:read).with(Media.get_id(url), :json).returns(data)
     Media.stubs(:notify_webhook).with('video_archiver', url, data, {}).returns('Notify webhook')
     assert_equal 'Notify webhook', Media.notify_video_already_archived(url, nil)
+  ensure
+    WebMock.disable!
   end
 
   # FIXME Mocking Youtube-DL to avoid `HTTP Error 429: Too Many Requests`
   test "should archive video info subtitles, thumbnails and update cache" do
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.youtube.com/watch?v=1vSJrexmVWU'
     id = Media.get_id url
 
@@ -449,11 +491,16 @@ class ArchiverTest < ActiveSupport::TestCase
     data.dig('archives', 'video_archiver', 'thumbnails').each do |thumb|
       assert_match /\A#{folder}\/#{id}.*\.jpg\z/, thumb
     end
+  ensure
+    WebMock.disable!
   end
 
   test "should raise retry error when video archiving fails" do
     Sidekiq::Testing.fake!
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.wsj.com/'
     Media.stubs(:supported_video?).with(url, a.id).returns(true)
     id = Media.get_id url
@@ -470,6 +517,8 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_raises Pender::RetryLater do
       Media.send_to_video_archiver(not_video_url, a.id)
     end
+  ensure
+    WebMock.disable!
   end
 
   test "should update media with error when supported video call raises on video archiving" do
@@ -478,8 +527,9 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.stubs(:get_canonical_url).returns(true)
     Media.any_instance.stubs(:try_https)
     Media.any_instance.stubs(:parse)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://example.com'
 
     assert_raises Pender::RetryLater do
@@ -498,6 +548,9 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should update media with error when video download fails when video archiving" do
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
     Media.any_instance.stubs(:try_https)
@@ -505,7 +558,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.stubs(:supported_video?).returns(true)
     Media.stubs(:system).returns(`(exit 1)`)
 
-    a = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.tiktok.com/@scout2015/video/6771039287917038854'
 
     assert_raises Pender::RetryLater do
@@ -584,7 +637,10 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should get proxy to download video from api key if present" do
-    api_key = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.youtube.com/watch?v=unv9aPZYF6E'
     m = Media.new url: url, key: api_key
 
@@ -594,9 +650,14 @@ class ArchiverTest < ActiveSupport::TestCase
     PenderConfig.current = nil
     m = Media.new url: url, key: api_key
     assert_equal 'http://my-user-prefix:12345@my-proxy.mine:1111', Media.yt_download_proxy(m.url)
+  ensure
+    WebMock.disable!
   end
 
   test "should use api key config when archiving video if present" do
+    WebMock.enable!
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
     Media.unstub(:supported_video?)
     Media.stubs(:system).returns(`(exit 0)`)
 
@@ -605,11 +666,12 @@ class ArchiverTest < ActiveSupport::TestCase
       config[config_key] = PenderConfig.get(config_key, "test_#{config_key}")
     end
 
-    url = 'https://www.youtube.com/watch?v=o1V1LnUU5VM'
-
     ApiKey.current = PenderConfig.current = Pender::Store.current = nil
-    api_key = create_api_key application_settings: { 'webhook_url': 'http://ca.ios.ba/files/meedan/webhook.php', 'webhook_token': 'test' }
+
+    api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    url = 'https://www.youtube.com/watch?v=o1V1LnUU5VM'
     Media.send_to_video_archiver(url, api_key.id)
+
     assert_equal api_key, ApiKey.current
     %w(endpoint access_key secret_key bucket bucket_region medias_asset_path).each do |key|
       assert !PenderConfig.current("storage_#{key}").blank?
@@ -627,6 +689,8 @@ class ArchiverTest < ActiveSupport::TestCase
       assert_equal api_key.settings[:config]["storage_#{key}"], PenderConfig.current("storage_#{key}")
       assert_equal api_key.settings[:config]["storage_#{key}"], Pender::Store.current.instance_variable_get(:@storage)[key]
     end
+  ensure
+    WebMock.disable!
   end
 
   test "should return true and get available snapshot if page was already archived on Archive.org" do

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -58,7 +58,7 @@ class MediaTest < ActiveSupport::TestCase
       header_options_without_cf = RequestHelper.html_options(url).merge(read_timeout: PenderConfig.get('timeout', 30).to_i)
       assert_nil header_options_without_cf['CF-Access-Client-Id']
       assert_nil header_options_without_cf['CF-Access-Client-Secret']
-  
+
       PenderConfig.current = nil
       ENV['hosts'] = {"example.com"=>{"cf_credentials"=>"1234:5678"}}.to_json
       header_options_with_cf = RequestHelper.html_options(url).merge(read_timeout: PenderConfig.get('timeout', 30).to_i)
@@ -82,7 +82,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal 'https://www.bbc.com', data['author_url']
     assert_equal '', data['picture']
   end
-  
+
   test "should get canonical URL parsed from html tags" do
     doc = ''
     open('test/data/page-with-url-on-tag.html') { |f| doc = f.read }
@@ -163,7 +163,7 @@ class MediaTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:try_https)
     OpenURI.unstub(:open_uri)
     Airbrake.unstub(:configured?)
-  end 
+  end
 
   test "should redirect to HTTPS if available and not already HTTPS" do
     m = create_media url: 'http://imotorhead.com'
@@ -292,7 +292,7 @@ class MediaTest < ActiveSupport::TestCase
     Media::PARSERS.each do |parser|
       parser.any_instance.stubs(:parse_data).raises(StandardError)
     end
-    
+
     # If we stub within this block, the stub isn't in place when we need it
     Media::PARSERS.each do |parser|
       m = create_media url: 'http://example.com'
@@ -540,11 +540,6 @@ class MediaTest < ActiveSupport::TestCase
     m.send(:get_html, RequestHelper.html_options(m.url))
   end
 
-  test "should handle error when can't notify webhook" do
-    webhook_info = { 'webhook_url' => 'http://invalid.webhook', 'webhook_token' => 'test' }
-    assert_equal false, Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
-  end
-
   test "should add not found error and return empty html" do
     url = 'https://www.facebook.com/ldfkgjdfghodhg'
 
@@ -658,12 +653,35 @@ class MediaUnitTest < ActiveSupport::TestCase
 
     Pender::Store.current.delete(id, :json)
     assert Pender::Store.current.read(id, :json).blank?
-    
+
     m = create_media url: url
     data = m.as_json
-    
+
     assert Pender::Store.current.read(id, :json).blank?
     assert_equal 'this is a title', data[:title]
     assert_equal 'https://www.example.com/%C3%A1%3C80%3E%3C99%3E%C3%A1%3C80%3E%3C84%3E%C3%A1%3C80%3E', data[:raw][:link]
+  end
+
+  test "#notify_webhook should raise exception for unsuccessful response from webhook" do
+    WebMock.stub_request(:post, /example.com/).and_return(status: 404, body: 'fake response body')
+    webhook_info = { 'webhook_url' => 'http://example.com/webhook', 'webhook_token' => 'test' }
+
+    assert_raises Net::HTTPServerException do
+      Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
+    end
+  end
+
+  test "#notify_webhook should return successful response from webhook" do
+    webhook_info = { 'webhook_url' => 'http://example.com/webhook', 'webhook_token' => 'test' }
+
+    WebMock.stub_request(:post, /example.com/).and_return(status: 200, body: 'fake response body')
+    response = Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
+    assert_equal "200", response.code
+    assert_equal 'fake response body', response.body
+
+    WebMock.stub_request(:post, /example.com/).and_return(status: 201, body: 'fake response body')
+    response = Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
+    assert_equal "201", response.code
+    assert_equal 'fake response body', response.body
   end
 end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -701,18 +701,4 @@ class MediaUnitTest < ActiveSupport::TestCase
     assert_equal "201", response.code
     assert_equal 'fake response body', response.body
   end
-
-  test "#notify_webhook should return successful response from webhook" do
-    webhook_info = { 'webhook_url' => 'http://example.com/webhook', 'webhook_token' => 'test' }
-
-    WebMock.stub_request(:post, /example.com/).and_return(status: 200, body: 'fake response body')
-    response = Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
-    assert_equal "200", response.code
-    assert_equal 'fake response body', response.body
-
-    WebMock.stub_request(:post, /example.com/).and_return(status: 201, body: 'fake response body')
-    response = Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
-    assert_equal "201", response.code
-    assert_equal 'fake response body', response.body
-  end
 end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -701,4 +701,18 @@ class MediaUnitTest < ActiveSupport::TestCase
     assert_equal "201", response.code
     assert_equal 'fake response body', response.body
   end
+
+  test "#notify_webhook should return successful response from webhook" do
+    webhook_info = { 'webhook_url' => 'http://example.com/webhook', 'webhook_token' => 'test' }
+
+    WebMock.stub_request(:post, /example.com/).and_return(status: 200, body: 'fake response body')
+    response = Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
+    assert_equal "200", response.code
+    assert_equal 'fake response body', response.body
+
+    WebMock.stub_request(:post, /example.com/).and_return(status: 201, body: 'fake response body')
+    response = Media.notify_webhook('metrics', 'http://example.com', {}, webhook_info)
+    assert_equal "201", response.code
+    assert_equal 'fake response body', response.body
+  end
 end

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -8,16 +8,16 @@ class MetricsIntegrationTest < ActiveSupport::TestCase
       fb_config = PenderConfig.get('facebook_test_app') || PenderConfig.get('facebook_app')
       PenderConfig.current = nil
       key = create_api_key application_settings: { config: { facebook_app: fb_config }}
-  
+
       url = 'https://www.google.com/'
-  
+
       # Make sure we don't send 10 requests to Facebook at once and get rate limited,
       # since Sidekiq otherwise would perform the ten days of updates at once
       Sidekiq::Worker.clear_all
       Sidekiq::Testing.fake! do
         m = create_media url: url, key: key
         m.as_json
-  
+
         # Perform once for each Facebook app we have in the configuration -
         # in case we get rate limited on the first app id but not second
         allowed_attempts = fb_config.split(";").count
@@ -37,10 +37,10 @@ class MetricsIntegrationTest < ActiveSupport::TestCase
           end
         end
         raise AllTestFacebookAppsRateLimited if attempts == allowed_attempts
-  
+
         id = Media.get_id(url)
         data = Pender::Store.current.read(id, :json)
-        
+
         assert data['metrics']['facebook']['share_count'] > 0
       end
     rescue AllTestFacebookAppsRateLimited => e
@@ -72,7 +72,7 @@ class MetricsUnitTest < ActiveSupport::TestCase
     isolated_setup
     Semaphore.new(facebook_app_id).unlock
   end
-  
+
   def teardown
     isolated_teardown
     Semaphore.new(facebook_app_id).unlock
@@ -83,7 +83,7 @@ class MetricsUnitTest < ActiveSupport::TestCase
     stub_facebook_metrics_request
 
     current_time = Time.now
-    
+
     assert_difference 'MetricsWorker.jobs.size', 1 do
       Metrics.get_metrics_from_facebook_in_background({}, 'https://example.com/trending-article', key.id)
     end
@@ -98,7 +98,7 @@ class MetricsUnitTest < ActiveSupport::TestCase
     stub_facebook_metrics_request
 
     current_time = Time.now
-    
+
     Metrics.get_metrics_from_facebook_in_background({}, 'http://example.com/trending-article', key.id)
     # Perform one removes the first, immediately enqueued background job
     # and schedules the subsequent one
@@ -172,6 +172,26 @@ class MetricsUnitTest < ActiveSupport::TestCase
     mocked_webhook_method.verify
   end
 
+  test "should still update cache if notifying webhook causes error" do
+    stub_facebook_oauth_request
+    stub_facebook_metrics_request
+    Media.stubs(:notify_webhook).raises(StandardError.new("fake error for test"))
+
+    url = 'https://example.com/trending-article'
+    id = Media.get_id(url)
+    Pender::Store.current.write(id, :json, {some: 'value'})
+
+    data = Pender::Store.current.read(id, :json)
+    assert_not data['metrics'].present?
+
+    assert_raises do
+      Metrics.get_metrics_from_facebook(url, key.id)
+    end
+
+    data = Pender::Store.current.read(id, :json)
+    assert data['metrics'].present?
+  end
+
   test  "should send exception to errbit when fb metrics returns a non-retryable error" do
     stub_facebook_oauth_request
     WebMock.stub_request(:get, /graph.facebook.com\/\S*access_token=fake-access-token/).to_return(status: 403, body: "{\"error\":{\"message\":\"Requires Facebook page permissions.\",\"code\":\"10\"}}")
@@ -227,7 +247,7 @@ class MetricsUnitTest < ActiveSupport::TestCase
       to_return(status: 200, body: {access_token: 'fake-access-token-2'}.to_json)
     WebMock.stub_request(:get, /graph.facebook.com\/\S*access_token=fake-access-token-2/).
       to_return(status: 200, body: {engagement: { shares: '123' } }.to_json)
-    
+
     api_key = create_api_key application_settings: { config: { facebook_app: "1111:2222;3333:4444" }}
     app_1_locker = Semaphore.new('1111')
     app_2_locker = Semaphore.new('3333')
@@ -238,7 +258,7 @@ class MetricsUnitTest < ActiveSupport::TestCase
       # Unlocked as part of normal test teardown
       assert_equal true, app_1_locker.locked?
     end
-    
+
     assert_equal false, app_2_locker.locked?
     metrics = Metrics.get_metrics_from_facebook('http://example.com/trending-article', api_key.id)
     # Unlock before we exit function with possible failure, since this
@@ -270,7 +290,7 @@ class MetricsUnitTest < ActiveSupport::TestCase
     }
 
     Metrics.get_metrics_from_facebook('http://example.com/trending-article', api_key.id)
-    
+
     assert_equal api_key, ApiKey.current
     assert_equal api_key.settings[:config][:facebook_app], PenderConfig.current(:facebook_app)
     %w(endpoint access_key secret_key bucket bucket_region video_bucket video_asset_path medias_asset_path).each do |key|


### PR DESCRIPTION
This PR does a few things:
1. Adds a delay before kicking off the archiving jobs, to give Check API a headstart to start creating the link, project media, and annotation that will be needed to associate the archival information
2. Begins raising exception when the webhook notification to Check API returns an unsuccessful response, which Sidekiq will then retry.
3. Uses WebMock to stub external requests to the endpoint in tests, and removes dependency on the external webhook endpoint on Caio's site (partly because it was returning 301, which is considered unsuccessful)

**Given that we should always expect the Check webhook to be working when we send a webhook notification from Pender, I think always retrying when the endpoint errors makes sense regardless of what that error returned from Check API is, but I'd love feedback on that**. Right now the webhook endpoint will error in the case of an incorrect bot name (404) or an incorrect secret token (400), and I'll be adding the race conditions (link, project media, or archiver annotation unavailable; 425).