### PR TITLE
Don't redefine constant

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -8,9 +8,9 @@ unless PenderConfig.get('airbrake_host').blank?
     config.performance_stats = false
   end
 
+  DEFAULT_MAX_SIDEKIQ_RETRIES = 25
   Airbrake.add_filter do |notice|
     # Ideally we'd handle this filter as part of sidekiq_retries_exhausted in future. For now we magic number it
-    DEFAULT_MAX_SIDEKIQ_RETRIES = 25
     if notice[:errors].any? { |error| error[:type] == 'Pender::RetryLater' } && notice[:params][:job] && notice[:params][:job].dig('retry_count').to_i < (SIDEKIQ_CONFIG[:max_retries] || DEFAULT_MAX_SIDEKIQ_RETRIES)
       notice.ignore!
     end


### PR DESCRIPTION
This constant was being redefined each time Airbrake hit the filter, which wasn't intended and was causing warnings in our logs. This moves the constant definition outside of the function scope.