### PR TITLE
Fix failure to deploy due to missing storage.yml

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,9 @@ module Pender
     })
 
     config.active_record.yaml_column_permitted_classes = [Symbol]
+
+    # We don't use ActiveStorage, so don't configure it for any env
+    config.active_storage.service = :local
   end
 end
 


### PR DESCRIPTION
After upgrading to Rails 6.1 and Ruby 3.0, our deploys began failing due to a missing storage.yml. storage.yml is needed to configure ActiveStorage, which we don't currently use. Not totally sure why it's showing up now and not when we upgraded to Rails 5.2.

To sidestep this, configure ActiveStorage to use :local in all environments. We will want to change this in the future if we start using ActiveRecord.

CV2-2668