### PR TITLE
Hardcode Sidekiq max retry when deciding to send to Errbit

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -9,7 +9,9 @@ unless PenderConfig.get('airbrake_host').blank?
   end
 
   Airbrake.add_filter do |notice|
-    if notice[:errors].any? { |error| error[:type] == 'Pender::RetryLater' } && notice[:params][:job] && notice[:params][:job].dig('retry_count').to_i < SIDEKIQ_CONFIG[:max_retries]
+    # Ideally we'd handle this filter as part of sidekiq_retries_exhausted in future. For now we magic number it
+    DEFAULT_MAX_SIDEKIQ_RETRIES = 25
+    if notice[:errors].any? { |error| error[:type] == 'Pender::RetryLater' } && notice[:params][:job] && notice[:params][:job].dig('retry_count').to_i < (SIDEKIQ_CONFIG[:max_retries] || DEFAULT_MAX_SIDEKIQ_RETRIES)
       notice.ignore!
     end
   end


### PR DESCRIPTION
Previously if a non-archiving job was hitting the max retries and the Sidekiq config for max retries was unset then that error reporting to Errbit woudl raise its own exception because it was trying to compare an integer to nil.

Trying to determine mathematically if we've hit the max number of retries in the filter is difficult, and we don't yet have access to Sidekiq variables since we're in the initializer. Ideally we would raise a final error by configuring sidekiq_retries_exhausted in each of the workers that handle it, but for now we can just hardcode the max number of retries to the max number of retries in Sidekiq and call it a day.