### PR TITLE
Make regex on twitter_profile less broad

### DIFF
--- a/app/models/parser/twitter_profile.rb
+++ b/app/models/parser/twitter_profile.rb
@@ -9,7 +9,7 @@ module Parser
 
       def patterns
         [
-          /^https?:\/\/((0|m|mobile|www)\.)?twitter\.com\/(?<username>[\w]{4,15})(\?.*)?[\/]*$/
+          /^https?:\/\/((0|m|mobile|www)\.)?twitter\.com\/(?<username>[\w]{4,15})[\/]*(\?.*)?[\/]*$/
         ]
       end
     end

--- a/test/models/parser/twitter_profile_test.rb
+++ b/test/models/parser/twitter_profile_test.rb
@@ -50,16 +50,18 @@ class TwitterProfileUnitTest < ActiveSupport::TestCase
     # Profile with query
     match_three = Parser::TwitterProfile.match?('https://twitter.com/username?ref_src=twsrc%5Etfw')
     assert_equal true, match_three.is_a?(Parser::TwitterProfile)
+    match_four = Parser::TwitterProfile.match?('https://twitter.com/username/?t=1')
+    assert_equal true, match_four.is_a?(Parser::TwitterProfile)
 
     # Mobile patterns
-    match_four = Parser::TwitterProfile.match?('https://0.twitter.com/username')
-    assert_equal true, match_four.is_a?(Parser::TwitterProfile)
-    match_five = Parser::TwitterProfile.match?('https://m.twitter.com/username')
+    match_five = Parser::TwitterProfile.match?('https://0.twitter.com/username')
     assert_equal true, match_five.is_a?(Parser::TwitterProfile)
-    match_six = Parser::TwitterProfile.match?('https://mobile.twitter.com/username')
+    match_six = Parser::TwitterProfile.match?('https://m.twitter.com/username')
     assert_equal true, match_six.is_a?(Parser::TwitterProfile)
-    match_seven = Parser::TwitterProfile.match?('https://mobile.twitter.com/username?ref_src=twsrc%5Etfw')
+    match_seven = Parser::TwitterProfile.match?('https://mobile.twitter.com/username')
     assert_equal true, match_seven.is_a?(Parser::TwitterProfile)
+    match_eight = Parser::TwitterProfile.match?('https://mobile.twitter.com/username?ref_src=twsrc%5Etfw')
+    assert_equal true, match_eight.is_a?(Parser::TwitterProfile)
   end
 
   test "does not match pages that should be parsed by pages" do


### PR DESCRIPTION
## Description

We were looking for anything that wasn’t ‘/', we want to make that less broad by only looking for [what actually can be in a username](https://help.twitter.com/en/managing-your-account/twitter-username-rules#error).

This way something like a search won’t be wrongly parsed as an user. It’s better to have the page parser try to parse that than the twitter profile parser. We know the twitter parser will fail, while the page parser might be able to return something.

References: 3717, 3740

## How has this been tested?

Added a new test "does not match patterns with usernames that are not permitted by twitter"
`rails test test/models/parser/twitter_profile_test.rb:71`

Also ran "matches known URL patterns, and returns instance on success" and "does not match pages that should be parsed by pages" to make sure nothing broke.
`rails test test/models/parser/twitter_profile_test.rb:41`
`rails test test/models/parser/twitter_profile_test.rb:61`

