### PR TITLE
Create TelegramItem parser and set title to URL

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -99,6 +99,7 @@ class Media
     Parser::DropboxItem,
     Parser::TiktokItem,
     Parser::TiktokProfile,
+    Parser::TelegramItem,
     Parser::KwaiItem,
     Parser::PageItem,
   ]

--- a/app/models/parser/telegram_item.rb
+++ b/app/models/parser/telegram_item.rb
@@ -1,0 +1,36 @@
+module Parser
+  class TelegramItem < Base
+    include ProviderInstagram
+
+    URL_REGEX = /^https?:\/\/(www\.)?(t|telegram)\.me\/(?<username>[^\/]+)\/(?<id>[0-9]+).*$/
+
+    class << self
+      def type
+        'telegram_item'.freeze
+      end
+
+      def patterns
+        [URL_REGEX]
+      end
+    end
+
+    private
+
+    # Main function for class
+    def parse_data_for_parser(doc, _original_url, _jsonld)
+      match = url.match(URL_REGEX)
+      id = match['id']
+      username = match['username']
+
+      set_data_field('title', url)
+      set_data_field('description', get_metadata_from_tag('og:description'), get_metadata_from_tag('twitter:description'))
+      set_data_field('username', username)
+      set_data_field('external_id', match['id'])
+      set_data_field('username', match['username'])
+      set_data_field('author_name', get_metadata_from_tag('og:title'), get_metadata_from_tag('twitter:title'))
+      set_data_field('picture', get_metadata_from_tag('og:image'), get_metadata_from_tag('twitter:image'))
+
+      parsed_data
+    end
+  end
+end

--- a/test/data/telegram-item.html
+++ b/test/data/telegram-item.html
@@ -1,0 +1,314 @@
+<!-- https://telegram.me/rechtsanwaeltin_beate_bahner/13285 -->
+<!DOCTYPE html>
+<html class="theme_dark"><head>
+  <meta charset="utf-8">
+  <title>Telegram: Contact @rechtsanwaeltin_beate_bahner</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <script>try{if(window.parent!=null&&window!=window.parent){window.parent.postMessage(JSON.stringify({eventType:'web_app_open_tg_link',eventData:{path_full:"\/rechtsanwaeltin_beate_bahner\/13285"}}),'https://web.telegram.org');}}catch(e){}</script>
+
+<meta property="og:title" content="Rechtsanwältin Beate Bahner">
+<meta property="og:image" content="https://cdn4.telegram-cdn.org/file/JiSDmlvWv8W53aKuY6twriFOlO2y7ALHWebS5tS8Ls84xhA9CYiCvIlbavSYvZLf0jWUoW4-d7zezr-8ODZxo14hIT4jaX8gXZrbw4w3rCCgZKmQYpIJ3uElqBKcW6wW8ndKXsTmbF9uYWOxtWHYdxOB-19-9mJ7k7_8DNZbgV1dm_V7nRwRJ8X5jKBTbuPwNq-9AomWIaOJ7cA-0Ll1e8fc2NnJxUTeopZUM5N9eqBLWzFLFdfWmG7bWn53Pn08IerzN-bbhc3gHzSNs6wOaWldBarA6gAwEBaxjnInEoOZwRR_uHnT_NIFAEcJEPCXbwXwmT2y5zZVzWJkoPgmWg.jpg">
+<meta property="og:site_name" content="Telegram">
+<meta property="og:description" content="❗ Pfizer bestätigt vor EU-Covid-Ausschuss: Covid-Impfpass beruhte auf großer Lüge❗
+
+Im Covid-Hearing des EU-Parlaments bestätigte ein führender Pfizer-Kopf: Es hat nie wissenschaftliche Daten dafür gegeben, wonach die mRNA-Behandlung die Weitergabe des Virus beschränken würde. Diese Annahme war aber Grundlage für Impfpropaganda und den „Grünen Pass“ der EU.
+„2G“ galt in Österreich für die gesamte Gesellschaft: Wer nicht geimpft war, der wurde von Österreichs Regierung sogar mit Hausarrest belegt. Am Dienstag schafft der holländische EU-Abgeordnete Rob Roos aber eindeutige Fakten: Es gab nie eine Evidenz dafür, dass die mRNA-Behandlung auch Infektionen behindern oder gar verhindern könnte. Das bestätige Janine Small, Präsidentin für internationale Entwicklungsmärkte von Pfizer.
+Keine Evidenz
+Man habe „wirklich mit der Geschwindigkeit der Wissenschaft vorankommen“ müssen, die die Erklärung von Small auf die Frage von Rob Roos. Und eindeutig: „Nein”, man hatte keinerlei Evidenz oder Daten, dass die Impfung eine Infektion verhindern könnte.
+Für Roos ist das „skandalös“. Er ist Vize-Chef der Fraktion der europäischen Konservativen und Reformer, in der etwa auch die Abgeordneten der AfD organisiert sind.
+Die Impfung damit zu bewerben, dass man auch andere schützen würde, war von Beginn weg ohne jegliche wissenschaftliche Grundlage. Von Sebastian Kurz, über Merkel zu Lauterbach, Mückstein und Olaf Scholz wurde diese Lüge von der Politik jedoch unzählige Male wiederholt. Ebenso von vielen Leitmedien und manchen „Experten“.
+
+Hier lesen Sie den vollständigen Bericht:
+
+👉🏼 https://tkp.at/2022/10/11/pfizer-bestaetigt-vor-eu-covid-ausschuss-covid-impfpass-beruhte-auf-grosser-luege/
+
+Kommentar: Was muss eigentlich noch alles ans Tageslicht kommen, bis Regierung und Presse auch darauf reagieren? Offensichtlich wird das alles inzwischen als gegeben hingenommen und stört den Mainstream nicht. Grundrechte Ade! Schauen wir mal, was mit dem Grünen Pass noch passiert, was uns noch zugemutet wird.
+
+Wenn Sie unsere Arbeit unterstützen wollen - Spendenkonto:
+🔹https://www.paypal.com/paypalme/afaev
+🔹 IBAN DE22830654080004273567
+
+👉🏼 Instagram
+https://www.instagram.com/anwaelte_afa/
+👉🏼 Twitter
+https://twitter.com/anwaelte_afa
+👉🏼 Facebook
+https://www.facebook.com/afaev.de
+👉🏼 Telegram
+www.t.me/Anwaelte_fuer_Aufklaerung
+👉🏼 Web
+www.afaev.de
+👉🏼 Gettr
+www.gettr.com/user/afaev">
+
+<meta property="twitter:title" content="Rechtsanwältin Beate Bahner">
+<meta property="twitter:image" content="https://cdn4.telegram-cdn.org/file/JiSDmlvWv8W53aKuY6twriFOlO2y7ALHWebS5tS8Ls84xhA9CYiCvIlbavSYvZLf0jWUoW4-d7zezr-8ODZxo14hIT4jaX8gXZrbw4w3rCCgZKmQYpIJ3uElqBKcW6wW8ndKXsTmbF9uYWOxtWHYdxOB-19-9mJ7k7_8DNZbgV1dm_V7nRwRJ8X5jKBTbuPwNq-9AomWIaOJ7cA-0Ll1e8fc2NnJxUTeopZUM5N9eqBLWzFLFdfWmG7bWn53Pn08IerzN-bbhc3gHzSNs6wOaWldBarA6gAwEBaxjnInEoOZwRR_uHnT_NIFAEcJEPCXbwXwmT2y5zZVzWJkoPgmWg.jpg">
+<meta property="twitter:site" content="@Telegram">
+
+<meta property="al:ios:app_store_id" content="686449807">
+<meta property="al:ios:app_name" content="Telegram Messenger">
+<meta property="al:ios:url" content="tg://resolve?domain=rechtsanwaeltin_beate_bahner&amp;post=13285">
+
+<meta property="al:android:url" content="tg://resolve?domain=rechtsanwaeltin_beate_bahner&amp;post=13285">
+<meta property="al:android:app_name" content="Telegram">
+<meta property="al:android:package" content="org.telegram.messenger">
+
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@Telegram">
+<meta name="twitter:description" content="❗ Pfizer bestätigt vor EU-Covid-Ausschuss: Covid-Impfpass beruhte auf großer Lüge❗
+
+Im Covid-Hearing des EU-Parlaments bestätigte ein führender Pfizer-Kopf: Es hat nie wissenschaftliche Daten dafür gegeben, wonach die mRNA-Behandlung die Weitergabe des Virus beschränken würde. Diese Annahme war aber Grundlage für Impfpropaganda und den „Grünen Pass“ der EU.
+„2G“ galt in Österreich für die gesamte Gesellschaft: Wer nicht geimpft war, der wurde von Österreichs Regierung sogar mit Hausarrest belegt. Am Dienstag schafft der holländische EU-Abgeordnete Rob Roos aber eindeutige Fakten: Es gab nie eine Evidenz dafür, dass die mRNA-Behandlung auch Infektionen behindern oder gar verhindern könnte. Das bestätige Janine Small, Präsidentin für internationale Entwicklungsmärkte von Pfizer.
+Keine Evidenz
+Man habe „wirklich mit der Geschwindigkeit der Wissenschaft vorankommen“ müssen, die die Erklärung von Small auf die Frage von Rob Roos. Und eindeutig: „Nein”, man hatte keinerlei Evidenz oder Daten, dass die Impfung eine Infektion verhindern könnte.
+Für Roos ist das „skandalös“. Er ist Vize-Chef der Fraktion der europäischen Konservativen und Reformer, in der etwa auch die Abgeordneten der AfD organisiert sind.
+Die Impfung damit zu bewerben, dass man auch andere schützen würde, war von Beginn weg ohne jegliche wissenschaftliche Grundlage. Von Sebastian Kurz, über Merkel zu Lauterbach, Mückstein und Olaf Scholz wurde diese Lüge von der Politik jedoch unzählige Male wiederholt. Ebenso von vielen Leitmedien und manchen „Experten“.
+
+Hier lesen Sie den vollständigen Bericht:
+
+👉🏼 https://tkp.at/2022/10/11/pfizer-bestaetigt-vor-eu-covid-ausschuss-covid-impfpass-beruhte-auf-grosser-luege/
+
+Kommentar: Was muss eigentlich noch alles ans Tageslicht kommen, bis Regierung und Presse auch darauf reagieren? Offensichtlich wird das alles inzwischen als gegeben hingenommen und stört den Mainstream nicht. Grundrechte Ade! Schauen wir mal, was mit dem Grünen Pass noch passiert, was uns noch zugemutet wird.
+
+Wenn Sie unsere Arbeit unterstützen wollen - Spendenkonto:
+🔹https://www.paypal.com/paypalme/afaev
+🔹 IBAN DE22830654080004273567
+
+👉🏼 Instagram
+https://www.instagram.com/anwaelte_afa/
+👉🏼 Twitter
+https://twitter.com/anwaelte_afa
+👉🏼 Facebook
+https://www.facebook.com/afaev.de
+👉🏼 Telegram
+www.t.me/Anwaelte_fuer_Aufklaerung
+👉🏼 Web
+www.afaev.de
+👉🏼 Gettr
+www.gettr.com/user/afaev
+">
+<meta name="twitter:app:name:iphone" content="Telegram Messenger">
+<meta name="twitter:app:id:iphone" content="686449807">
+<meta name="twitter:app:url:iphone" content="tg://resolve?domain=rechtsanwaeltin_beate_bahner&amp;post=13285">
+<meta name="twitter:app:name:ipad" content="Telegram Messenger">
+<meta name="twitter:app:id:ipad" content="686449807">
+<meta name="twitter:app:url:ipad" content="tg://resolve?domain=rechtsanwaeltin_beate_bahner&amp;post=13285">
+<meta name="twitter:app:name:googleplay" content="Telegram">
+<meta name="twitter:app:id:googleplay" content="org.telegram.messenger">
+<meta name="twitter:app:url:googleplay" content="https://t.me/rechtsanwaeltin_beate_bahner/13285">
+
+<meta name="apple-itunes-app" content="app-id=686449807, app-argument: tg://resolve?domain=rechtsanwaeltin_beate_bahner&amp;post=13285">
+  <script>window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches&&document.documentElement&&document.documentElement.classList&&document.documentElement.classList.add('theme_dark');</script>
+  <link rel="icon" type="image/svg+xml" href="//telegram.org/img/website_icon.svg?4">
+<link rel="apple-touch-icon" sizes="180x180" href="//telegram.org/img/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="//telegram.org/img/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="//telegram.org/img/favicon-16x16.png">
+<link rel="alternate icon" href="//telegram.org/img/favicon.ico" type="image/x-icon">
+  <link href="//telegram.org/css/font-roboto.css?1" rel="stylesheet" type="text/css">
+  <!--link href="/css/myriad.css" rel="stylesheet"-->
+  <link href="//telegram.org/css/bootstrap.min.css?3" rel="stylesheet">
+  <link href="//telegram.org/css/telegram.css?234" rel="stylesheet" media="screen">
+</head>
+<body class="sticky_actions">
+    <div class="tgme_background_wrap">
+  <canvas id="tgme_background" class="tgme_background default" width="50" height="50" data-colors="dbddbb,6ba587,d5d88d,88b884"></canvas>
+  <div class="tgme_background_pattern default"></div>
+</div>
+  <div class="tgme_page_wrap">
+    <div class="tgme_head_wrap">
+      <div class="tgme_head">
+        <a href="//telegram.org/" class="tgme_head_brand">
+          <svg class="tgme_logo" height="34" viewBox="0 0 133 34" width="133" xmlns="http://www.w3.org/2000/svg">
+            <g fill="none" fill-rule="evenodd">
+              <circle cx="17" cy="17" fill="var(--accent-btn-color)" r="17"></circle><path d="m7.06510669 16.9258959c5.22739451-2.1065178 8.71314291-3.4952633 10.45724521-4.1662364 4.9797665-1.9157646 6.0145193-2.2485535 6.6889567-2.2595423.1483363-.0024169.480005.0315855.6948461.192827.1814076.1361492.23132.3200675.2552048.4491519.0238847.1290844.0536269.4231419.0299841.65291-.2698553 2.6225356-1.4375148 8.986738-2.0315537 11.9240228-.2513602 1.2428753-.7499132 1.5088847-1.2290685 1.5496672-1.0413153.0886298-1.8284257-.4857912-2.8369905-1.0972863-1.5782048-.9568691-2.5327083-1.3984317-4.0646293-2.3321592-1.7703998-1.0790837-.212559-1.583655.7963867-2.5529189.2640459-.2536609 4.7753906-4.3097041 4.755976-4.431706-.0070494-.0442984-.1409018-.481649-.2457499-.5678447-.104848-.0861957-.2595946-.0567202-.3712641-.033278-.1582881.0332286-2.6794907 1.5745492-7.5636077 4.6239616-.715635.4545193-1.3638349.6759763-1.9445998.6643712-.64024672-.0127938-1.87182452-.334829-2.78737602-.6100966-1.12296117-.3376271-1.53748501-.4966332-1.45976769-1.0700283.04048-.2986597.32581586-.610598.8560076-.935815z" fill="#fff"></path><path d="m49.4 24v-12.562h-4.224v-2.266h11.198v2.266h-4.268v12.562zm16.094-4.598h-7.172c.066 1.936 1.562 2.772 3.3 2.772 1.254 0 2.134-.198 2.97-.484l.396 1.848c-.924.396-2.2.682-3.74.682-3.476 0-5.522-2.134-5.522-5.412 0-2.97 1.804-5.764 5.236-5.764 3.476 0 4.62 2.86 4.62 5.214 0 .506-.044.902-.088 1.144zm-7.172-1.892h4.708c.022-.99-.418-2.618-2.222-2.618-1.672 0-2.376 1.518-2.486 2.618zm9.538 6.49v-15.62h2.706v15.62zm14.84-4.598h-7.172c.066 1.936 1.562 2.772 3.3 2.772 1.254 0 2.134-.198 2.97-.484l.396 1.848c-.924.396-2.2.682-3.74.682-3.476 0-5.522-2.134-5.522-5.412 0-2.97 1.804-5.764 5.236-5.764 3.476 0 4.62 2.86 4.62 5.214 0 .506-.044.902-.088 1.144zm-7.172-1.892h4.708c.022-.99-.418-2.618-2.222-2.618-1.672 0-2.376 1.518-2.486 2.618zm19.24-1.144v6.072c0 2.244-.462 3.85-1.584 4.862-1.1.99-2.662 1.298-4.136 1.298-1.364 0-2.816-.308-3.74-.858l.594-2.046c.682.396 1.826.814 3.124.814 1.76 0 3.08-.924 3.08-3.234v-.924h-.044c-.616.946-1.694 1.584-3.124 1.584-2.662 0-4.554-2.2-4.554-5.236 0-3.52 2.288-5.654 4.862-5.654 1.65 0 2.596.792 3.102 1.672h.044l.11-1.43h2.354c-.044.726-.088 1.606-.088 3.08zm-2.706 2.948v-1.738c0-.264-.022-.506-.088-.726-.286-.99-1.056-1.738-2.2-1.738-1.518 0-2.64 1.32-2.64 3.498 0 1.826.924 3.3 2.618 3.3 1.012 0 1.892-.66 2.2-1.65.088-.264.11-.638.11-.946zm5.622 4.686v-7.26c0-1.452-.022-2.508-.088-3.454h2.332l.11 2.024h.066c.528-1.496 1.782-2.266 2.948-2.266.264 0 .418.022.638.066v2.53c-.242-.044-.484-.066-.814-.066-1.276 0-2.178.814-2.42 2.046-.044.242-.066.528-.066.814v5.566zm16.05-6.424v3.85c0 .968.044 1.914.176 2.574h-2.442l-.198-1.188h-.066c-.638.836-1.76 1.43-3.168 1.43-2.156 0-3.366-1.562-3.366-3.19 0-2.684 2.398-4.07 6.358-4.048v-.176c0-.704-.286-1.87-2.178-1.87-1.056 0-2.156.33-2.882.792l-.528-1.76c.792-.484 2.178-.946 3.872-.946 3.432 0 4.422 2.178 4.422 4.532zm-2.64 2.662v-1.474c-1.914-.022-3.74.374-3.74 2.002 0 1.056.682 1.54 1.54 1.54 1.1 0 1.87-.704 2.134-1.474.066-.198.066-.396.066-.594zm5.6 3.762v-7.524c0-1.232-.044-2.266-.088-3.19h2.31l.132 1.584h.066c.506-.836 1.474-1.826 3.3-1.826 1.408 0 2.508.792 2.97 1.98h.044c.374-.594.814-1.034 1.298-1.342.616-.418 1.298-.638 2.2-.638 1.76 0 3.564 1.21 3.564 4.642v6.314h-2.64v-5.918c0-1.782-.616-2.838-1.914-2.838-.924 0-1.606.66-1.892 1.43-.088.242-.132.594-.132.902v6.424h-2.64v-6.204c0-1.496-.594-2.552-1.848-2.552-1.012 0-1.694.792-1.958 1.518-.088.286-.132.594-.132.902v6.336z" fill="var(--tme-logo-color)" fill-rule="nonzero"></path>
+            </g>
+          </svg>
+        </a>
+        <a class="tgme_head_right_btn" href="//telegram.org/dl?tme=9c6ffd5537746482b4_11533950295881217303">
+          Download for Mac
+        </a>
+      </div>
+    </div>
+    <div class="tgme_body_wrap">
+      <div class="tgme_page tgme_page_post">
+        <div class="tgme_page_widget_wrap" id="widget">
+<div class="tgme_page_widget">
+  <iframe id="telegram-post-rechtsanwaeltin_beate_bahner-13285" src="https://t.me/rechtsanwaeltin_beate_bahner/13285?embed=1&amp;mode=tme" width="100%" height="" frameborder="0" scrolling="no" style="overflow: hidden; border: none; min-width: 320px; height: 1891px;"></iframe><script src="https://telegram.org/js/telegram-widget.js?21" data-telegram-post="rechtsanwaeltin_beate_bahner/13285" data-mode="tme" data-width="100%"></script>
+</div>
+</div>
+      </div>
+      <div class="tgme_page_widget_actions_wrap stuck" id="widget_actions_wrap">
+<div class="tgme_page_widget_actions" id="widget_actions">
+  <div class="tgme_page_widget_actions_cont">
+    <div class="tgme_page_widget_action_right">
+      <div class="tgme_page_context_btn"><a class="tgme_action_button_new" href="/s/rechtsanwaeltin_beate_bahner/13285"><svg class="tgme_action_button_icon web_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><g class="icon_body" fill="none" stroke-width="2"><g><path d="M12 3c-2.386 0-4.677.949-6.364 2.636C3.949 7.323 3 9.614 3 12c0 2.386.949 4.677 2.636 6.364C7.323 20.051 9.614 21 12 21c2.386 0 4.677-.949 6.364-2.636C20.051 16.677 21 14.386 21 12c0-2.386-.949-4.677-2.636-6.364C16.677 3.949 14.386 3 12 3zM20.5 15h-17m17-6h-17"></path><path d="M12 21c-4.971 0-9-4.029-9-9s4.029-9 9-9" stroke-linecap="round"></path><path d="M12 21c-1-.5-3.5-4.029-3.5-9S11 3.5 12 3M12 21c1-.5 3.5-4.029 3.5-9S13 3.5 12 3" stroke-linecap="round"></path></g><g><path d="M36 3c-2.386 0-4.677.949-6.364 2.636C27.949 7.323 27 9.614 27 12c0 2.386.949 4.677 2.636 6.364C31.323 20.051 33.614 21 36 21c2.386 0 4.677-.949 6.364-2.636C44.051 16.677 45 14.386 45 12c0-2.386-.949-4.677-2.636-6.364C40.677 3.949 38.386 3 36 3zM44.5 15h-17m17-6h-17"></path><path d="M36 21c-4.942-.004-8.96-4.029-8.96-9S31.058 3.004 36 3" stroke-linecap="round"></path><path d="M36 21c-.986-.5-3.45-4.029-3.45-9S35.014 3.5 36 3M36 21c1.029-.496 3.54-4.029 3.54-9S37.029 3.496 36 3" stroke-linecap="round"></path></g><g><path d="M60 3c-2.386 0-4.677.949-6.364 2.636C51.949 7.323 51 9.614 51 12c0 2.386.949 4.677 2.636 6.364C55.323 20.051 57.614 21 60 21c2.386 0 4.677-.949 6.364-2.636C68.051 16.677 69 14.386 69 12c0-2.386-.949-4.677-2.636-6.364C64.677 3.949 62.386 3 60 3zM68.5 15h-17m17-6h-17"></path><path d="M60 21c-4.841-.016-8.82-4.029-8.82-9S55.159 3.016 60 3" stroke-linecap="round"></path><path d="M60 21c-.934-.5-3.27-4.029-3.27-9S59.066 3.5 60 3M60 21c1.13-.484 3.68-4.029 3.68-9S61.13 3.484 60 3" stroke-linecap="round"></path></g><g><path d="M84 3c-2.386 0-4.677.949-6.364 2.636C75.949 7.323 75 9.614 75 12c0 2.386.949 4.677 2.636 6.364C79.323 20.051 81.614 21 84 21c2.386 0 4.677-.949 6.364-2.636C92.051 16.677 93 14.386 93 12c0-2.386-.949-4.677-2.636-6.364C88.677 3.949 86.386 3 84 3zM92.5 15h-17m17-6h-17"></path><path d="M84 21c-4.633-.043-8.532-4.029-8.532-9S79.367 3.043 84 3" stroke-linecap="round"></path><path d="M84 21c-.83-.5-2.904-4.029-2.904-9S83.17 3.5 84 3M84 21c1.338-.457 3.968-4.029 3.968-9S85.338 3.457 84 3" stroke-linecap="round"></path></g><g><path d="M108 3c-2.386 0-4.677.949-6.364 2.636C99.949 7.323 99 9.614 99 12c0 2.386.949 4.677 2.636 6.364C103.323 20.051 105.614 21 108 21c2.386 0 4.677-.949 6.364-2.636C116.051 16.677 117 14.386 117 12c0-2.386-.949-4.677-2.636-6.364C112.677 3.949 110.386 3 108 3zM116.5 15h-17m17-6h-17"></path><path d="M108 21c-4.275-.088-8.037-4.029-8.037-9s3.762-8.912 8.037-9" stroke-linecap="round"></path><path d="M108 21c-.65-.5-2.274-4.029-2.274-9S107.35 3.5 108 3M108 21c1.696-.412 4.463-4.029 4.463-9S109.696 3.412 108 3" stroke-linecap="round"></path></g><g><path d="M132 3c-2.386 0-4.677.949-6.364 2.636C123.949 7.323 123 9.614 123 12c0 2.386.949 4.677 2.636 6.364C127.323 20.051 129.614 21 132 21c2.386 0 4.677-.949 6.364-2.636C140.051 16.677 141 14.386 141 12c0-2.386-.949-4.677-2.636-6.364C136.677 3.949 134.386 3 132 3zM140.5 15h-17m17-6h-17"></path><path d="M132 21c-3.751-.154-7.311-4.029-7.311-9s3.56-8.846 7.311-9" stroke-linecap="round"></path><path d="M132 21c-.386-.5-1.35-4.029-1.35-9s.964-8.5 1.35-9M132 21c2.22-.346 5.189-4.029 5.189-9S134.22 3.346 132 3" stroke-linecap="round"></path></g><g><path d="M156 3c-2.386 0-4.677.949-6.364 2.636C147.949 7.323 147 9.614 147 12c0 2.386.949 4.677 2.636 6.364C151.323 20.051 153.614 21 156 21c2.386 0 4.677-.949 6.364-2.636C164.051 16.677 165 14.386 165 12c0-2.386-.949-4.677-2.636-6.364C160.677 3.949 158.386 3 156 3zM164.5 15h-17m17-6h-17"></path><path d="M156 21c-3.155-.229-6.485-4.029-6.485-9s3.33-8.771 6.485-9" stroke-linecap="round"></path><path d="M156 21c-.085-.5-.299-4.029-.299-9s.214-8.5.299-9M156 21c2.816-.271 6.015-4.029 6.015-9S158.816 3.271 156 3" stroke-linecap="round"></path></g><g><path d="M180 3c-2.386 0-4.677.949-6.364 2.636C171.949 7.323 171 9.614 171 12c0 2.386.949 4.677 2.636 6.364C175.323 20.051 177.614 21 180 21c2.386 0 4.677-.949 6.364-2.636C188.051 16.677 189 14.386 189 12c0-2.386-.949-4.677-2.636-6.364C184.677 3.949 182.386 3 180 3zM188.5 15h-17m17-6h-17"></path><path d="M180 21c-2.627-.295-5.753-4.029-5.753-9s3.126-8.705 5.753-9M180 21c.181-.5.633-4.029.633-9s-.452-8.5-.633-9" stroke-linecap="round"></path><path d="M180 21c3.344-.205 6.747-4.029 6.747-9S183.344 3.205 180 3" stroke-linecap="round"></path></g><g><path d="M204 3c-2.386 0-4.677.949-6.364 2.636C195.949 7.323 195 9.614 195 12c0 2.386.949 4.677 2.636 6.364C199.323 20.051 201.614 21 204 21c2.386 0 4.677-.949 6.364-2.636C212.051 16.677 213 14.386 213 12c0-2.386-.949-4.677-2.636-6.364C208.677 3.949 206.386 3 204 3zM212.5 15h-17m17-6h-17"></path><path d="M204 21c-2.21-.348-5.176-4.029-5.176-9S201.79 3.348 204 3M204 21c.39-.5 1.367-4.029 1.367-9S204.39 3.5 204 3" stroke-linecap="round"></path><path d="M204 21c3.761-.152 7.324-4.029 7.324-9S207.761 3.152 204 3" stroke-linecap="round"></path></g><g><path d="M228 3c-2.386 0-4.677.949-6.364 2.636C219.949 7.323 219 9.614 219 12c0 2.386.949 4.677 2.636 6.364C223.323 20.051 225.614 21 228 21c2.386 0 4.677-.949 6.364-2.636C236.051 16.677 237 14.386 237 12c0-2.386-.949-4.677-2.636-6.364C232.677 3.949 230.386 3 228 3zM236.5 15h-17m17-6h-17"></path><path d="M228 21c-1.891-.388-4.734-4.029-4.734-9s2.843-8.612 4.734-9M228 21c.551-.5 1.929-4.029 1.929-9S228.551 3.5 228 3" stroke-linecap="round"></path><path d="M228 21c4.08-.112 7.766-4.029 7.766-9S232.08 3.112 228 3" stroke-linecap="round"></path></g><g><path d="M252 3c-2.386 0-4.677.949-6.364 2.636C243.949 7.323 243 9.614 243 12c0 2.386.949 4.677 2.636 6.364C247.323 20.051 249.614 21 252 21c2.386 0 4.677-.949 6.364-2.636C260.051 16.677 261 14.386 261 12c0-2.386-.949-4.677-2.636-6.364C256.677 3.949 254.386 3 252 3zM260.5 15h-17m17-6h-17"></path><path d="M252 21c-1.647-.419-4.396-4.029-4.396-9s2.749-8.581 4.396-9M252 21c.674-.5 2.36-4.029 2.36-9s-1.686-8.5-2.36-9" stroke-linecap="round"></path><path d="M252 21c4.324-.081 8.104-4.029 8.104-9s-3.78-8.919-8.104-9" stroke-linecap="round"></path></g><g><path d="M276 3c-2.386 0-4.677.949-6.364 2.636C267.949 7.323 267 9.614 267 12c0 2.386.949 4.677 2.636 6.364C271.323 20.051 273.614 21 276 21c2.386 0 4.677-.949 6.364-2.636C284.051 16.677 285 14.386 285 12c0-2.386-.949-4.677-2.636-6.364C280.677 3.949 278.386 3 276 3zM284.5 15h-17m17-6h-17"></path><path d="M276 21c-1.459-.442-4.135-4.029-4.135-9s2.676-8.558 4.135-9M276 21c.769-.5 2.691-4.029 2.691-9S276.769 3.5 276 3" stroke-linecap="round"></path><path d="M276 21c4.512-.058 8.365-4.029 8.365-9S280.512 3.058 276 3" stroke-linecap="round"></path></g><g><path d="M300 3c-2.386 0-4.677.949-6.364 2.636C291.949 7.323 291 9.614 291 12c0 2.386.949 4.677 2.636 6.364C295.323 20.051 297.614 21 300 21c2.386 0 4.677-.949 6.364-2.636C308.051 16.677 309 14.386 309 12c0-2.386-.949-4.677-2.636-6.364C304.677 3.949 302.386 3 300 3zM308.5 15h-17m17-6h-17"></path><path d="M300 21c-1.315-.46-3.936-4.029-3.936-9s2.621-8.54 3.936-9M300 21c.842-.5 2.945-4.029 2.945-9S300.842 3.5 300 3" stroke-linecap="round"></path><path d="M300 21c4.656-.04 8.564-4.029 8.564-9S304.656 3.04 300 3" stroke-linecap="round"></path></g><g><path d="M324 3c-2.386 0-4.677.949-6.364 2.636C315.949 7.323 315 9.614 315 12c0 2.386.949 4.677 2.636 6.364C319.323 20.051 321.614 21 324 21c2.386 0 4.677-.949 6.364-2.636C332.051 16.677 333 14.386 333 12c0-2.386-.949-4.677-2.636-6.364C328.677 3.949 326.386 3 324 3zM332.5 15h-17m17-6h-17"></path><path d="M324 21c-1.205-.474-3.784-4.029-3.784-9s2.579-8.526 3.784-9M324 21c.897-.5 3.138-4.029 3.138-9S324.897 3.5 324 3" stroke-linecap="round"></path><path d="M324 21c4.766-.026 8.716-4.029 8.716-9s-3.95-8.974-8.716-9" stroke-linecap="round"></path></g><g><path d="M348 3c-2.386 0-4.677.949-6.364 2.636C339.949 7.323 339 9.614 339 12c0 2.386.949 4.677 2.636 6.364C343.323 20.051 345.614 21 348 21c2.386 0 4.677-.949 6.364-2.636C356.051 16.677 357 14.386 357 12c0-2.386-.949-4.677-2.636-6.364C352.677 3.949 350.386 3 348 3zM356.5 15h-17m17-6h-17"></path><path d="M348 21c-1.124-.484-3.672-4.029-3.672-9s2.548-8.516 3.672-9M348 21c.938-.5 3.282-4.029 3.282-9S348.938 3.5 348 3" stroke-linecap="round"></path><path d="M348 21c4.847-.016 8.828-4.029 8.828-9S352.847 3.016 348 3" stroke-linecap="round"></path></g><g><path d="M372 3c-2.386 0-4.677.949-6.364 2.636C363.949 7.323 363 9.614 363 12c0 2.386.949 4.677 2.636 6.364C367.323 20.051 369.614 21 372 21c2.386 0 4.677-.949 6.364-2.636C380.051 16.677 381 14.386 381 12c0-2.386-.949-4.677-2.636-6.364C376.677 3.949 374.386 3 372 3zM380.5 15h-17m17-6h-17"></path><path d="M372 21c-1.066-.492-3.592-4.029-3.592-9s2.526-8.508 3.592-9M372 21c.967-.5 3.384-4.029 3.384-9S372.967 3.5 372 3" stroke-linecap="round"></path><path d="M372 21c4.905-.008 8.908-4.029 8.908-9S376.905 3.008 372 3" stroke-linecap="round"></path></g><g><path d="M396 3c-2.386 0-4.677.949-6.364 2.636C387.949 7.323 387 9.614 387 12c0 2.386.949 4.677 2.636 6.364C391.323 20.051 393.614 21 396 21c2.386 0 4.677-.949 6.364-2.636C404.051 16.677 405 14.386 405 12c0-2.386-.949-4.677-2.636-6.364C400.677 3.949 398.386 3 396 3zM404.5 15h-17m17-6h-17"></path><path d="M396 21c-1.028-.496-3.539-4.029-3.539-9s2.511-8.504 3.539-9M396 21c.986-.5 3.451-4.029 3.451-9S396.986 3.5 396 3" stroke-linecap="round"></path><path d="M396 21c4.943-.004 8.961-4.029 8.961-9S400.943 3.004 396 3" stroke-linecap="round"></path></g><g><path d="M420 3c-2.386 0-4.677.949-6.364 2.636C411.949 7.323 411 9.614 411 12c0 2.386.949 4.677 2.636 6.364C415.323 20.051 417.614 21 420 21c2.386 0 4.677-.949 6.364-2.636C428.051 16.677 429 14.386 429 12c0-2.386-.949-4.677-2.636-6.364C424.677 3.949 422.386 3 420 3zM428.5 15h-17m17-6h-17"></path><path d="M420 21c-1.007-.499-3.509-4.029-3.509-9s2.502-8.501 3.509-9M420 21c.997-.5 3.488-4.029 3.488-9S420.997 3.5 420 3" stroke-linecap="round"></path><path d="M420 21c4.964-.001 8.991-4.029 8.991-9S424.964 3.001 420 3" stroke-linecap="round"></path></g><g><path d="M444 3c-2.386 0-4.677.949-6.364 2.636C435.949 7.323 435 9.614 435 12c0 2.386.949 4.677 2.636 6.364C439.323 20.051 441.614 21 444 21c2.386 0 4.677-.949 6.364-2.636C452.051 16.677 453 14.386 453 12c0-2.386-.949-4.677-2.636-6.364C448.677 3.949 446.386 3 444 3zM452.5 15h-17m17-6h-17"></path><path d="M444 21c-1-.5-3.5-4.029-3.5-9s2.5-8.5 3.5-9M444 21c1-.5 3.5-4.029 3.5-9S445 3.5 444 3" stroke-linecap="round"></path><path d="M444 21c4.971 0 9-4.029 9-9s-4.029-9-9-9" stroke-linecap="round"></path></g></g></svg><span class="tgme_action_button_label">Context</span></a></div>
+    </div>
+    <div class="tgme_page_widget_action_left">
+      <div class="tgme_page_embed_btn">
+        <a class="tgme_action_button_new" onclick="return toggleEmbed();"><svg class="tgme_action_button_icon embed_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path class="icon_body" d="M8 16.5L3.5 12 8 7.5m8 9l4.5-4.5L16 7.5M31.83 16.5l-4.5-4.5 4.5-4.5m8.34 9l4.5-4.5-4.5-4.5M55.085 16.5l-4.5-4.5 4.5-4.5m9.83 9l4.5-4.5-4.5-4.5M78.449 16.5l-4.5-4.5 4.5-4.5m11.102 9l4.5-4.5-4.5-4.5M102.158 16.5l-4.5-4.5 4.5-4.5m11.684 9l4.5-4.5-4.5-4.5M126.033 16.5l-4.5-4.5 4.5-4.5m11.934 9l4.5-4.5-4.5-4.5M150 16.5l-4.5-4.5 4.5-4.5m12 9l4.5-4.5-4.5-4.5M174.098 16.5l-4.5-4.5 4.5-4.5m11.804 9l4.5-4.5-4.5-4.5M198.526 16.5l-4.5-4.5 4.5-4.5m10.948 9l4.5-4.5-4.5-4.5M223.372 16.5l-4.5-4.5 4.5-4.5m9.256 9l4.5-4.5-4.5-4.5M248.086 16.5l-4.5-4.5 4.5-4.5m7.828 9l4.5-4.5-4.5-4.5M272.511 16.5l-4.5-4.5 4.5-4.5m6.978 9l4.5-4.5-4.5-4.5M296.762 16.5l-4.5-4.5 4.5-4.5m6.476 9l4.5-4.5-4.5-4.5M320.906 16.5l-4.5-4.5 4.5-4.5m6.188 9l4.5-4.5-4.5-4.5M344.979 16.5l-4.5-4.5 4.5-4.5m6.042 9l4.5-4.5-4.5-4.5M369 16.5l-4.5-4.5 4.5-4.5m6 9l4.5-4.5-4.5-4.5M392.989 16.5l-4.5-4.5 4.5-4.5m6.022 9l4.5-4.5-4.5-4.5M416.95 16.5l-4.5-4.5 4.5-4.5m6.1 9l4.5-4.5-4.5-4.5M440.866 16.5l-4.5-4.5 4.5-4.5m6.268 9l4.5-4.5-4.5-4.5M464.722 16.5l-4.5-4.5 4.5-4.5m6.556 9l4.5-4.5-4.5-4.5M488.543 16.5l-4.5-4.5 4.5-4.5m6.914 9l4.5-4.5-4.5-4.5M512.386 16.5l-4.5-4.5 4.5-4.5m7.228 9l4.5-4.5-4.5-4.5M536.27 16.5l-4.5-4.5 4.5-4.5m7.46 9l4.5-4.5-4.5-4.5M560.186 16.5l-4.5-4.5 4.5-4.5m7.628 9l4.5-4.5-4.5-4.5M584.124 16.5l-4.5-4.5 4.5-4.5m7.752 9l4.5-4.5-4.5-4.5M608.079 16.5l-4.5-4.5 4.5-4.5m7.842 9l4.5-4.5-4.5-4.5M632.047 16.5l-4.5-4.5 4.5-4.5m7.906 9l4.5-4.5-4.5-4.5M656.025 16.5l-4.5-4.5 4.5-4.5m7.95 9l4.5-4.5-4.5-4.5M680.01 16.5l-4.5-4.5 4.5-4.5m7.98 9l4.5-4.5-4.5-4.5M704.002 16.5l-4.5-4.5 4.5-4.5m7.996 9l4.5-4.5-4.5-4.5M728 16.5l-4.5-4.5 4.5-4.5m8 9l4.5-4.5-4.5-4.5" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg><span class="tgme_action_button_label">Embed</span></a>
+      </div>
+    </div>
+    <div class="tgme_page_widget_action">
+      <a class="tgme_action_button_new shine" href="tg://resolve?domain=rechtsanwaeltin_beate_bahner&amp;post=13285">View In Channel</a>
+    </div>
+    <div class="tgme_page_embed_action">
+      <textarea class="tgme_page_embed_code" rows="3" id="embed_code_field" readonly="">&lt;script async src="https://telegram.org/js/telegram-widget.js?21" data-telegram-post="rechtsanwaeltin_beate_bahner/13285" data-width="100%"&gt;&lt;/script&gt;</textarea>
+      <div class="tgme_page_copy_action">
+        <a class="tgme_action_button_new" id="widget_copy" onclick="return copyEmbedCode(this);"><svg class="tgme_action_button_icon copy_icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><g class="icon_body" fill="none" stroke-width="2"><g><path d="M8.5 6h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707V7c0-.265.105-.52.293-.707C7.98 6.105 8.235 6 8.5 6"></path><path d="M15.5 2h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M32.33 5.83h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M39.67 2.17h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M55.585 5.085h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M64.415 2.915h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M78.949 4.449h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M89.051 3.551h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M102.658 4.158h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M113.342 3.842h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M126.533 4.033h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M137.467 3.967h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M150.5 4h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707V5c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M161.5 4h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M174.598 4.098h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M185.402 3.902h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M199.026 4.526h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M208.974 3.474h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M223.872 5.372h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M232.128 2.628h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M248.586 6.086h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M255.414 1.914h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M273.011 6.511h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M278.989 1.489h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M297.262 6.762h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M302.738 1.238h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M321.406 6.906h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M326.594 1.094h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M345.479 6.979h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M350.521 1.021h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M369.5 7h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707V8c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M374.5 1h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M393.489 6.989h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M398.511 1.011h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M417.45 6.95h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M422.55 1.05h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M441.366 6.866h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M446.634 1.134h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M465.222 6.722h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M470.778 1.278h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M489.043 6.543h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M494.957 1.457h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M512.886 6.386h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M519.114 1.614h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M536.77 6.27h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M543.23 1.73h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M560.686 6.186h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M567.314 1.814h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M584.624 6.124h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M591.376 1.876h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M608.579 6.079h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M615.421 1.921h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M632.547 6.047h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M639.453 1.953h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M656.525 6.025h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M663.475 1.975h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M680.51 6.01h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M687.49 1.99h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M704.502 6.002h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707v-14c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M711.498 1.998h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g><g><path d="M728.5 6h11c.265 0 .52.105.707.293.188.187.293.442.293.707v14c0 .265-.105.52-.293.707-.187.188-.442.293-.707.293h-11c-.265 0-.52-.105-.707-.293-.188-.187-.293-.442-.293-.707V7c0-.265.105-.52.293-.707.187-.188.442-.293.707-.293"></path><path d="M735.5 2h-11c-.552 0-1 .448-1 1v13" stroke-linecap="round"></path></g></g></svg>Copy</a>
+      </div>
+    </div>
+  </div>
+</div>
+</div>
+<div class="tgme_page_widget_actions_helper" id="widget_actions_helper"></div>
+    </div>
+  </div>
+
+  <div id="tgme_frame_cont"></div>
+
+  <script src="//telegram.org/js/tgwallpaper.min.js?3"></script>
+
+  <script type="text/javascript">
+
+var protoUrl = "tg:\/\/resolve?domain=rechtsanwaeltin_beate_bahner&post=13285";
+if (false) {
+var iframeContEl = document.getElementById('tgme_frame_cont') || document.body;
+var iframeEl = document.createElement('iframe');
+iframeContEl.appendChild(iframeEl);
+var pageHidden = false;
+window.addEventListener('pagehide', function () {
+  pageHidden = true;
+}, false);
+window.addEventListener('blur', function () {
+  pageHidden = true;
+}, false);
+if (iframeEl !== null) {
+  iframeEl.src = protoUrl;
+}
+!false && setTimeout(function() {
+  if (!pageHidden) {
+    window.location = protoUrl;
+  }
+}, 2000);
+}
+else if (protoUrl) {
+setTimeout(function() {
+  window.location = protoUrl;
+}, 100);
+}
+
+var tme_bg = document.getElementById('tgme_background');
+if (tme_bg) {
+TWallpaper.init(tme_bg);
+TWallpaper.animate(true);
+window.onfocus = function(){ TWallpaper.update(); };
+}
+document.body.classList.remove('no_transition');
+
+function toggleTheme(dark) {
+document.documentElement.classList.toggle('theme_dark', dark);
+window.Telegram && Telegram.setWidgetOptions({dark: dark});
+}
+if (window.matchMedia) {
+var darkMedia = window.matchMedia('(prefers-color-scheme: dark)');
+toggleTheme(darkMedia.matches);
+darkMedia.addListener(function(e) {
+  toggleTheme(e.matches);
+});
+}
+
+  function toggleEmbed() {
+var widget_actions = document.getElementById('widget_actions');
+if (widget_actions.classList.contains('embed_opened')) {
+  widget_actions.classList.remove('embed_opened');
+  var widget_copy = document.getElementById('widget_copy');
+  if (widget_copy.classList.contains('pressed')) {
+    widget_copy.classList.remove('pressed');
+  }
+} else {
+  widget_actions.classList.add('embed_opened');
+  if (!document.body.classList.contains('fixed_actions')) {
+    window.scrollTo(0, document.body.offsetHeight);
+  }
+  selectEmbedCode();
+}
+checkActionsPosition();
+return false;
+}
+function selectEmbedCode() {
+var field = document.getElementById('embed_code_field');
+field.focus();
+field.setSelectionRange(0, field.value.length);
+}
+function copyEmbedCode(btn) {
+if (btn.classList.contains('pressed')) {
+  btn.classList.remove('pressed');
+  btn.offsetTop + 1;
+}
+btn.classList.add('pressed');
+selectEmbedCode();
+document.execCommand('copy');
+return false;
+}
+function pauseWallpaper(el) {
+var animEnd = function() {
+  el.removeEventListener('transitionend', animEnd);
+  TWallpaper.animate(true);
+}
+TWallpaper.animate(false);
+el.addEventListener('transitionend', animEnd);
+}
+function checkActionsPosition() {
+var widget = document.getElementById('widget');
+var widget_actions_wrap = document.getElementById('widget_actions_wrap');
+var widget_actions = document.getElementById('widget_actions');
+var widget_rect = widget.getBoundingClientRect();
+var actions_bottom = widget_rect.bottom + widget_actions_wrap.offsetHeight;
+var client_bottom = window.innerHeight || html.clientHeight;
+var body_classlist = document.body.classList;
+if (actions_bottom > client_bottom) {
+  if (!body_classlist.contains('fixed_actions')) {
+    widget.style.marginBottom = widget_actions_wrap.offsetHeight + 'px';
+    pauseWallpaper(widget_actions);
+    body_classlist.add('fixed_actions');
+  }
+} else {
+  if (body_classlist.contains('fixed_actions')) {
+    widget.style.marginBottom = '';
+    pauseWallpaper(widget_actions);
+    body_classlist.remove('fixed_actions');
+  }
+}
+}
+function postMessageHandler(event) {
+try { var data = JSON.parse(event.data); }
+catch(e) { var data = {}; }
+if (data.event == 'resize') {
+  setTimeout(checkActionsPosition, 50);
+}
+}
+if (!CSS || !CSS.supports || !CSS.supports('position', 'sticky') || !IntersectionObserver) {
+window.addEventListener('resize', checkActionsPosition);
+window.addEventListener('scroll', checkActionsPosition);
+window.addEventListener('message', postMessageHandler);
+} else {
+document.body.classList.add('sticky_actions');
+var observer = new IntersectionObserver(function(records, observer) {
+  for (var i = 0; i < records.length; i++) {
+    var record = records[i];
+    var widget_actions_wrap = document.getElementById('widget_actions_wrap');
+    var widget_actions = document.getElementById('widget_actions');
+    if (widget_actions_wrap) {
+      pauseWallpaper(widget_actions);
+      widget_actions_wrap.classList.toggle('stuck', !record.isIntersecting);
+    }
+  }
+}, {threshold: [0], root: document});
+observer.observe(document.getElementById('widget_actions_helper'));
+}
+
+  </script>
+
+
+
+</body></html>

--- a/test/models/parser/telegram_test.rb
+++ b/test/models/parser/telegram_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class TelegramIntegrationTest < ActiveSupport::TestCase
+  test "should parse Telegram item URL and set unique title" do
+    m = create_media url: 'https://t.me/rechtsanwaeltin_beate_bahner/13285'
+    data = m.as_json
+    assert_equal 'rechtsanwaeltin_beate_bahner', data['username']
+    assert_equal 'item', data['type']
+    assert_equal 'telegram', data['provider']
+    assert_equal 'Rechtsanwältin Beate Bahner', data['author_name']
+    assert_equal 'https://t.me/rechtsanwaeltin_beate_bahner/13285', data['title']
+    assert_match /Pfizer bestätigt vor EU-Covid-Ausschuss/, data['description']
+    assert_nil data['error']
+  end
+end
+
+class TelegramProfileUnitTest < ActiveSupport::TestCase
+  def setup
+    isolated_setup
+  end
+
+  def teardown
+    isolated_teardown
+  end
+end
+
+class TelegramItemUnitTest <  ActiveSupport::TestCase
+  def setup
+    isolated_setup
+  end
+
+  def teardown
+    isolated_teardown
+  end
+
+  test "returns provider and type" do
+    assert_equal Parser::TelegramItem.type, 'telegram_item'
+  end
+
+  test "matches known kwai URL patterns, and returns instance on success" do
+    assert_nil Parser::TelegramItem.match?('https://example.com')
+
+    match_one = Parser::TelegramItem.match?('https://t.me/rechtsanwaeltin_beate_bahner/13285')
+    assert_equal true, match_one.is_a?(Parser::TelegramItem)
+
+    match_one = Parser::TelegramItem.match?('https://telegram.me/rechtsanwaeltin_beate_bahner/13285')
+    assert_equal true, match_one.is_a?(Parser::TelegramItem)
+  end
+
+  test "assigns values to hash from the HTML doc, and sets URL as title" do
+    doc = response_fixture_from_file('telegram-item.html', parse_as: :html)
+
+    data = Parser::TelegramItem.new('https://t.me/example_account/12345').parse_data(doc)
+    assert_equal 'https://t.me/example_account/12345', data[:title]
+    assert_match /❗ Pfizer bestätigt vor EU-Covid-Ausschuss/, data[:description]
+    assert_equal 'Rechtsanwältin Beate Bahner', data[:author_name]
+    assert_equal 'example_account', data[:username]
+    assert_equal '12345', data[:external_id]
+    assert_match /cdn4.telegram-cdn.org\/file/, data[:picture]
+  end
+end


### PR DESCRIPTION
Previously Telegram links were being parsed by the PageItem parser, which used the non-unique title as our title, which is used for similarity matching. Because Telegram sets the title of the page to the channel that published it, this meant that items were being marked as similar just because they were published by the same channel - not necessarily the same topic.

To address this, this commit creates a TelegramItem parser that simplifies the fetching logic (mostly the same as what PageItem did), and sets the title as the URL since there is no other unique identifier provided (eg, no post title).

Telegram profiles seemed to parse as I'd expect, so I continued to let those fall back to PageItem as they do now.

**Before / currently on QA**
<img width="522" alt="Screen Shot 2023-01-17 at 2 16 07 PM" src="https://user-images.githubusercontent.com/3675092/213024448-a7966b5e-70d1-43de-834e-a908f9a4d58a.png">

**After**
<img width="528" alt="Screen Shot 2023-01-17 at 1 57 48 PM" src="https://user-images.githubusercontent.com/3675092/213023334-62f69475-60d6-4907-9902-b8e146418ee5.png">

CV2-2612