### PR TITLE
Add basic storage.yml to fix deploys, and remove unused config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,9 +37,6 @@ module Pender
     })
 
     config.active_record.yaml_column_permitted_classes = [Symbol]
-
-    # We don't use ActiveStorage, so don't configure it for any env
-    config.active_storage.service = :local
   end
 end
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,34 @@
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-1
+#   bucket: your_own_bucket
+
+# Remember not to checkin your GCS keyfile to a repository
+# google:
+#   service: GCS
+#   project: your_project
+#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+#   bucket: your_own_bucket
+
+# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# microsoft:
+#   service: AzureStorage
+#   storage_account_name: your_account_name
+#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+#   container: your_container_name
+
+# mirror:
+#   service: Mirror
+#   primary: local
+#   mirrors: [ amazon, google, microsoft ]


### PR DESCRIPTION
This is the default installed by Rails that we were missing due to upgrades. Although we're not using ActiveStorage, our deploys are erroring without this config file.

This also removes the declaration of local storage that had been previously added to try to get around this same error, since I think we don't need it and it will be confusing in the future.

CV2-2668