### PR TITLE
3571 - Update unavailable facebook items tests

### DIFF
--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -21,7 +21,7 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     assert !data['published_at'].blank?
   end
 
-  test "should set title to URL and error if crowdtangle fails" do
+  test "should set title to URL if an item is unavailable" do
     # This URL requires login to see
     m = create_media url: 'https://www.facebook.com/caiosba/posts/8457689347638947'
     data = m.as_json
@@ -29,7 +29,6 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     assert_equal 'facebook', data['provider']
     assert_equal 'item', data['type']
     assert_equal 'https://www.facebook.com/caiosba/posts/8457689347638947', data['title']
-    assert !data['error'].blank?
   end
 
   # Previous integration tests
@@ -112,12 +111,12 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     assert_equal 'item', data['type']
   end
 
-  test "should return empty html when FB url is private and cannot be embedded" do
+  test "should return html even when FB url is private" do
     url = 'https://www.facebook.com/caiosba/posts/1913749825339929'
     m = create_media url: url
     data = m.as_json
     assert_equal 'facebook', data['provider']
-    assert_equal '', data['html']
+    assert_match "<div class=\"fb-post\" data-href=\"https://www.facebook.com/caiosba/posts/1913749825339929\">", data['html']
   end
 
   test "should store oembed data of a facebook post" do


### PR DESCRIPTION
## Description

Sometimes facebook items are unavailable. Before we didn’t get any response in those cases, now we get a page letting us know the page is not available. With this we are now able to create an embed.

We want to keep this new behavior, so we only need to update the tests.

**What the embed looks like**
<img width="588" alt="Screenshot 2023-08-14 at 16 03 41" src="https://github.com/meedan/pender/assets/87862340/3823a0f5-bbf0-4d6f-b701-eeddb1e726e0">

**On check**
<img width="598" alt="Screenshot 2023-08-14 at 16 04 12" src="https://github.com/meedan/pender/assets/87862340/8670b785-4ac5-4d09-ae5f-65d1e99e4523">


References: 3571

## How has this been tested?

Updated the failing tests.