### PR TITLE
CV2-3030: Replace URI.open with URI().open in Pender

### DIFF
--- a/app/helpers/medias_helper.rb
+++ b/app/helpers/medias_helper.rb
@@ -139,7 +139,7 @@ module MediasHelper
     extension = '.jpg' if extension.blank? || extension == '.php'
     filename = "#{id}/#{attr}#{extension}"
     begin
-      URI.open(url) do |content|
+      URI(url).open do |content|
         Pender::Store.current.store_object(filename, content, 'medias/')
       end
       self.data[attr] = "#{Pender::Store.current.storage_path('medias')}/#{filename}"


### PR DESCRIPTION
Updated URI open to be more secure

From CodeQL:
If Kernel.open is given a file name that starts with a | character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to IO.read, IO.write, IO.binread, IO.binwrite, IO.foreach, IO.readlines and URI.open.

TLDR:
If you pass the url directly to URI it will error if it's anything other than an URI. You can pass more 'things' to open, which makes it more susceptible to malicious action.