### PR TITLE
Send metrics errors to Honeycomb, and silence retryable ones

### DIFF
--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -101,8 +101,6 @@ module Metrics
       if is_retryable
         @locker.lock(3600) if FACEBOOK_RATE_LIMIT_CODES.include?(error['code'].to_i)
         raise Pender::RetryLater, 'Metrics request failed'
-      else
-        PenderAirbrake.notify("Facebook metrics error: #{error['code']}", url: url, key_id: ApiKey.current&.id, error: error, retryable: is_retryable)
       end
     end
 

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -88,11 +88,22 @@ module Metrics
       is_retryable = (RETRYABLE_FACEBOOK_ERROR_CODES + FACEBOOK_RATE_LIMIT_CODES).include?(error['code'].to_i)
 
       Rails.logger.warn level: 'WARN', message: "Facebook metrics error: #{error['code']} - #{error['message']}", url: url, key_id: ApiKey.current&.id, error: error, retryable: is_retryable
-      PenderAirbrake.notify("Facebook metrics error: #{error['code']} - #{error['message']}", url: url, key_id: ApiKey.current&.id, error: error, retryable: is_retryable)
-      return unless is_retryable
-
-      @locker.lock(3600) if FACEBOOK_RATE_LIMIT_CODES.include?(error['code'].to_i)
-      raise Pender::RetryLater, 'Metrics request failed'
+      TracingService.set_error_status(
+        "Facebook metrics error",
+        attributes: {
+          'app.api_key' => ApiKey.current&.id,
+          'facebook.metrics.error.code' => error['code'],
+          'facebook.metrics.error.message' => error['message'],
+          'facebook.metrics.url' => url,
+          'facebook.metrics.retryable' => is_retryable
+        }
+      )
+      if is_retryable
+        @locker.lock(3600) if FACEBOOK_RATE_LIMIT_CODES.include?(error['code'].to_i)
+        raise Pender::RetryLater, 'Metrics request failed'
+      else
+        PenderAirbrake.notify("Facebook metrics error: #{error['code']}", url: url, key_id: ApiKey.current&.id, error: error, retryable: is_retryable)
+      end
     end
 
     def notify_webhook_and_update_metrics_cache(url, name, value, key_id)

--- a/lib/tracing_service.rb
+++ b/lib/tracing_service.rb
@@ -3,13 +3,32 @@ class TracingService
   class << self
     def add_attributes_to_current_span(attributes)
       current_span = OpenTelemetry::Trace.current_span
-      current_span.add_attributes(format_attributes(attributes))
+      add_attributes(current_span, attributes)
+    end
+
+    # Set error on span in Otel without a corresponding exception
+    def set_error_status(error_message, attributes: {})
+      current_span = OpenTelemetry::Trace.current_span
+      current_span.status = OpenTelemetry::Trace::Status.error(error_message)
+      add_attributes(current_span, attributes)
+    end
+
+    # Set error on span in Otel with a corresponding exception
+    def record_exception(e = nil, error_message = nil, attributes: {})
+      current_span = OpenTelemetry::Trace.current_span
+      current_span.status = OpenTelemetry::Trace::Status.error(error_message || e.message)
+      current_span.record_exception(e, attributes: format_attributes(attributes))
     end
 
     private
 
     def format_attributes(attributes)
       attributes.compact
+    end
+
+    def add_attributes(current_span, attributes)
+      return if attributes.empty?
+      current_span.add_attributes(format_attributes(attributes))
     end
   end
 end

--- a/test/lib/tracing_service_test.rb
+++ b/test/lib/tracing_service_test.rb
@@ -1,6 +1,28 @@
 require 'test_helper'
 
 class TracingServiceTest < ActiveSupport::TestCase
+  # These integration tests are just meant to make sure that we don't see any issues
+  # our unit tests don't cover, since those tests are mostly stubs because of issues accessing
+  # set attributes on the recorded spans.
+  test "add_attributes_to_current_span works for real" do
+    assert_nothing_raised do
+      TracingService.add_attributes_to_current_span({'foo' => 'bar'})
+    end
+  end
+
+  test "#record_exception works for real" do
+    assert_nothing_raised do
+      TracingService.record_exception(StandardError.new("some fake error"), attributes: {'foo' => 'bar'})
+    end
+  end
+
+  test "#set_error_status works for real" do
+    assert_nothing_raised do
+      TracingService.set_error_status("some fake error", attributes: {'foo' => 'bar'})
+    end
+  end
+
+  # Unit tests below
   test "#add_attributes_to_current_span should set attributes via open telemetry" do
     fake_span = MiniTest::Mock.new
     fake_span.expect :add_attributes, nil, [{'foo' => 'bar'}]
@@ -18,6 +40,95 @@ class TracingServiceTest < ActiveSupport::TestCase
 
     OpenTelemetry::Trace.stub(:current_span, fake_span) do
       TracingService.add_attributes_to_current_span({'foo' => nil, 'bar' => 'baz'})
+    end
+
+    fake_span.verify
+  end
+
+  test "#record_exception reports passed exception its default message to open telemetry span" do
+    exception = StandardError.new('exception message')
+    fake_span = MiniTest::Mock.new
+    fake_status = MiniTest::Mock.new
+
+    fake_span.expect :record_exception, nil, [exception, attributes: {}]
+    fake_span.expect :status=, nil, [fake_status]
+
+    arguments_checker = Proc.new do |message|
+      assert_equal 'exception message', message
+      fake_status
+    end
+
+    OpenTelemetry::Trace::Status.stub(:error, arguments_checker) do
+      OpenTelemetry::Trace.stub(:current_span, fake_span) do
+        TracingService.record_exception(exception)
+      end
+    end
+
+    fake_span.verify
+  end
+
+  test "#record_exception discards empty values in attribute hash" do
+    fake_span = MiniTest::Mock.new
+    exception = StandardError.new('exception message')
+    fake_span.expect :record_exception, nil, [exception, attributes: {'bar'=>'baz'}]
+    def fake_span.status=(val); nil; end
+
+    OpenTelemetry::Trace.stub(:current_span, fake_span) do
+      TracingService.record_exception(exception, attributes: {'foo' => nil, 'bar' => 'baz'})
+    end
+
+    fake_span.verify
+  end
+
+  test "#record_exception passes along custom error message if provided" do
+    exception = StandardError.new('exception message')
+    fake_span = MiniTest::Mock.new
+    fake_status = MiniTest::Mock.new
+
+    fake_span.expect :record_exception, nil, [exception, attributes: {}]
+    fake_span.expect :status=, nil, [fake_status]
+
+    arguments_checker = Proc.new do |message|
+      assert_equal 'my custom message', message
+      fake_status
+    end
+
+    OpenTelemetry::Trace::Status.stub(:error, arguments_checker) do
+      OpenTelemetry::Trace.stub(:current_span, fake_span) do
+        TracingService.record_exception(exception, 'my custom message')
+      end
+    end
+
+    fake_span.verify
+  end
+
+  test "#set_error_status sets error status with provided message on current span" do
+    fake_span = MiniTest::Mock.new
+    fake_status = MiniTest::Mock.new
+
+    fake_span.expect :status=, nil, [fake_status]
+
+    arguments_checker = Proc.new do |message|
+      assert_equal 'my error message', message
+      fake_status
+    end
+
+    OpenTelemetry::Trace::Status.stub(:error, arguments_checker) do
+      OpenTelemetry::Trace.stub(:current_span, fake_span) do
+        TracingService.set_error_status('my error message')
+      end
+    end
+
+    fake_span.verify
+  end
+
+  test "#set_error_status adds any passed attributes" do
+    fake_span = MiniTest::Mock.new
+    fake_span.expect :add_attributes, nil, [{'foo' => 'bar'}]
+    def fake_span.status=(val); nil; end
+
+    OpenTelemetry::Trace.stub(:current_span, fake_span) do
+      TracingService.set_error_status('my error message', attributes: {'foo' => 'bar'})
     end
 
     fake_span.verify

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -192,21 +192,6 @@ class MetricsUnitTest < ActiveSupport::TestCase
     assert data['metrics'].present?
   end
 
-  test  "should send exception to errbit when fb metrics returns a non-retryable error" do
-    stub_facebook_oauth_request
-    WebMock.stub_request(:get, /graph.facebook.com\/\S*access_token=fake-access-token/).to_return(status: 403, body: "{\"error\":{\"message\":\"Requires Facebook page permissions.\",\"code\":\"10\"}}")
-
-    mocked_airbrake = MiniTest::Mock.new
-    mocked_airbrake.expect :call, :return_value do |message, args|
-      message.match(/Facebook metrics error: 10 - Requires Facebook page permissions/) && !args[:retryable]
-    end
-
-    PenderAirbrake.stub(:notify, mocked_airbrake) do
-      Metrics.get_metrics_from_facebook('http://example.com/trending-article-123', key.id)
-    end
-    mocked_airbrake.verify
-  end
-
   test "should add error to tracing span and raise retry error when fb metrics returns a retryable error" do
     stub_facebook_oauth_request
     WebMock.stub_request(:get, /graph.facebook.com\/\S*access_token=fake-access-token/).to_return(status: 400, body: "{\"error\":{\"message\":\"Try again soon.\",\"code\":\"101\"}}")

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -207,21 +207,27 @@ class MetricsUnitTest < ActiveSupport::TestCase
     mocked_airbrake.verify
   end
 
-  test "should send exception to errbit and raise retry error when fb metrics returns a retryable error" do
+  test "should add error to tracing span and raise retry error when fb metrics returns a retryable error" do
     stub_facebook_oauth_request
-    WebMock.stub_request(:get, /graph.facebook.com\/\S*access_token=fake-access-token/).to_return(status: 400, body: "{\"error\":{\"message\":\"Missing client_id parameter.\",\"code\":\"101\"}}")
+    WebMock.stub_request(:get, /graph.facebook.com\/\S*access_token=fake-access-token/).to_return(status: 400, body: "{\"error\":{\"message\":\"Try again soon.\",\"code\":\"101\"}}")
 
-    mocked_airbrake = MiniTest::Mock.new
-    mocked_airbrake.expect :call, :return_value do |message, args|
-      message.match(/Facebook metrics error: 101 - Missing client_id parameter/) && args[:retryable]
+    mocked_tracer = MiniTest::Mock.new
+    mocked_tracer.expect :call, :return_value do |message, args|
+      message.match(/Facebook metrics error/) &&
+        args.keys.count == 5 &&
+        args[:attributes]['app.api_key'] == key.id &&
+        args[:attributes]['facebook.metrics.error.code'] == "101"
+        args[:attributes]['facebook.metrics.error.message'] == 'Try again soon.' &&
+        args[:attributes]['facebook.metrics.url'] == 'http://example.com/trending-article' &&
+        args[:attributes]['facebook.metrics.retryable']
     end
 
     assert_raises Pender::RetryLater do
-      PenderAirbrake.stub(:notify, mocked_airbrake) do
+      TracingService.stub(:set_error_status, mocked_tracer) do
         Metrics.get_metrics_from_facebook('http://example.com/trending-article', key.id)
       end
     end
-    mocked_airbrake.verify
+    mocked_tracer.verify
   end
 
   test "should lock facebook_app when rate limiting detected, and queue for retry" do


### PR DESCRIPTION
Try to quiet Errbit a bit, since we get a ton of non-actionable errors. They're useful for keeping track of what's happening, but sending to an exception reporting service seems like a lot.