### PR TITLE
Full width Facebook embeds

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,8 +14,10 @@
   <%= javascript_include_tag 'embed', skip_pipeline: true %>
 
   <style type="text/css">
-    html {
-      text-align: center;
+    .fb_iframe_widget,
+    .fb_iframe_widget iframe,
+    .fb-post span {
+      width: 100% !important;
     }
 
     .pender-container {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,10 @@
   <%= javascript_include_tag 'embed', skip_pipeline: true %>
 
   <style type="text/css">
+    html {
+      text-align: center;
+    }
+
     .pender-container {
       text-align: left;
     }


### PR DESCRIPTION
By default, Facebook embeds have a fixed width of 552px. On Check Web, the embed container is wider than that, so the embeds are displayed aligned to the left. This PR makes sure that the Facebook embeds are displayed with full width.

Fixes CV2-2857.