### PR TITLE
CV2-3119: protection weakened or disabled warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session
+  skip_before_action :verify_authenticity_token
   
   def process_action(*)
     if PenderConfig.get('memory_report', false).to_s == 'true'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token, unless: :csrf_required?
 
   def process_action(*)
     if PenderConfig.get('memory_report', false).to_s == 'true'
@@ -8,5 +8,12 @@ class ApplicationController < ActionController::Base
     else
       super
     end
+  end
+
+  private
+
+  def csrf_required?
+    header = PenderConfig.get('authorization_header') || 'X-Token'
+    request.headers[header].blank?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
   skip_before_action :verify_authenticity_token
 
   def process_action(*)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery with: :null_session
+  
   def process_action(*)
     if PenderConfig.get('memory_report', false).to_s == 'true'
-     MemoryProfiler.report { super }.pretty_print(detailed_report: true, scale_bytes: true)
+      MemoryProfiler.report { super }.pretty_print(detailed_report: true, scale_bytes: true)
     else
       super
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,19 +1,9 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session
-  skip_before_action :verify_authenticity_token, unless: :csrf_required?
-
   def process_action(*)
     if PenderConfig.get('memory_report', false).to_s == 'true'
      MemoryProfiler.report { super }.pretty_print(detailed_report: true, scale_bytes: true)
     else
       super
     end
-  end
-
-  private
-
-  def csrf_required?
-    header = PenderConfig.get('authorization_header') || 'X-Token'
-    request.headers[header].blank?
   end
 end


### PR DESCRIPTION
We want to remove the CodeQL warning about CSRF.

From the docs:
APIs may want to disable this behavior since they are typically designed to be state-less: that is, the request API client handles the session instead of Rails. One way to achieve this is to use the :null_session strategy instead, which allows unverified requests to be handled, but with an empty session

source:
https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html#method-i-verify_authenticity_token

As Caio requested, I ran an integration test, just to double check it didn't break anything, and that passed 🎉 