### PR TITLE
Use context to send additional metadata to Sentry

### DIFF
--- a/lib/pender_sentry.rb
+++ b/lib/pender_sentry.rb
@@ -1,8 +1,10 @@
 class PenderSentry
-  def self.notify(e, data = {})
-    Sentry.with_scope do |scope|
-      scope.set_tags(data)
-      Sentry.capture_exception(e)
+  class << self
+    def notify(e, data = {})
+      Sentry.with_scope do |scope|
+        scope.set_context('application', data)
+        Sentry.capture_exception(e)
+      end
     end
   end
 end


### PR DESCRIPTION
Previously we were using tags, which isn't quite right. They are searchable but only support primitives as a result, which didn't make sense for the data we wanted to send.

This instead moves toward using context, which is more readable in the Sentry interface and allows us to send complex data like we were before. More of a drop-in replacement for how we were using Errbit.

For this approach, we just need to watch the size of the payload. We could set additional contexts with unique names in the future. More on that here: https://develop.sentry.dev/sdk/event-payloads/contexts/

CV2-2897