### PR TITLE
Implement a FileItem parser

### DIFF
--- a/app/models/concerns/media_oembed.rb
+++ b/app/models/concerns/media_oembed.rb
@@ -34,10 +34,12 @@ module MediaOembed
     url = original_url || self.url
     if Media.valid_raw_oembed?(self.data)
       self.data['oembed'] = self.data['raw']['oembed'].merge(width: maxwidth, height: maxheight, html: Media.default_oembed_html(url, maxwidth, maxheight))
+    elsif self.provider == 'file'
+      self.data['oembed'] = Media.default_oembed(self.data, url, maxwidth, maxheight)
     else
       self.as_json if self.data.empty?
       %w(type provider).each { |key| self.data[key] = self.send(key.to_sym) }
-      self.data['oembed'] = get_raw_oembed_data(url)|| Media.default_oembed(self.data, url, maxwidth, maxheight)
+      self.data['oembed'] = get_raw_oembed_data(url) || Media.default_oembed(self.data, url, maxwidth, maxheight)
     end
     self.data['author_name'] ||= self.data.dig('raw', 'oembed', 'author_name')
     self.data['oembed']

--- a/app/models/concerns/media_oembed.rb
+++ b/app/models/concerns/media_oembed.rb
@@ -32,10 +32,10 @@ module MediaOembed
 
   def get_oembed_data(original_url = nil, maxwidth = nil, maxheight= nil)
     url = original_url || self.url
-    if Media.valid_raw_oembed?(self.data)
-      self.data['oembed'] = self.data['raw']['oembed'].merge(width: maxwidth, height: maxheight, html: Media.default_oembed_html(url, maxwidth, maxheight))
-    elsif self.provider == 'file'
+    if self.provider == 'file'
       self.data['oembed'] = Media.default_oembed(self.data, url, maxwidth, maxheight)
+    elsif Media.valid_raw_oembed?(self.data)
+      self.data['oembed'] = self.data['raw']['oembed'].merge(width: maxwidth, height: maxheight, html: Media.default_oembed_html(url, maxwidth, maxheight))
     else
       self.as_json if self.data.empty?
       %w(type provider).each { |key| self.data[key] = self.send(key.to_sym) }

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -100,6 +100,7 @@ class Media
     Parser::TiktokProfile,
     Parser::TelegramItem,
     Parser::KwaiItem,
+    Parser::FileItem,
     Parser::PageItem,
   ]
 

--- a/app/models/parser/file_item.rb
+++ b/app/models/parser/file_item.rb
@@ -1,0 +1,24 @@
+module Parser
+  class FileItem < Base
+    class FileReceivedException < StandardError; end
+
+    FILE_ITEM_URL = /^.*\.(?<ext>png|gif|jpg|jpeg|bmp|tif|tiff|pdf|mp3|mp4|ogg|mov|csv|svg|wav)$/i
+
+    class << self
+      def type
+        'file_item'.freeze
+      end
+
+      def patterns
+        [FILE_ITEM_URL]
+      end
+    end
+
+    private
+
+    # Main function for class
+    def parse_data_for_parser(_doc, _original_url, _jsonld)
+      parsed_data
+    end
+  end
+end

--- a/test/models/parser/file_item_test.rb
+++ b/test/models/parser/file_item_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class FileItemIntegrationTest < ActiveSupport::TestCase
+  test "should return an errored object (for now) when parsing an image file URL, and avoid setting binary data as raw oembed" do
+    m = create_media url: 'https://christa.town//img/christatown.gif'
+    data = m.as_json
+    assert_equal 'item', data['type']
+    assert_equal 'file', data['provider']
+    assert_equal 'https://christa.town/img/christatown.gif', data['title']
+    assert data['oembed'].present?
+    assert data['raw']['oembed'].blank?
+  end
+end
+
+class FileItemUnitTest <  ActiveSupport::TestCase
+  def setup
+    isolated_setup
+  end
+
+  def teardown
+    isolated_teardown
+  end
+
+  def doc
+    nil
+  end
+
+  test "returns provider and type" do
+    assert_equal Parser::FileItem.type, 'file_item'
+  end
+
+  test "matches known URL patterns for file types, and returns instance on success" do
+    assert_nil Parser::FileItem.match?('https://example.com/index')
+    assert_nil Parser::FileItem.match?('https://example.com/index.html')
+
+    assert Parser::FileItem.match?('https://example.com/piglet.png').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.PNG').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.gif').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.jpg').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.jpeg').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.bmp').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.tif').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.tiff').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.pdf').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.mp3').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.mp4').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.ogg').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.mov').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.csv').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.svg').is_a?(Parser::FileItem)
+    assert Parser::FileItem.match?('https://example.com/piglet.wav').is_a?(Parser::FileItem)
+  end
+
+  # We want to move this to using a head request and react based on the header info
+  test "passes data straight through, for now" do
+    data = Parser::FileItem.new('https://example.com/piglet.png').parse_data(nil)
+    assert data['title'].blank?
+  end
+end


### PR DESCRIPTION
Currently we're causing an error when a user submits a file URL to Pender, either via the Check web interface or API. This means that partners can't submit links pointing to files.

While we want to eventually detect filetype using a HEAD request to the URL before fetching the file itself, this is a quick and easy way for us to do a best guess at most file types we would expect using the current flow - making a get request, then passing it off to a parser that matches the URL structure.

In order to prevent erroring on the Check API side, I also had to prevent the oembed from returning the file data. This invovled what I hope is a temporary carveout for file parsers, and telling them to use the default Oembed.

The result of all of this is that users can submit a link to a file and just see a URL with no additional metadata or oembed in the Check view, kind of like our normal fallback behavior.

CV2-2724