### PR TITLE
update regex in the kwai item

### DIFF
--- a/app/models/parser/kwai_item.rb
+++ b/app/models/parser/kwai_item.rb
@@ -22,8 +22,8 @@ module Parser
         jsonld = (jsonld_array.find{|item| item.dig('@type') == 'VideoObject'} || {})
 
         title = get_kwai_text_from_tag(doc, '.info .title') 
-        name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name').strip || match_username(url)
-        description = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('transcript').strip || jsonld.dig('description').strip
+        name = get_kwai_text_from_tag(doc, '.name') || jsonld.dig('creator','name')&.strip || match_username(url)
+        description = get_kwai_text_from_tag(doc, '.info .title') || jsonld.dig('transcript')&.strip || jsonld.dig('description')&.strip
         @parsed_data.merge!({
           title: title,
           description: description,

--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -35,7 +35,16 @@ class KwaiUnitTest <  ActiveSupport::TestCase
     assert_equal true, match_one.is_a?(Parser::KwaiItem)
     match_two = Parser::KwaiItem.match?('https://m.kwai.com/photo/150000228494834/5222636779124848117')
     assert_equal true, match_two.is_a?(Parser::KwaiItem)
+    match_three = Parser::KwaiItem.match?('https://kwai-video.com/p/6UCtAajG')
+    assert_equal true, match_three.is_a?(Parser::KwaiItem)
+    match_four = Parser::KwaiItem.match?('https://www.kwai.com/@AnonymouSScobar/video/5217288797260590112?page_source=guest_profile')
+    assert_equal true, match_four.is_a?(Parser::KwaiItem)
   end
+  
+  test "does not match kwai profile URL" do
+    match_five = Parser::PageItem.match?('https://www.kwai.com/@AnonymouSScobar')
+    assert_equal false, match_five.is_a?(Parser::KwaiItem)
+  end    
 
   test "assigns values to hash from the HTML doc" do
     doc = response_fixture_from_file('kwai-page.html', parse_as: :html)
@@ -60,16 +69,16 @@ class KwaiUnitTest <  ActiveSupport::TestCase
 
   test "assigns values to hash from the json+ld and falls back to url as title" do
     doc = Nokogiri::HTML(<<~HTML)
-      <script data-n-head="ssr" type="application/ld+json" id="VideoObject">{"url":"https://www.kwai.com/fakelink","name":"Fake User. Áudio original criado por Fake User. ","description":"#tag1 #tag2 #tag3","transcript":"video transcript","thumbnailUrl":["http://ak-br-pic.kwai.net/kimg/fake_thumbnail.webp"],"uploadDate":"2022-04-03 19:33:22","contentUrl":"https://cloudflare-br-cdn.kwai.net/upic/2022/04/03/19/fake_video.mp4?tag=1-1694090789-s-0-lm1vo6rkom-4c561f7187b6ac1b","commentCount":3568,"duration":"PT27S","width":612,"height":544,"audio":{"name":"Áudio original criado por Fake User","author":"Fake User","@type":"CreativeWork"},"creator":{"name":"Fake User","image":"https://aws-br-pic.kwai.net/bs2/overseaHead/fake_image.jpg","description":"criador de  conteúdo","alternateName":"fakeuser","url":"https://www.kwai.com/@fakeuser","interactionStatistic":[{"userInteractionCount":449001,"interactionType":{"@type":"http://schema.org/LikeAction"},"@type":"InteractionCounter"},{"userInteractionCount":33974,"interactionType":{"@type":"http://schema.org/FollowAction"},"@type":"InteractionCounter"}],"mainEntityOfPage":{"@id":"https://www.kwai.com/@wdklv443","@type":"ProfilePage"},"@type":"Person"},"interactionStatistic":[{"userInteractionCount":163968,"interactionType":{"@type":"http://schema.org/WatchAction"},"@type":"InteractionCounter"},{"userInteractionCount":10489,"interactionType":{"@type":"http://schema.org/LikeAction"},"@type":"InteractionCounter"},{"userInteractionCount":11899,"interactionType":{"@type":"http://schema.org/ShareAction"},"@type":"InteractionCounter"}],"mainEntityOfPage":{"@id":"https://www.kwai.com/fakelink","@type":"ItemPage"},"@context":"https://schema.org/","@type":"VideoObject"}</script>
+      <script data-n-head="ssr" type="application/ld+json" id="VideoObject">{"url":"https://www.kwai.com/@fakeuser/111111111","name":"Fake User. Áudio original criado por Fake User. ","description":"#tag1 #tag2 #tag3","transcript":"video transcript","thumbnailUrl":["http://ak-br-pic.kwai.net/kimg/fake_thumbnail.webp"],"uploadDate":"2022-04-03 19:33:22","contentUrl":"https://cloudflare-br-cdn.kwai.net/upic/2022/04/03/19/fake_video.mp4?tag=1-1694090789-s-0-lm1vo6rkom-4c561f7187b6ac1b","commentCount":3568,"duration":"PT27S","width":612,"height":544,"audio":{"name":"Áudio original criado por Fake User","author":"Fake User","@type":"CreativeWork"},"creator":{"name":"Fake User","image":"https://aws-br-pic.kwai.net/bs2/overseaHead/fake_image.jpg","description":"criador de  conteúdo","alternateName":"fakeuser","url":"https://www.kwai.com/@fakeuser","interactionStatistic":[{"userInteractionCount":449001,"interactionType":{"@type":"http://schema.org/LikeAction"},"@type":"InteractionCounter"},{"userInteractionCount":33974,"interactionType":{"@type":"http://schema.org/FollowAction"},"@type":"InteractionCounter"}],"mainEntityOfPage":{"@id":"https://www.kwai.com/@wdklv443","@type":"ProfilePage"},"@type":"Person"},"interactionStatistic":[{"userInteractionCount":163968,"interactionType":{"@type":"http://schema.org/WatchAction"},"@type":"InteractionCounter"},{"userInteractionCount":10489,"interactionType":{"@type":"http://schema.org/LikeAction"},"@type":"InteractionCounter"},{"userInteractionCount":11899,"interactionType":{"@type":"http://schema.org/ShareAction"},"@type":"InteractionCounter"}],"mainEntityOfPage":{"@id":"https://www.kwai.com/@fakeuser/111111111","@type":"ItemPage"},"@context":"https://schema.org/","@type":"VideoObject"}</script>
     HTML
 
-    WebMock.stub_request(:any, 'https://www.kwai.com/fakelink').to_return(status: 200, body: doc.to_s)
+    WebMock.stub_request(:any, 'https://www.kwai.com/@fakeuser/111111111').to_return(status: 200, body: doc.to_s)
 
-    media = Media.new(url: 'https://www.kwai.com/fakelink')
+    media = Media.new(url: 'https://www.kwai.com/@fakeuser/111111111')
     data = media.as_json
 
     assert_equal 'video transcript', data['description']
-    assert_equal 'https://www.kwai.com/fakelink', data['title']
+    assert_equal 'https://www.kwai.com/@fakeuser/111111111', data['title']
     assert_equal 'Fake User', data['author_name']
   end
 end

--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -81,4 +81,12 @@ class KwaiUnitTest <  ActiveSupport::TestCase
     assert_equal 'https://www.kwai.com/@fakeuser/111111111', data['title']
     assert_equal 'Fake User', data['author_name']
   end
+
+  test "fallbacks to the username on the url when doc and json+ld are not present, if name is present in the url" do
+    empty_doc = Nokogiri::HTML('')
+
+    data = Parser::KwaiItem.new('https://www.kwai.com/@fakeuser/111111111').parse_data(empty_doc, 'https://www.kwai.com/@fakeuser/111111111')
+
+    assert_equal 'fakeuser', data['author_name']
+  end
 end


### PR DESCRIPTION
## Description

We want to make sure kwai profiles are not being parsed by the item parser.
Until we add a profile item for kwai they will be parsed by page.

Notes:
- I added a regex for when we have a kwai-video host instead of only kwai.
- When we have the username in the url, we are getting it as a fallback.

References: 3723

## How has this been tested?

test "matches known kwai URL patterns, and returns instance on success"
test "does not match kwai profile URL"
test "fallbacks to the username on the url when doc and json+ld are not present, if name is present in the url"
