### PR TITLE
Small fixes: Improve error reporting to Sentry

### DIFF
--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -1,9 +1,9 @@
 require 'pender/exception'
 
 module Metrics
-  class << self
-    class RequestFailedException < StandardError; end
+  class RequestFailedException < StandardError; end
 
+  class << self
     RETRYABLE_FACEBOOK_ERROR_CODES = [
       1, # Error validating client secret
       101, # Missing client_id parameter

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -12,7 +12,7 @@ if File.exist?(file)
 
     config.death_handlers << ->(job, ex) do
       if ex.is_a?(Pender::Exception::RetryLater)
-        ex = Pender::Exception::RetryLimitHit.new(job)
+        ex = Pender::Exception::RetryLimitHit.new(ex)
       end
       Sentry.capture_exception(ex)
     end

--- a/test/models/parser/instagram_profile_test.rb
+++ b/test/models/parser/instagram_profile_test.rb
@@ -111,7 +111,7 @@ class InstagramProfileUnitTest < ActiveSupport::TestCase
       airbrake_call_count += 1
       assert_equal ProviderInstagram::ApiError, e.class
     end
-    PenderAirbrake.stub(:notify, arguments_checker) do
+    PenderSentry.stub(:notify, arguments_checker) do
       data = Parser::InstagramProfile.new('https://www.instagram.com/fake-account').parse_data(doc)
       assert_equal 1, airbrake_call_count
     end


### PR DESCRIPTION
- Failed jobs were sending job information instead of wrapped exception information
- RequestFailedException showed "<Class-asldkfjas>::RequestFailedException" because the custom exception was defined within the self block instead of within the module block.

CV2-2897