### PR TITLE
3644 - identify facebook login pages

### DIFF
--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -101,7 +101,7 @@ module ProviderFacebook
     title = get_page_title(html_page)
     return unless title
     return if NONUNIQUE_TITLES.include?(title.downcase)
-
+    
     title
   end
 end

--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -101,7 +101,7 @@ module ProviderFacebook
     title = get_page_title(html_page)
     return unless title
     return if NONUNIQUE_TITLES.include?(title.downcase)
-    
+
     title
   end
 end

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -23,7 +23,7 @@ module Parser
       /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/photo(.php)?\/?\?fbid=(?<id>[0-9]+)&set=a\.([0-9]+)(\.([0-9]+)\.([0-9]+))?.*/,
       /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/photo(.php)?\?fbid=(?<id>[0-9]+)&set=p\.([0-9]+).*/,
       /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/permalink.php\?story_fbid=(?<id>[0-9]+)&id=([0-9]+).*/,
-      /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/story.php\?story_fbid=(?<id>[0-9]+)&id=(?<user_id>[0-9]+).*/,
+      /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/story.php\?story_fbid=(?<id>[0-9a-zA-Z]+)&id=(?<user_id>[0-9]+).*/,
       /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/events\/(?<id>[0-9]+)\/permalink\/([0-9]+).*/,
       /^https?:\/\/(?<subdomain>[^\.]+\.)?facebook\.com\/groups\/(?<profile>[^\/]+)\/permalink\/(?<id>[0-9]+).*/,
       /^https?:\/\/(www\.)?facebook\.com\/(?<id>[^\/\?]+).*$/,
@@ -74,8 +74,15 @@ module Parser
         strip_facebook_from_title!
 
         @parsed_data['html'] = html_for_facebook_post(parsed_data.dig('username'), doc, url) || ''
+        
+        if (@parsed_data['title'].downcase).include?('log in')
+          @parsed_data.merge!(
+            title: url,
+            description: '',
+          )
+        end
       end
-
+      
       parsed_data
     end
 

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -76,7 +76,7 @@ module Parser
         @parsed_data['html'] = html_for_facebook_post(parsed_data.dig('username'), doc, url) || ''
         
         ['log in or sign up to view', 'log into facebook', 'log in to facebook'].each do |login|
-          if (@parsed_data[:title].downcase).include?(login)
+          if @parsed_data[:title] && (@parsed_data[:title].downcase).include?(login)
             @parsed_data.merge!(
               title: url,
               description: '',

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -75,12 +75,15 @@ module Parser
 
         @parsed_data['html'] = html_for_facebook_post(parsed_data.dig('username'), doc, url) || ''
         
-        if (@parsed_data['title'].downcase).include?('log in')
-          @parsed_data.merge!(
-            title: url,
-            description: '',
-          )
+        ['log in or sign up to view', 'log into facebook', 'log in to facebook'].each do |login|
+          if (@parsed_data[:title].downcase).include?(login)
+            @parsed_data.merge!(
+              title: url,
+              description: '',
+            )
+          end
         end
+
       end
       
       parsed_data

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -477,7 +477,7 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
     parser = Parser::FacebookItem.new('https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/')
     data = parser.parse_data(empty_doc, throwaway_url)
 
-    assert_match '', data['title']
+    assert_match 'https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/', data['title']
     assert_match '', data['description']
   end
 end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -286,6 +286,8 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
     # Category
     assert Parser::FacebookItem.match?('https://www.facebook.com/pages/category/Society---Culture-Website/PoporDezamagit/photos/').is_a?(Parser::FacebookItem)
     assert Parser::FacebookItem.match?('https://www.facebook.com/groups/memetics.hacking/permalink/1580570905320222/').is_a?(Parser::FacebookItem)
+    # Story
+    assert Parser::FacebookItem.match?('https://m.facebook.com/story.php?story_fbid=pfbid0213Dz5MyduLTHpELPoRmop9E7zj3Ed163P7djxSWbkfvaMSBrjNYTY9BFx6h7i3zWl&id=100054495283578').is_a?(Parser::FacebookItem)
   end
 
   test "sends tracing information to honeycomb, including updated URL" do
@@ -468,5 +470,14 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
   test "#oembed_url returns URL with the instance URL" do
     oembed_url = Parser::FacebookItem.new('https://www.facebook.com/fakeaccount/posts/1234').oembed_url
     assert_equal 'https://www.facebook.com/plugins/post/oembed.json/?url=https://www.facebook.com/fakeaccount/posts/1234', oembed_url
+  end
+
+  test "should return default data if login page" do
+    #not finished, to do
+    parser = Parser::FacebookItem.new('https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/')
+    data = parser.parse_data(empty_doc, throwaway_url)
+
+    assert_match '', data['title']
+    assert_match '', data['description']
   end
 end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -472,10 +472,16 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
     assert_equal 'https://www.facebook.com/plugins/post/oembed.json/?url=https://www.facebook.com/fakeaccount/posts/1234', oembed_url
   end
 
-  test "should return default data if login page" do
-    #not finished, to do
+  test "should return default data when redirected to login page" do
+    WebMock.stub_request(:any, /api.crowdtangle.com\/post/).to_return(status: 200, body: crowdtangle_response_not_found)
+
+    doc = Nokogiri::HTML(<<~HTML)
+      <meta property="og:title" content="Log into Facebook | Facebook" />
+      <meta property="og:description" content="Log into Facebook to start sharing and connecting with your friends, family, and people you know." />
+    HTML
+
     parser = Parser::FacebookItem.new('https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/')
-    data = parser.parse_data(empty_doc, throwaway_url)
+    data = parser.parse_data(doc, throwaway_url)
 
     assert_match 'https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/', data['title']
     assert_match '', data['description']

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -347,7 +347,7 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
   end
 
   # Implicitly testing MediaCrowdtangleItem
-  test "sends error to errbit when we receive unexpected response from crowdtangle API" do
+  test "sends error to sentry when we receive unexpected response from crowdtangle API" do
     WebMock.stub_request(:any, /api.crowdtangle.com\/post/).to_return(status: 200, body: '')
 
     data = {}


### PR DESCRIPTION
## Description

We don't want the title and description to be set to 'log in to facebook'.
The title should be the url and description should be an empty string.

We were having two issues:
1. the story link was being parsed by the page parser, so we updated the regex
2. the facebook parser was being redirected to a login page, which meant that the metadata we used for the title and description was 'log in...'. Now we check one final time and update the title if needed.

References: 3644

## How has this been tested?

1. Added `assert Parser::FacebookItem.match?('https://m.facebook.com/story.php?story_fbid=pfbid0213Dz5MyduLTHpELPoRmop9E7zj3Ed163P7djxSWbkfvaMSBrjNYTY9BFx6h7i3zWl&id=100054495283578').is_a?(Parser::FacebookItem)` to  test "matches known URL patterns, and returns instance on success" (`rails test test/models/parser/facebook_item_test.rb:258`) 
2. Added a new test to check that the `title` and `description` are set correctly when the `og:title` returns 'log in or sign up to view', 'log into facebook' or 'log in to facebook' (`rails test test/models/parser/facebook_item_test.rb:475`) 

## Things to pay attention to during code review
There are two failures in the tests:
1. "should not change url when redirected to login page" (`rails test test/models/parser/facebook_item_test.rb:59`) is currently failing, but it's also failing on develop. I'll deal with that issue on a separate ticket.
2. the other one is a kwai test, so that is unrelated to this PR.

