### PR TITLE
3653 - extract username correctly when there is a query

### DIFF
--- a/app/models/parser/twitter_profile.rb
+++ b/app/models/parser/twitter_profile.rb
@@ -9,8 +9,10 @@ module Parser
 
       def patterns
         [
-          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[\w\d]+)(\??.*)$/,
-          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[\w\d]+)(\??.*)$/
+          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[\w\d]+)(\?+.*)$/,
+          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[\w\d]+)(\?+.*)$/,
+          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[^\/]+)$/,
+          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[^\/]+)$/
         ]
       end
     end

--- a/app/models/parser/twitter_profile.rb
+++ b/app/models/parser/twitter_profile.rb
@@ -9,8 +9,8 @@ module Parser
 
       def patterns
         [
-          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[\w\d]+)\?*[^\/]+$/,
-          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[\w\d]+)\?*[^\/]+$/
+          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[\w\d]+)(\??.*)$/,
+          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[\w\d]+)(\??.*)$/
         ]
       end
     end

--- a/app/models/parser/twitter_profile.rb
+++ b/app/models/parser/twitter_profile.rb
@@ -9,8 +9,8 @@ module Parser
 
       def patterns
         [
-          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[^\/]+)$/,
-          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[^\/]+)$/
+          /^https?:\/\/(www\.)?twitter\.com\/(?<username>[\w\d]+)\?*[^\/]+$/,
+          /^https?:\/\/(0|m|mobile)\.twitter\.com\/(?<username>[\w\d]+)\?*[^\/]+$/
         ]
       end
     end

--- a/test/models/parser/twitter_profile_test.rb
+++ b/test/models/parser/twitter_profile_test.rb
@@ -51,6 +51,10 @@ class TwitterProfileUnitTest < ActiveSupport::TestCase
     match_one = Parser::TwitterProfile.match?('https://twitter.com/meedan')
     assert_equal true, match_one.is_a?(Parser::TwitterProfile)
 
+    # Profile with query
+    match_one = Parser::TwitterProfile.match?('https://twitter.com/meedan?ref_src=twsrc%5Etfw')
+    assert_equal true, match_one.is_a?(Parser::TwitterProfile)
+
     # Mobile patterns
     match_two = Parser::TwitterProfile.match?('https://0.twitter.com/meedan')
     assert_equal true, match_two.is_a?(Parser::TwitterProfile)
@@ -58,6 +62,8 @@ class TwitterProfileUnitTest < ActiveSupport::TestCase
     assert_equal true, match_three.is_a?(Parser::TwitterProfile)
     match_four = Parser::TwitterProfile.match?('https://mobile.twitter.com/meedan')
     assert_equal true, match_four.is_a?(Parser::TwitterProfile)
+    match_five = Parser::TwitterProfile.match?('https://mobile.twitter.com/meedan?ref_src=twsrc%5Etfw')
+    assert_equal true, match_five.is_a?(Parser::TwitterProfile)
   end
 
   test "it makes a get request to the user lookup by username endpoint successfully" do
@@ -192,5 +198,14 @@ class TwitterProfileUnitTest < ActiveSupport::TestCase
   test "#oembed_url returns URL with the instance URL" do
     oembed_url = Parser::TwitterProfile.new('https://twitter.com/fake-account').oembed_url
     assert_equal 'https://publish.twitter.com/oembed?url=https://twitter.com/fake-account', oembed_url
+  end
+
+  test "should parse tweet profile with a query on the url" do
+    stub_profile_lookup.returns(twitter_profile_response_success)
+
+    data = Parser::TwitterProfile.new('https://www.twitter.com/fake_user?ref_src=twsrc%5Etfw').parse_data(empty_doc)
+
+    assert_equal 'fake_user', data['external_id']
+    assert_equal '@fake_user', data['username']
   end
 end


### PR DESCRIPTION

## Description
Sometimes a profile url might come with a query, e.g: `https://twitter.com/username?ref_src=blah`. 
We need to make sure we are getting only the username to make the request to the twitter api endpoint. To do that I updated the regex inside `twiter_profile.rb`.

References: 3653

## How has this been tested?

I added two new tests to the test "matches known URL patterns, and returns instance on success" (`rails test test/models/parser/twitter_profile_test.rb:41`).

I also added a new test that checks for this specific scenario "should parse tweet profile with a query on the url" (`rails test test/models/parser/twitter_profile_test.rb:203`).


