### PR TITLE
Wider display for Twitter embeds.

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,18 +14,30 @@
   <%= javascript_include_tag 'embed', skip_pipeline: true %>
 
   <style type="text/css">
-    .fb_iframe_widget,
-    .fb_iframe_widget iframe,
-    .fb-post span {
-      width: 100% !important;
-    }
-
     .pender-container {
       text-align: left;
     }
 
+    .fb_iframe_widget,
+    .fb_iframe_widget iframe,
+    .fb-post span {
+      width: 100% !important;
+      max-width: 100% !important;
+      text-align: center;
+      margin: auto;
+    }
+
     .twitter-tweet {
       display: inline-block !important;
+      width: 100% !important;
+      max-width: 100% !important;
+      text-align: center;
+    }
+
+    #twitter-widget-0 {
+      display: inline-block !important;
+      max-width: 500px !important;
+      width: 100% !important;
     }
   </style>
 </head>


### PR DESCRIPTION
There is a hard-coded width of 550px which we can't change, but we can increase the current embed width from 250px to maximum 550px, make it responsive and centered. This is what this commit adds.

Fixes CV2-2857.