### PR TITLE
Prevent exponential creation of metrics jobs on failure

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -83,7 +83,7 @@ class Media
       self.upload_images
     end
     self.archive(options.delete(:archivers))
-    Metrics.get_metrics_from_facebook_in_background(self.data, self.url, ApiKey.current&.id)
+    Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
     Pender::Store.current.read(Media.get_id(self.url), :json) || cleanup_data_encoding(data)
   end
 

--- a/app/workers/metrics_worker.rb
+++ b/app/workers/metrics_worker.rb
@@ -1,6 +1,10 @@
 class MetricsWorker
   include Sidekiq::Worker
 
+  # approximately ~17hrs from start
+  # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
+  sidekiq_options retry: 13
+
   def perform(url, key_id, count, facebook_id = nil)
     Metrics.get_metrics_from_facebook(url, key_id, count, facebook_id)
   end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -399,7 +399,7 @@ class ArchiverTest < ActiveSupport::TestCase
   test "should return false and add error to data when video archiving is not supported" do
     Media.unstub(:supported_video?)
     Media.any_instance.stubs(:parse)
-    Metrics.stubs(:get_metrics_from_facebook_in_background)
+    Metrics.stubs(:schedule_fetching_metrics_from_facebook)
 
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')

--- a/test/workers/archiver_worker_test.rb
+++ b/test/workers/archiver_worker_test.rb
@@ -3,7 +3,7 @@ require_relative '../test_helper'
 class ArchiverWorkerTest < ActiveSupport::TestCase
 
   test "should update cache when video archiving fails the max retries" do
-    Metrics.stubs(:get_metrics_from_facebook_in_background)
+    Metrics.stubs(:schedule_fetching_metrics_from_facebook)
     url = 'https://twitter.com/meedan/status/1202732707597307905'
     m = create_media url: url
     data = m.as_json
@@ -13,7 +13,7 @@ class ArchiverWorkerTest < ActiveSupport::TestCase
     data = m.as_json
     assert_equal LapisConstants::ErrorCodes::const_get('ARCHIVER_FAILURE'), data.dig('archives', 'video_archiver', 'error', 'code')
     assert_equal 'Test Archiver', data.dig('archives', 'video_archiver', 'error', 'message')
-    Metrics.unstub(:get_metrics_from_facebook_in_background)
+    Metrics.unstub(:schedule_fetching_metrics_from_facebook)
   end
 
   test "should update cache when Archive.org fails the max retries" do


### PR DESCRIPTION
Previously, in some cases we were exponentially creating new Metrics updates for URLs beacuse we queued the next update inside the existing background job, and relied on a passed variable to dictate when to stop scheduling jobs (that on error would not always be set).

This instead schedules all of our updates at the start (for ten days, the previous setting) and caps the amount of retries up to one day (according to the Sidekiq documentation for back-off timing). This means there will be a max of 130 metrics fetches per link. We could reduce this if we wanted (either by turning off retries entirely, or - maybe better - only retrying the first, since it's presumably most important). Curious for your thoughts @caiosba.

In theory we could stop passing count / update_number, but this would change the signature of the method, which would cause issues for currently queued Sidekiq jobs, so I just left it and used it for some logging.