### PR TITLE
Set log level to debug in deployed environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
At some point in past we set this to :info, but it obscures any warning and other output that would help us understand what's going on in our logs for deployed environments. So, let's set it back.