### PR TITLE
3305 - Make sure pender works with PostgreSQL 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   postgres:
-    image: postgres:12
+    image: postgres:12-bullseye
     ports:
       - "5432:5432"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.2"
 volumes:
   redis:
   minio:
-  postgres11:
+  postgres12:
 services:
   redis:
     image: redis:5
@@ -21,7 +21,7 @@ services:
       MINIO_ACCESS_KEY: AKIAIOSFODNN7EXAMPLE
       MINIO_SECRET_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
   postgres:
-    image: postgres:11
+    image: postgres:12
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
## Description
Update to use Postgres 12, the scope of this was to make sure the application works well locally in development mode and that tests pass in Travis and in the Check Web integration tests.

References: cv2-3305, cv2-3308

## How has this been tested?
To make sure the application works locally I ran the seeds file, and went through the interface to see if everything was created and working correctly. I also ran the integration tests on check-web (successfully), following the instructions in the confluence article (_How to run cross-application integration tests in CI on demand_). 

## Things to pay attention to during code review
_Not sure if this is important to pay attention during code-review, but I think it's important to add_

- Since we are upgrading between major versions (11 to 12) we have to either migrate the data to a new volume or delete the old volume. Because this was only for the development environment I only deleted the old volume. [Link to relevant conversation](https://github.com/docker-library/postgres/issues/682#issuecomment-587104091)
- We had an issue with building on Travis that seems related to a change the maintainers of the postgres docker images have made to the underlying OS image layer: Previous: Debian 11 (bullseye) New: Debian 12 (bookworm). The workaround seems to be using postgres-bullseye.More on this [here](https://stackoverflow.com/a/76591040)
