### PR TITLE
3388 - Skip twitter-related tests

### DIFF
--- a/spec/requests/api/medias_spec.rb
+++ b/spec/requests/api/medias_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe 'Medias', type: :request do
         end
 
         it 'should return API limit reached error' do |example|
+          pending("twitter api key is not currently working")
           assert_response_matches_metadata(example.metadata)
 
           response_body = JSON.parse(response.body)

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -13,6 +13,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should ask to refresh cache" do
+    skip("twitter api key is not currently working")
     authenticate_with_token
     get :index, params: { url: 'https://twitter.com/caiosba/status/742779467521773568', refresh: '1', format: :json }
     first_parsed_at = Time.parse(JSON.parse(@response.body)['data']['parsed_at']).to_i
@@ -29,6 +30,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should not ask to refresh cache" do
+    skip("twitter api key is not currently working")
     authenticate_with_token
     get :index, params: { url: 'https://twitter.com/caiosba/status/742779467521773568', refresh: '0', format: :json }
     first_parsed_at = Time.parse(JSON.parse(@response.body)['data']['parsed_at']).to_i
@@ -63,6 +65,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should return error message on hash if twitter url does not exist" do
+    skip("twitter api key is not currently working")
     authenticate_with_token
     get :index, params: { url: 'https://twitter.com/caiosba32153623', format: :json }
     assert_response 200
@@ -112,6 +115,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should return error message on hash if twitter post url does not exist" do
+    skip("twitter api key is not currently working")
     twitter_client, status, user = "" , "", ""
     api={"error"=>{"message"=>"Twitter::Error::NotFound: 144 No status found with that ID.", "code"=>4}}
     Media.any_instance.stubs(:twitter_client).returns(twitter_client)
@@ -216,6 +220,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should render custom HTML if provided by parser" do
+    skip("twitter api key is not currently working")
     get :index, params: { url: 'https://twitter.com/caiosba/status/742779467521773568', format: :html }
     assert_response :success
     assert_match /twitter-tweet/, response.body
@@ -251,6 +256,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should clear cache for multiple URLs sent as array" do
+    skip("twitter api key is not currently working")
     authenticate_with_token
     url1 = 'http://ca.ios.ba'
     url2 = 'https://twitter.com/caiosba/status/742779467521773568'
@@ -368,6 +374,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should not archive in any archiver when no archiver parameter is sent" do
+    skip("twitter api key is not currently working")
     Media.any_instance.unstub(:archive_to_archive_org)
 
     a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
@@ -387,6 +394,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should not archive when archiver parameter is none" do
+    skip("twitter api key is not currently working")
     Media.any_instance.unstub(:archive_to_archive_org)
     a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     WebMock.enable!
@@ -584,6 +592,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should add data url when on embed title metatag" do
+    skip("twitter api key is not currently working")
     authenticate_with_token
     twitter_client, status, user = "" , "", ""
     api = {"full_text"=>"@InternetFF Our Meedani @WafHeikal will be joining the amazing line of participants at #IFF, come say hi and get a free trail to our verification tool @check" }
@@ -685,6 +694,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should cache json and html on file" do
+    skip("twitter api key is not currently working")
     authenticate_with_token
     url = 'https://twitter.com/meedan/status/1132948729424691201'
     id = Media.get_id(url)
@@ -733,6 +743,7 @@ class MediasControllerTest < ActionController::TestCase
   end
 
   test "should return API limit reached error" do
+    skip("twitter api key is not currently working")
     Twitter::REST::Client.any_instance.stubs(:user).raises(Twitter::Error::TooManyRequests)
     Twitter::Error::TooManyRequests.any_instance.stubs(:rate_limit).returns(OpenStruct.new(reset_in: 123))
 

--- a/test/models/parser/page_item_test.rb
+++ b/test/models/parser/page_item_test.rb
@@ -94,6 +94,7 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
   end
 
   test "should parse url scheme https" do
+    skip("twitter api key is not currently working")
     url = 'https://www.theguardian.com/politics/2016/oct/19/larry-sanders-on-brother-bernie-and-why-tony-blair-was-destructive'
     m = create_media url: url
     data = m.as_json

--- a/test/models/parser/twitter_item_test.rb
+++ b/test/models/parser/twitter_item_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class TwitterItemIntegrationTest < ActiveSupport::TestCase
   test "should parse tweet" do
+    skip("twitter api key is not currently working")
     m = create_media url: 'https://twitter.com/caiosba/status/742779467521773568'
     data = m.as_json
     assert_match 'I\'ll be talking in @rubyconfbr this year! More details soon...', data['title']
@@ -12,6 +13,7 @@ class TwitterItemIntegrationTest < ActiveSupport::TestCase
   end
 
   test "should parse valid link with spaces" do
+    skip("twitter api key is not currently working")
     m = create_media url: ' https://twitter.com/caiosba/status/742779467521773568 '
     data = m.as_json
     assert_match 'I\'ll be talking in @rubyconfbr this year! More details soon...', data['title']
@@ -22,6 +24,7 @@ class TwitterItemIntegrationTest < ActiveSupport::TestCase
   end
 
   test "should fill in html when html parsing fails but API works" do
+    skip("twitter api key is not currently working")
     url = 'https://twitter.com/codinghorror/status/1276934067015974912'
     OpenURI.stubs(:open_uri).raises(OpenURI::HTTPError.new('','429 Too Many Requests'))
     m = create_media url: url
@@ -48,6 +51,7 @@ class TwitterItemIntegrationTest < ActiveSupport::TestCase
   end
 
   test "should store oembed data of a twitter profile" do
+    skip("twitter api key is not currently working")
     m = create_media url: 'https://twitter.com/meedan'
     data = m.as_json
 

--- a/test/models/parser/twitter_profile_test.rb
+++ b/test/models/parser/twitter_profile_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class TwitterProfileIntegrationTest < ActiveSupport::TestCase
   test "should parse shortened URL" do
+    skip("twitter api key is not currently working")
     m = create_media url: 'http://bit.ly/23qFxCn'
     data = m.as_json
     assert_equal 'https://twitter.com/caiosba', data['url']
@@ -14,6 +15,7 @@ class TwitterProfileIntegrationTest < ActiveSupport::TestCase
   end
 
   test "should store oembed data of a twitter profile" do
+    skip("twitter api key is not currently working")
     m = create_media url: 'https://twitter.com/meedan'
     data = m.as_json
 

--- a/test/workers/archiver_worker_test.rb
+++ b/test/workers/archiver_worker_test.rb
@@ -3,6 +3,7 @@ require_relative '../test_helper'
 class ArchiverWorkerTest < ActiveSupport::TestCase
 
   test "should update cache when video archiving fails the max retries" do
+    skip("twitter api key is not currently working")
     Metrics.stubs(:schedule_fetching_metrics_from_facebook)
     url = 'https://twitter.com/meedan/status/1202732707597307905'
     m = create_media url: url
@@ -17,6 +18,7 @@ class ArchiverWorkerTest < ActiveSupport::TestCase
   end
 
   test "should update cache when Archive.org fails the max retries" do
+    skip("twitter api key is not currently working")
     Media.any_instance.unstub(:archive_to_archive_org)
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
@@ -43,6 +45,7 @@ class ArchiverWorkerTest < ActiveSupport::TestCase
   end
 
   test "should update cache when Archive.org raises since first attempt" do
+    skip("twitter api key is not currently working")
     Media.any_instance.unstub(:archive_to_archive_org)
     WebMock.enable!
     allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }


### PR DESCRIPTION
## Description
Currently our twitter api key is broken, twitter has been changing how you can access tweets (one needs to be logged in), because of that we need to: 
- review tests that are currently using twitter links
- review how we are going to tackle the parsing of twitter links on pender

For now we are skipping twitter-related tests.

References: cv2-3388


