### PR TITLE
3644 - facebok identify login pages refactor

### DIFF
--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -81,13 +81,16 @@ module ProviderFacebook
     title = get_page_title(html_page)
     return if title.blank?
 
-    if page_is_unavailable || ['log in or sign up to view', 'log into facebook', 'log in to facebook'].include?(title.downcase)
-      @parsed_data['title'] = @parsed_data['description'] = ''
-      @parsed_data['error'] = {
-        message: 'Login required to see this profile',
-        code: Lapis::ErrorCodes::const_get('LOGIN_REQUIRED'),
-      }
+    ['log in or sign up to view', 'log into facebook', 'log in to facebook'].each do |login|
+      if page_is_unavailable || title.downcase.include?(login)
+        @parsed_data['title'] = nil
+        @parsed_data['description'] = ''
+        @parsed_data['error'] = {
+          message: 'Login required to see this profile',
+          code: Lapis::ErrorCodes::const_get('LOGIN_REQUIRED'),
+        }
       return true
+      end
     end
   end
 

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -52,7 +52,7 @@ module Parser
         set_data_field('object_id', grabber.post_id)
         set_data_field('uuid', grabber.uuid)
         set_data_field('external_id', grabber.uuid)
-
+        
         @parsed_data['raw']['crowdtangle'] = get_crowdtangle_data(parsed_data['uuid']) || {}
         if has_valid_crowdtangle_data?
           crowdtangle_data = format_crowdtangle_result(parsed_data['raw']['crowdtangle'])
@@ -61,7 +61,7 @@ module Parser
           @parsed_data.merge!(crowdtangle_data)
         else
           og_metadata = get_opengraph_metadata.reject{|k,v| v.nil?}
-
+          
           if should_use_markup_title?
             set_data_field('title', get_unique_facebook_page_title(doc))
           else
@@ -70,11 +70,11 @@ module Parser
           set_data_field('description', og_metadata['description'])
           set_data_field('picture', og_metadata['picture'])
         end
+        set_facebook_privacy_error(doc, unavailable_page)
 
         strip_facebook_from_title!
-
+        
         @parsed_data['html'] = html_for_facebook_post(parsed_data.dig('username'), doc, url) || ''
-
       end
       
       parsed_data
@@ -82,7 +82,6 @@ module Parser
 
     def html_for_facebook_post(username, html_page, request_url)
       return unless html_page
-      return if set_facebook_privacy_error(html_page, unavailable_page)
       return if username && !['groups', 'flx'].include?(username)
       return unless not_an_event_page && not_a_group_post
 

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -52,7 +52,7 @@ module Parser
         set_data_field('object_id', grabber.post_id)
         set_data_field('uuid', grabber.uuid)
         set_data_field('external_id', grabber.uuid)
-        
+
         @parsed_data['raw']['crowdtangle'] = get_crowdtangle_data(parsed_data['uuid']) || {}
         if has_valid_crowdtangle_data?
           crowdtangle_data = format_crowdtangle_result(parsed_data['raw']['crowdtangle'])
@@ -61,7 +61,7 @@ module Parser
           @parsed_data.merge!(crowdtangle_data)
         else
           og_metadata = get_opengraph_metadata.reject{|k,v| v.nil?}
-          
+
           if should_use_markup_title?
             set_data_field('title', get_unique_facebook_page_title(doc))
           else

--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -74,15 +74,6 @@ module Parser
         strip_facebook_from_title!
 
         @parsed_data['html'] = html_for_facebook_post(parsed_data.dig('username'), doc, url) || ''
-        
-        ['log in or sign up to view', 'log into facebook', 'log in to facebook'].each do |login|
-          if @parsed_data[:title] && (@parsed_data[:title].downcase).include?(login)
-            @parsed_data.merge!(
-              title: url,
-              description: '',
-            )
-          end
-        end
 
       end
       

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -480,10 +480,12 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
       <meta property="og:description" content="Log into Facebook to start sharing and connecting with your friends, family, and people you know." />
     HTML
 
-    parser = Parser::FacebookItem.new('https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/')
-    data = parser.parse_data(doc, throwaway_url)
+    WebMock.stub_request(:any, 'https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/').to_return(status: 200, body: doc.to_s)
 
-    assert_match 'https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/', data['title']
+    media = Media.new(url: 'https://m.facebook.com/groups/593719938050039/permalink/1184073722347988/')
+    data = media.as_json
+
+    assert_equal 'https://m.facebook.com/groups/593719938050039/permalink/1184073722347988', data['title']
     assert_match '', data['description']
   end
 end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -69,18 +69,19 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     assert_equal url, m.url
   end
 
-  test "should add login required error and return empty html and description" do
+  test "should add login required error, return html and empty description" do
     html = "<title id='pageTitle'>Log in or sign up to view</title><meta property='og:description' content='See posts, photos and more on Facebook.'>"
     RequestHelper.stubs(:get_html).returns(Nokogiri::HTML(html))
     Media.any_instance.stubs(:follow_redirections)
 
     m = create_media url: 'https://www.facebook.com/caiosba/posts/3588207164560845'
     data = m.as_json
+    
     assert_equal 'Login required to see this profile', data[:error][:message]
     assert_equal Lapis::ErrorCodes::const_get('LOGIN_REQUIRED'), data[:error][:code]
     assert_equal m.url, data[:title]
     assert data[:description].empty?
-    assert data[:html].empty?
+    assert_match "<div class=\"fb-post\" data-href=\"https://www.facebook.com/caiosba/posts/3588207164560845\"></div>", data['html']
   end
 
   test "should get canonical URL parsed from facebook html when it is relative" do

--- a/test/models/parser/facebook_profile_test.rb
+++ b/test/models/parser/facebook_profile_test.rb
@@ -153,7 +153,7 @@ class FacebookProfileUnitTest < ActiveSupport::TestCase
 
     assert_equal Lapis::ErrorCodes::const_get('LOGIN_REQUIRED'), data[:error][:code]
     assert_match /Login required/, data[:error][:message]
-    assert data['title'].empty?
+    assert data['title'].nil?
     assert data['description'].empty?
   end
 
@@ -162,7 +162,7 @@ class FacebookProfileUnitTest < ActiveSupport::TestCase
 
     assert_equal Lapis::ErrorCodes::const_get('LOGIN_REQUIRED'), data[:error][:code]
     assert_match /Login required/, data[:error][:message]
-    assert data['title'].empty?
+    assert data['title'].nil?
     assert data['description'].empty?
   end
 


### PR DESCRIPTION
## Description

I had added a final check inside `facebook_item`, but realized that it would be better to update how the `provider_facebook` checks if a page is a login page, so we check only once instead of doing it twice.
This is a refactor of the work in this PR: [3644 - identify facebook login pages #381](https://github.com/meedan/pender/pull/381). 

References: 3644

## How has this been tested?

`rails test test/models/parser/facebook_profile_test.rb:476`

## Things to pay attention to during code review

I thought this was pretty straightforward, but found a small issue while working on this: 
We had a couple tests that wanted opposite things ("should add login required error and return empty html and description" / "should return html even when FB url is private"), they were both passing because we were sometimes failing to check for login pages.

The behavior we want is to return the `data[:html]` and to try to create the embed even if a login or private page:
- sometimes even if the link redirects to a login, the embed works
- even if the embed shows 'log into facebook', that might be useful as it will make it clear to the user that it's not a Check error

So I updated the tests and code accordingly.

