### PR TITLE
Add ApiKey as user information in Sentry

### DIFF
--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -36,6 +36,7 @@ module Api
         api_key = ApiKey.valid.where(access_token: token).last
         ApiKey.current = api_key
         TracingService.add_attributes_to_current_span('app.api_key' => api_key&.id)
+        PenderSentry.set_user_info(api_key: api_key&.id)
 
         PenderConfig.reload
         (render_unauthorized and return false) if ApiKey.current.nil?

--- a/lib/pender_sentry.rb
+++ b/lib/pender_sentry.rb
@@ -6,5 +6,9 @@ class PenderSentry
         Sentry.capture_exception(e)
       end
     end
+
+    def set_user_info(api_key: nil)
+      Sentry.set_user(id: api_key)
+    end
   end
 end

--- a/test/controllers/base_api_controller_test.rb
+++ b/test/controllers/base_api_controller_test.rb
@@ -53,4 +53,13 @@ class BaseApiControllerTest < ActionController::TestCase
 
     get :about, params: { format: :json }
   end
+
+  test "should set API key information in Sentry" do
+    api_key = create_api_key
+    authenticate_with_token(api_key)
+
+    PenderSentry.expects(:set_user_info).with(api_key: api_key.id)
+
+    get :about, params: { format: :json }
+  end
 end

--- a/test/lib/pender_sentry_test.rb
+++ b/test/lib/pender_sentry_test.rb
@@ -1,0 +1,23 @@
+require_relative '../test_helper'
+
+class PenderSentryTest < ActiveSupport::TestCase
+  test "should notify sentry with passed application data" do
+    error = StandardError.new('test error')
+
+    scope_mock = mock('scope')
+    scope_mock.expects(:set_context).with('application', {thing: 'one', other_thing: 'two'})
+
+    Sentry.expects(:capture_exception).with(error)
+    Sentry.stubs(:with_scope).yields(scope_mock).returns(true)
+
+    PenderSentry.notify(error, thing: 'one', other_thing: 'two')
+  end
+
+  test ".set_user_info should set API key on user" do
+    error = StandardError.new('test error')
+
+    Sentry.expects(:set_user).with(id: 3)
+
+    PenderSentry.set_user_info(api_key: 3)
+  end
+end


### PR DESCRIPTION
This will add an API Key ID, similar to what we use in Honeycomb, to error information sent to Sentry.

This uses the same interface as Check API's Sentry class, but sets the user_id as the API key since that is our closest proxy for a user in this application. Check API uses the actual User ID for this.

CV2-2897