### PR TITLE
3386 - make sure oembed_json is a Hash

### DIFF
--- a/app/models/oembed_item.rb
+++ b/app/models/oembed_item.rb
@@ -42,11 +42,11 @@ class OembedItem
 
   def parse_oembed_response(response)
     return if response.nil? || response.body.blank?
-
     oembed_json = {}
     begin
       oembed_json = JSON.parse(response.body)
-      if oembed_json['html'].present?
+      return unless oembed_json.is_a?(Hash)
+      if oembed_json['html'].present? 
         doc = Nokogiri::HTML oembed_json['html']
         # Discard the oEmbed's HTML fragment in the following cases:
         # - The script.src URL is not HTTPS


### PR DESCRIPTION
## Description

We sometimes get an error when parsing the `oembed`: `TypeError: no implicit conversion of String into Integer`

This happens with similar specific urls, all weirdly named urls with `.top` domain. Those sites return '404' on their `response.body`, when we `JSON.parse` it, it returns an integer, which breaks things. 

This was fixed by returning early if the value is not a `Hash`.

References: 3386

## How has this been tested?

Tested parsing some of the urls that were causing this error. (there are some examples on the ticket)