### PR TITLE
Use the normalized URL when accessing cache, and send to archivers

### DIFF
--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -22,6 +22,7 @@ module Api
           (render_url_invalid; return) unless is_url?(@url)
 
           @id = Media.get_id(@url)
+
           (render_uncached_media and return) if @refresh || Pender::Store.current.read(@id, :json).nil?
           respond_to do |format|
             format.html { render_as_html }
@@ -66,6 +67,8 @@ module Api
           rescue_block = Proc.new { |_e| render_url_invalid and return true }
           handle_exceptions(OpenSSL::SSL::SSLError, rescue_block, {url: @url, request: request}) do
             @media = Media.new(url: @url, request: request)
+            @url = @media.url
+            @id = Media.get_id(@url)
           end
         end and return true
         false

--- a/app/helpers/medias_helper.rb
+++ b/app/helpers/medias_helper.rb
@@ -123,7 +123,7 @@ module MediasHelper
   end
 
   def upload_images
-    id = Media.get_id(self.original_url)
+    id = Media.get_id(self.url)
     updates = {}
     [:author_picture, :picture].each do |attr|
       img_url = self.data.dig(attr)
@@ -133,7 +133,7 @@ module MediasHelper
         updates[attr] = self.data[attr]
       end
     end
-    Media.update_cache(self.original_url, updates) unless updates.empty?
+    Media.update_cache(self.url, updates) unless updates.empty?
   end
 
   def upload_image(id, attr, url)

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -5,15 +5,11 @@ module MediaArchiveOrgArchiver
     Media.declare_archiver('archive_org', [/^.*$/], :only)
   end
 
-  def archive_to_archive_org
-    self.class.send_to_archive_org_in_background(self.original_url, ApiKey.current&.id)
+  def archive_to_archive_org(url, key_id)
+    ArchiverWorker.perform_in(30.seconds, url, :archive_org, key_id)
   end
 
   module ClassMethods
-    def send_to_archive_org_in_background(url, key_id)
-      ArchiverWorker.perform_in(30.seconds, url, :archive_org, key_id)
-    end
-
     def send_to_archive_org(url, key_id, _supported = nil)
       handle_archiving_exceptions('archive_org', { url: url, key_id: key_id }) do
         encoded_uri = URI.encode(URI.decode(url))

--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -16,7 +16,7 @@ module MediaArchiver
     Media.enabled_archivers(available, self).each do |name, rule|
       rule[:patterns].each do |pattern|
         if (rule[:modifier] == :only && !pattern.match(url).nil?) || (rule[:modifier] == :except && pattern.match(url).nil?)
-          self.send("archive_to_#{name}")
+          self.public_send("archive_to_#{name}", url, ApiKey.current&.id)
         end
       end
     end
@@ -47,7 +47,7 @@ module MediaArchiver
   end
 
   def filter_archivers(archivers)
-    id = Media.get_id(original_url)
+    id = Media.get_id(self.url)
     data = Pender::Store.current.read(id, :json)
     return archivers if data.nil? || data.dig(:archives).nil?
     archivers - data[:archives].keys

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -5,15 +5,11 @@ module MediaPermaCcArchiver
     Media.declare_archiver('perma_cc', [/^.*$/], :only)
   end
 
-  def archive_to_perma_cc
-    self.class.send_to_perma_cc_in_background(self.original_url, ApiKey.current&.id)
+  def archive_to_perma_cc(url, key_id)
+    ArchiverWorker.perform_in(30.seconds, url, :perma_cc, key_id)
   end
 
   module ClassMethods
-    def send_to_perma_cc_in_background(url, key_id)
-      ArchiverWorker.perform_in(30.seconds, url, :perma_cc, key_id)
-    end
-
     def send_to_perma_cc(url, key_id, _supported = nil)
       handle_archiving_exceptions('perma_cc', { url: url, key_id: key_id }) do
         perma_cc_key = PenderConfig.get('perma_cc_key')

--- a/app/models/concerns/media_video_archiver.rb
+++ b/app/models/concerns/media_video_archiver.rb
@@ -7,15 +7,11 @@ module MediaVideoArchiver
     Media.declare_archiver('video', [/^.*$/], :only)
   end
 
-  def archive_to_video
-    self.class.archive_video_in_background(self.original_url, ApiKey.current&.id)
+  def archive_to_video(url, key_id)
+    ArchiverWorker.perform_async(url, :video_archiver, key_id)
   end
 
   module ClassMethods
-    def archive_video_in_background(url, key_id)
-      ArchiverWorker.perform_async(url, :video_archiver, key_id)
-    end
-
     def send_to_video_archiver(url, key_id, supported = nil)
       handle_archiving_exceptions('video_archiver', { url: url, key_id: key_id }) do
         supported = supported_video?(url, key_id) if supported.nil?

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -73,18 +73,18 @@ class Media
   end
 
   def as_json(options = {})
-    if options.delete(:force) || Pender::Store.current.read(Media.get_id(self.original_url), :json).nil?
+    if options.delete(:force) || Pender::Store.current.read(Media.get_id(self.url), :json).nil?
       handle_exceptions(self, StandardError) { self.parse }
       self.data['title'] = self.url if self.data['title'].blank?
       data = self.data.merge(Media.required_fields(self)).with_indifferent_access
       if data[:error].blank?
-        Pender::Store.current.write(Media.get_id(self.original_url), :json, cleanup_data_encoding(data))
+        Pender::Store.current.write(Media.get_id(self.url), :json, cleanup_data_encoding(data))
       end
       self.upload_images
     end
     self.archive(options.delete(:archivers))
-    Metrics.get_metrics_from_facebook_in_background(self.data, self.original_url, ApiKey.current&.id)
-    Pender::Store.current.read(Media.get_id(self.original_url), :json) || cleanup_data_encoding(data)
+    Metrics.get_metrics_from_facebook_in_background(self.data, self.url, ApiKey.current&.id)
+    Pender::Store.current.read(Media.get_id(self.url), :json) || cleanup_data_encoding(data)
   end
 
   PARSERS = [

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -11,11 +11,11 @@ module Metrics
       613, # Calls to graph_url_engagement_count have exceeded the rate of 10 calls per 3600 seconds
     ]
 
-    def get_metrics_from_facebook_in_background(data, original_url, key_id)
+    def get_metrics_from_facebook_in_background(data, url, key_id)
       facebook_id = data['uuid'] if is_a_facebook_post?(data)
       # Delaying a bit to prevent race condition where initial request that creates
       # record on Check API beats our metrics reporting
-      MetricsWorker.perform_in(10.seconds, original_url, key_id, 0, facebook_id)
+      MetricsWorker.perform_in(10.seconds, url, key_id, 0, facebook_id)
     end
 
     def get_metrics_from_facebook(url, key_id, count = 0, facebook_id = nil)

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -38,7 +38,7 @@ class MetricsIntegrationTest < ActiveSupport::TestCase
         end
         raise AllTestFacebookAppsRateLimited if attempts == allowed_attempts
 
-        id = Media.get_id(url)
+        id = Media.get_id(m.url)
         data = Pender::Store.current.read(id, :json)
 
         assert data['metrics']['facebook']['share_count'] > 0

--- a/test/models/parser/page_item_test.rb
+++ b/test/models/parser/page_item_test.rb
@@ -39,7 +39,6 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
   test "should parse url with arabic or already encoded chars" do
     urls = ['http://www.aljazeera.net/news/arabic/2016/10/19/تحذيرات-أممية-من-احتمال-نزوح-مليون-مدني-من-الموصل', 'http://www.aljazeera.net/news/arabic/2016/10/19/%D8%AA%D8%AD%D8%B0%D9%8A%D8%B1%D8%A7%D8%AA-%D8%A3%D9%85%D9%85%D9%8A%D8%A9-%D9%85%D9%86-%D8%A7%D8%AD%D8%AA%D9%85%D8%A7%D9%84-%D9%86%D8%B2%D9%88%D8%AD-%D9%85%D9%84%D9%8A%D9%88%D9%86-%D9%85%D8%AF%D9%86%D9%8A-%D9%85%D9%86-%D8%A7%D9%84%D9%85%D9%88%D8%B5%D9%84']
     urls.each do |url|
-      id = Media.get_id url
       m = create_media url: url
       data = m.as_json
       assert_equal 'تحذيرات أممية من احتمال نزوح مليون مدني من الموصل', data['title']
@@ -48,7 +47,7 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
       assert_equal '', data['username']
       assert_match /^https?:\/\/www\.aljazeera\.net$/, data['author_url']
       assert_nil data['error']
-      assert_match /\/medias\/#{id}\/picture/, data['picture']
+      assert_not_nil data['picture']
     end
   end
 
@@ -101,7 +100,6 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
 
   test "should parse url scheme http" do
     url = 'http://www.theatlantic.com/magazine/archive/2016/11/war-goes-viral/501125/'
-    id = Media.get_id url
     m = create_media url: url
     data = m.as_json
     assert_match 'War Goes Viral', data['title']
@@ -109,7 +107,7 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     assert !data['published_at'].blank?
     assert_match /Brooking.+Singer/, data['username']
     assert_match /https?:\/\/www.theatlantic.com/, data['author_url']
-    assert_match /\/#{id}\/picture/, data['picture']
+    assert_not_nil data['picture']
   end
 
   test "should parse url scheme https" do
@@ -306,7 +304,7 @@ class PageItemUnitTest < ActiveSupport::TestCase
   end
 
   test "does not set oembed data if there is an issue with returned oembed data" do
-    OembedItem.any_instance.stubs(:get_data).returns( 
+    OembedItem.any_instance.stubs(:get_data).returns(
       {
         raw: {
           oembed: {


### PR DESCRIPTION
Previously we were using the original URL to control cache. This causes
a problem because we use the normalized URL to communicate with Check API,
causing a problem because there would often not be a cache present for
the same link that was previously submitted if the normalized verison was
different than the original link.

This takes the approach of using normalized URLs for caching, so we have a
single source of truth that is compatible with the way that Check API stores
URLs from Pender.

This also sends the normalized URL to the archiving service, instead of
the original URL. Using the original URL for archiving because the archiving
service wasn't matching the Link saved to Check API, which was stripped previously by Pender. This commit brings in line
the URL parsing behavior so that we can get a match our archive to the
same link.

Lastly, the change in caching behavior caused some tests to fail, since before
we could just generate a caache ID from whatever URL we set. Now we can only
use the normalized URL to generate an accurate cache key, which happens both
within Media.new and media.as_json. To sidestep this in tests we can either
use a normalized URL from the start (often easier, if we don't intend to test
normalization though can be confusing when it fails) or generate the cache ID
like so: `m = Media.new(url); id = Media.get_id(m.url)`