### PR TITLE
3063 - address cross site scripting

### DIFF
--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -6,15 +6,6 @@ var Pender = {};
 (function($) {
   'use strict';
 
-  // Add custom CSS
-  // var css = document.location.hash.replace('#css=', '');
-  // if (css !== '') {
-  //   $('head').append('<link rel="stylesheet" href="' + css + '" type="text/css" class="pender-custom-css" />');
-  //   $('meta[name="twitter:image"]').attr('content', function(index, attr) {
-  //     return attr + '?css=' + css;
-  //   });
-  // }
-
   // Alert parent window when the height changes
   var htmlHeight = 0;
   if (!Pender.id) {

--- a/public/javascripts/embed.js
+++ b/public/javascripts/embed.js
@@ -7,13 +7,13 @@ var Pender = {};
   'use strict';
 
   // Add custom CSS
-  var css = document.location.hash.replace('#css=', '');
-  if (css !== '') {
-    $('head').append('<link rel="stylesheet" href="' + css + '" type="text/css" class="pender-custom-css" />');
-    $('meta[name="twitter:image"]').attr('content', function(index, attr) {
-      return attr + '?css=' + css;
-    });
-  }
+  // var css = document.location.hash.replace('#css=', '');
+  // if (css !== '') {
+  //   $('head').append('<link rel="stylesheet" href="' + css + '" type="text/css" class="pender-custom-css" />');
+  //   $('meta[name="twitter:image"]').attr('content', function(index, attr) {
+  //     return attr + '?css=' + css;
+  //   });
+  // }
 
   // Alert parent window when the height changes
   var htmlHeight = 0;


### PR DESCRIPTION
## Description

This was used in Bridge, isn't used more and was causing a cross-scripting warning: https://github.com/meedan/pender/security/code-scanning/15

References: cv2-3063

## How has this been tested?
Ran the pender tests locally, but we have two failing tests: [should handle concurrency](https://github.com/meedan/pender/blob/3063-address-cross-site-scripting/test/integration/medias_integration_test.rb#L33) and [should generate the public archiving folder for videos](https://github.com/meedan/pender/blob/3063-address-cross-site-scripting/test/models/archiver_test.rb#L573). The second one seems unrelated, but I'm not sure about the first? It looks for a title but can't find it. I tried getting the html for that page, but it failed. However, on CI they all passed.

I also tested generating embeds (tiktok, twitter, telegram, page and youtube) using the get request, and it worked, except for youtube. 
