### PR TITLE
Remove ticket link from pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context – why has this been changed/fixed.
 
-References: [TICKET-ID](url), [TICKET-ID](url), …
+References: TICKET-ID, TICKET-ID, …
 
 ## How has this been tested?
 


### PR DESCRIPTION
PRs should only include the ticket number and not include the links to our jira board, since it's not publicly accessible.

