### PR TITLE
3018 - update guard clause to avoid undefined method error

### DIFF
--- a/app/models/parser/facebook_item/ids_grabber.rb
+++ b/app/models/parser/facebook_item/ids_grabber.rb
@@ -25,7 +25,6 @@ module Parser
             return @post_id
           end
         end
-
         if post_id = post_id_from_params(url)
           @post_id = post_id
           return @post_id
@@ -119,9 +118,10 @@ module Parser
         'set' => 'set',
         'photos' => 'album_id'
       }
-      return unless mapping.keys.include?(id)
-      return if (params = parse_uri(uri)).empty?
-
+      params = parse_uri(uri)
+      return if params.empty? 
+      return unless mapping.keys.include?(id) && params.keys.include?(mapping[id])
+      
       # Get relevant info from a.12345 or 12345:0
       slug = params[mapping[id]].first
       slug[/(\d+)/, 1]


### PR DESCRIPTION
## Description

Here we are trying to grab an `id` from facebook (post, album, etc.) We do that by matching patterns. When an url doesn't match our patterns, we run a fallback, `post_id_from_params(url)`, and try to get the id there. So we are looking for an `id` inside a key.

The problem here was we were looking for a key that didn't exist. If we get an url with a query for photos, like `https://www.facebook.com/search/photos?q=%E0%...`. It would look for the values from the key `"album_id"` in the `params` hash, but that key does not exist, the only key there is `"q"`, and that returns a query, not the id. 

So I updated the guard clause to check if the key exists in params.

References: cv2-3018

## How has this been tested?
1. I ran the failing url. We stopped getting the error. We get `nil`, since there is no `id` to grab.
2. I ran a successful url. I found a test that had an url that used the fallback, ran the test and got a successful id. 

