### PR TITLE
Use postgres in development and test, instead of sqlite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 
 # install dependencies
-RUN apt-get update -qq && apt-get install -y curl build-essential git graphicsmagick inotify-tools libsqlite3-dev libpq-dev python --no-install-recommends
+RUN apt-get update -qq && apt-get install -y curl build-essential git graphicsmagick inotify-tools libpq-dev python --no-install-recommends
 
 # install our app
 RUN mkdir -p /app

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 gem 'rails', '~> 6.1.0'
-gem 'sqlite3'
-gem 'pg', '0.20'
+gem 'pg', '1.1'
 group :development, :test do
   gem 'byebug'
   gem 'gem-licenses'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,7 +302,7 @@ GEM
     parallel (1.22.1)
     parallel_tests (3.8.1)
       parallel
-    pg (0.20.0)
+    pg (1.1.0)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -412,8 +412,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.0)
-      mini_portile2 (~> 2.8.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.2.1)
@@ -496,7 +494,7 @@ DEPENDENCIES
   opentelemetry-instrumentation-sidekiq
   opentelemetry-sdk
   parallel_tests
-  pg (= 0.20)
+  pg (= 1.1)
   postrank-uri!
   puma (= 5.6.4)
   rack (>= 1.6.11)
@@ -521,7 +519,6 @@ DEPENDENCIES
   simplecov-console
   spring
   sprockets (= 3.7.2)
-  sqlite3
   twitter
   web-console (~> 3.5.1)
   webmock

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,19 +1,23 @@
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
   pool: 5
-  timeout: 5000
+  timeout: 10000
+  host: postgres
+  username: postgres
+  password: postgres
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: pender_development
 
-# Warning: The database(s) defined as "testXXX" will be erased and
+# Warning: The database(s) defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set to the same as development or production.
 test:
   <<: *default
-  database: db/test<%= ENV['TEST_ENV_NUMBER'] %>.sqlite3
+  database: pender_test_<%= ENV['TEST_ENV_NUMBER'] %>_db
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: pender_production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "2.2"
 volumes:
   redis:
   minio:
+  postgres11:
 services:
   redis:
     image: redis:5
@@ -19,6 +20,14 @@ services:
     environment:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+  postgres:
+    image: postgres:11
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: pender-tests
   pender:
     build: .
     shm_size: 1G
@@ -28,6 +37,7 @@ services:
     volumes:
       - ".:/app"
     depends_on:
+      - postgres
       - redis
       - minio
     environment:

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -22,7 +22,7 @@ ENV DEPLOYUSER=pender \
 COPY production/bin /opt/bin/
 RUN chmod 755 /opt/bin/*.sh
 
-RUN apt-get update && apt-get install -y curl build-essential git libpq-dev libsqlite3-dev graphicsmagick inotify-tools python --no-install-recommends
+RUN apt-get update && apt-get install -y curl build-essential git libpq-dev graphicsmagick inotify-tools python --no-install-recommends
 
 # install youtube-dl
 RUN curl -L https://youtube-dl.org/downloads/latest/youtube-dl -o /usr/local/bin/youtube-dl \
@@ -31,13 +31,13 @@ RUN curl -L https://youtube-dl.org/downloads/latest/youtube-dl -o /usr/local/bin
 # pender user
 RUN useradd ${DEPLOYUSER} -s /bin/bash -m
 
-# copy and install the gems separately since they take so long to build 
+# copy and install the gems separately since they take so long to build
 # this way we can more easily cache them and allow code changes to be built later
 WORKDIR ${DEPLOYDIR}
 COPY ./Gemfile ${DEPLOYDIR}/Gemfile
 COPY ./Gemfile.lock ${DEPLOYDIR}/Gemfile.lock
 RUN echo "gem: --no-rdoc --no-ri" > ~/.gemrc \
-	&& bundle install --deployment --without development test 
+	&& bundle install --deployment --without development test
 
 COPY . ${DEPLOYDIR}
 

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -101,7 +101,7 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal '', data['username']
     assert_match 'https://xkcd.com', data['author_url']
     assert_equal '', data['screenshot']
-    assert_match /imgs/, data['picture']
+    assert data['picture'].present?
   end
 
   test "should return author picture" do


### PR DESCRIPTION
Previously we were using sqlite for development and test environments while our deployed environments used postgres. This caused an issue during the Rails upgrade where our Postgres version was out of date but never caught locally or in CI because of the difference in configuration. This commit has us use postgres as the local database, removes references to sqlite, and updates postgres to be compatible with the 6.1 version of ActiveRecord.

CV2-2668