### PR TITLE
3723 – Fix Kwai parser

### DIFF
--- a/app/models/parser/kwai_item.rb
+++ b/app/models/parser/kwai_item.rb
@@ -19,7 +19,7 @@ module Parser
       handle_exceptions(StandardError) do
         jsonld = (jsonld_array.find{|item| item.dig('@type') == 'VideoObject'} || {})
 
-        title = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('name')
+        title = get_kwai_text_from_tag(doc, '.info .title') 
         name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name')
         description = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('transcript') || jsonld.dig('description')
         @parsed_data.merge!({

--- a/app/models/parser/kwai_item.rb
+++ b/app/models/parser/kwai_item.rb
@@ -15,17 +15,21 @@ module Parser
     private    
 
     # Main function for class
-    def parse_data_for_parser(doc, _original_url, _jsonld_array)
+    def parse_data_for_parser(doc, _original_url, jsonld_array)
       handle_exceptions(StandardError) do
-        title = get_kwai_text_from_tag(doc, '.info .title')
-        name = get_kwai_text_from_tag(doc, '.name')
+        jsonld = (jsonld_array.find{|item| item.dig('@type') == 'VideoObject'} || {})
+
+        title = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('name')
+        name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name')
+        description = jsonld.dig('transcript') || jsonld.dig('description')
         @parsed_data.merge!({
           title: title,
-          description: title,
+          description: description,
           author_name: name,
           username: name
         })
       end
+
       parsed_data
     end
   

--- a/app/models/parser/kwai_item.rb
+++ b/app/models/parser/kwai_item.rb
@@ -21,7 +21,7 @@ module Parser
 
         title = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('name')
         name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name')
-        description = jsonld.dig('transcript') || jsonld.dig('description')
+        description = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('transcript') || jsonld.dig('description')
         @parsed_data.merge!({
           title: title,
           description: description,

--- a/app/models/parser/kwai_item.rb
+++ b/app/models/parser/kwai_item.rb
@@ -20,8 +20,8 @@ module Parser
         jsonld = (jsonld_array.find{|item| item.dig('@type') == 'VideoObject'} || {})
 
         title = get_kwai_text_from_tag(doc, '.info .title') 
-        name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name')
-        description = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('transcript') || jsonld.dig('description')
+        name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name').strip
+        description = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('transcript').strip || jsonld.dig('description').strip
         @parsed_data.merge!({
           title: title,
           description: description,

--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -2,14 +2,15 @@ require 'test_helper'
 
 class KwaiIntegrationTest < ActiveSupport::TestCase
   test "should parse Kwai URL" do
-    m = create_media url: 'https://s.kw.ai/p/1mCb9SSh'
+    m = create_media url: 'https://kwai-video.com/p/md02RsCS'
     data = m.as_json
-    assert_equal 'Reginaldo Silva2871', data['username']
+
+    assert_equal 'Arthur Virgilio', data['username']
     assert_equal 'item', data['type']
     assert_equal 'kwai', data['provider']
-    assert_equal 'Reginaldo Silva2871', data['author_name']
-    assert_equal 'F. Francisco', data['title']
-    assert_equal 'F. Francisco', data['description']
+    assert_equal 'Arthur Virgilio', data['author_name']
+    assert_match 'Presidente Zelensky foi consagrado numa sala de reuniões', data['title']
+    assert_match 'foi consagrado numa sala de reuniões do G7', data['description']
     assert_nil data['error']
   end
 end
@@ -44,5 +45,9 @@ class KwaiUnitTest <  ActiveSupport::TestCase
     assert_equal 'A special video', data[:description]
     assert_equal 'Reginaldo Silva2871', data[:author_name]
     assert_equal 'Reginaldo Silva2871', data[:username]
+  end
+
+  test "assigns values to hash from ldjson" do
+    
   end
 end

--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -41,26 +41,35 @@ class KwaiUnitTest <  ActiveSupport::TestCase
     doc = response_fixture_from_file('kwai-page.html', parse_as: :html)
 
     data = Parser::KwaiItem.new('https://s.kw.ai/p/example').parse_data(doc)
-    assert_equal "A special video", data[:title]
-    assert_equal "A special video", data[:description]
-    assert_equal 'Reginaldo Silva2871', data[:author_name]
-    assert_equal 'Reginaldo Silva2871', data[:username]
+      assert_equal "A special video", data[:title]
+      assert_equal "A special video", data[:description]
+      assert_equal 'Reginaldo Silva2871', data[:author_name]
+      assert_equal 'Reginaldo Silva2871', data[:username]
+    end
+
+  test "assigns description and username to hash from the json+ld" do
+    empty_doc = Nokogiri::HTML('')
+  
+    jsonld = [{"url"=>"https://www.kwai.com/@fakeuser/video/5221229445268222050", "name"=>"Fake User. Áudio original criado por Fake User.", "description"=>"#tag1 #tag2 #tag3", "transcript"=>"video transcript ", "creator"=>{"name"=>"Fake User", "description"=>"Fake User Description", "alternateName"=>"fakeuser", "url"=>"https://www.kwai.com/@fakeuser"}, "@context"=>"https://schema.org/", "@type"=>"VideoObject"}]
+  
+    data = Parser::KwaiItem.new('https://www.kwai.com/fakelink').parse_data(empty_doc, 'https://www.kwai.com/fakelink', jsonld)
+  
+    assert_equal 'video transcript', data['description']
+    assert_equal 'Fake User', data['author_name']
   end
 
-  test "assigns values to hash from the json+ld" do
-    empty_doc = Nokogiri::HTML('')
-
+  test "assigns values to hash from the json+ld and falls back to url as title" do
     doc = Nokogiri::HTML(<<~HTML)
-      <script data-n-head="ssr" type="application/ld+json" id="VideoObject">{"url":"https://www.kwai.com/@fakeuser/video/5221229445268222050","name":"Fake User. Áudio original criado por Fake User. ","description":"#tag1 #tag2 #tag3","transcript":"video transcript","thumbnailUrl":["http://ak-br-pic.kwai.net/kimg/fake_image_thumbnail.webp"],"uploadDate":"2023-05-22 01:41:04","contentUrl":"https://aws-br-cdn.kwai.net/upic/2023/05/22/01/fake_link.mp4?tag=1-1694439486-s-0-rnlkpacssc-56115f1493ef597d","commentCount":105,"duration":"PT1M7S","width":592,"height":1280,"audio":{"name":"Áudio original criado por Fake User","author":"Fake User","@type":"CreativeWork"},"creator":{"name":"Fake User","image":"https://aws-br-pic.kwai.net/bs2/overseaHead/fake_image.jpg","description":"Fake User Description","alternateName":"fakeuser","url":"https://www.kwai.com/@fakeuser","genre":["News","Politics & Economics"],"mainEntityOfPage":{"@id":"https://www.kwai.com/@fakeuser/video/5221229445268222050","@type":"ItemPage"},"@context":"https://schema.org/","@type":"VideoObject"}</script>
+      <script data-n-head="ssr" type="application/ld+json" id="VideoObject">{"url":"https://www.kwai.com/fakelink","name":"Fake User. Áudio original criado por Fake User. ","description":"#tag1 #tag2 #tag3","transcript":"video transcript","thumbnailUrl":["http://ak-br-pic.kwai.net/kimg/fake_thumbnail.webp"],"uploadDate":"2022-04-03 19:33:22","contentUrl":"https://cloudflare-br-cdn.kwai.net/upic/2022/04/03/19/fake_video.mp4?tag=1-1694090789-s-0-lm1vo6rkom-4c561f7187b6ac1b","commentCount":3568,"duration":"PT27S","width":612,"height":544,"audio":{"name":"Áudio original criado por Fake User","author":"Fake User","@type":"CreativeWork"},"creator":{"name":"Fake User","image":"https://aws-br-pic.kwai.net/bs2/overseaHead/fake_image.jpg","description":"criador de  conteúdo","alternateName":"fakeuser","url":"https://www.kwai.com/@fakeuser","interactionStatistic":[{"userInteractionCount":449001,"interactionType":{"@type":"http://schema.org/LikeAction"},"@type":"InteractionCounter"},{"userInteractionCount":33974,"interactionType":{"@type":"http://schema.org/FollowAction"},"@type":"InteractionCounter"}],"mainEntityOfPage":{"@id":"https://www.kwai.com/@wdklv443","@type":"ProfilePage"},"@type":"Person"},"interactionStatistic":[{"userInteractionCount":163968,"interactionType":{"@type":"http://schema.org/WatchAction"},"@type":"InteractionCounter"},{"userInteractionCount":10489,"interactionType":{"@type":"http://schema.org/LikeAction"},"@type":"InteractionCounter"},{"userInteractionCount":11899,"interactionType":{"@type":"http://schema.org/ShareAction"},"@type":"InteractionCounter"}],"mainEntityOfPage":{"@id":"https://www.kwai.com/fakelink","@type":"ItemPage"},"@context":"https://schema.org/","@type":"VideoObject"}</script>
     HTML
 
-    WebMock.stub_request(:any, 'https://www.kwai.com/@fakeuser/video/5221229445268222050').to_return(status: 200, body: doc.to_s)
+    WebMock.stub_request(:any, 'https://www.kwai.com/fakelink').to_return(status: 200, body: doc.to_s)
 
-    media = Media.new(url: 'https://www.kwai.com/@fakeuser/video/5221229445268222050')
+    media = Media.new(url: 'https://www.kwai.com/fakelink')
     data = media.as_json
 
     assert_equal 'video transcript', data['description']
-    assert_equal 'https://www.kwai.com/@fakeuser/video/5221229445268222050', data['title']
+    assert_equal 'https://www.kwai.com/fakelink', data['title']
     assert_equal 'Fake User', data['author_name']
   end
 end

--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -47,7 +47,15 @@ class KwaiUnitTest <  ActiveSupport::TestCase
     assert_equal 'Reginaldo Silva2871', data[:username]
   end
 
-  test "assigns values to hash from ldjson" do
-    
+  test "assigns values to hash from the json+ld" do
+    empty_doc = Nokogiri::HTML('')
+
+    jsonld = [{"url"=>"https://www.kwai.com/@fakeuser/video/5221229445268222050", "name"=>"Fake User. Áudio original criado por Fake User.", "description"=>"#tag1 #tag2 #tag3", "transcript"=>"video transcript", "creator"=>{"name"=>"Fake User", "description"=>"Fake User Description", "alternateName"=>"fakeuser", "url"=>"https://www.kwai.com/@fakeuser"}, "@context"=>"https://schema.org/", "@type"=>"VideoObject"}]
+
+    data = Parser::KwaiItem.new('https://www.kwai.com/fakelink').parse_data(empty_doc, 'https://www.kwai.com/fakelink', jsonld)
+
+    assert_equal 'video transcript', data['description']
+    assert_equal 'Fake User. Áudio original criado por Fake User.', data['title']
+    assert_equal 'Fake User', data['author_name']
   end
 end


### PR DESCRIPTION
## Description

Our Kwai test has been failing for a while, since it had been flaky before we assumed it was just flaky again. However, it seems that the parsing is indeed broken: we search the doc for '.info .title' and for '.name', and both of those are returning nil.

We can get data from the jsonld script. Besides the `name`(we can get that from `creator name`), it doesn't return the same exact data as before. We can use `description` or `transcription` for `data['description']`. For `title` we don't have a good substitute, so we are just using the default fallback from `Media` (`url`).

We are leaving the old behavior and adding the data from the jsonld script as a fallback. Kwai has changed their HTML and changed it back again before. So we think it's worth keeping the old behavior, at least for now.

References: 3723, 3716

## How has this been tested?

I updated the integration test to use the new values we are fetching (`rails test test/models/parser/kwai_test.rb:4`), and added two unit tests:
- make sure we are getting author_name and description from json+ld successfully (`rails test test/models/parser/kwai_test.rb:50`)
- make sure the title uses the url as a fallback (`rails test test/models/parser/kwai_test.rb:61`)

