### PR TITLE
Stop sending Redis information to Honeycomb

### DIFF
--- a/lib/pender_open_telemetry_config.rb
+++ b/lib/pender_open_telemetry_config.rb
@@ -19,7 +19,6 @@ module Pender
         config.use 'OpenTelemetry::Instrumentation::ConcurrentRuby'
         config.use 'OpenTelemetry::Instrumentation::Net::HTTP'
         config.use 'OpenTelemetry::Instrumentation::Rails'
-        config.use 'OpenTelemetry::Instrumentation::Redis'
         config.use 'OpenTelemetry::Instrumentation::Sidekiq'
       end
     end


### PR DESCRIPTION
Redis accounts for most of our events in Honeycomb, which we're often going over, but we don't find it very useful. This removes the instrumentation so that we no longer track that information.