### PR TITLE
notify Sentry about RetryLimitHit only from sidekiq

### DIFF
--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -61,10 +61,6 @@ module MediaArchiver
 
     def give_up(info = {})
       url, archiver, key_id = info[:args][0], info[:args][1], info[:args][2]
-      PenderSentry.notify(
-        StandardError.new(info[:error_message]),
-        info.merge({ url: url, archiver: archiver, key_id: key_id })
-      )
       Rails.logger.warn level: 'WARN', message: "[#{info[:error_class]}] #{info[:error_message]}", url: url, archiver: archiver
       data = { error: { message: info[:error_message], code: Lapis::ErrorCodes::const_get('ARCHIVER_FAILURE') }}
       Media.notify_webhook_and_update_cache(archiver, url, data, key_id)

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -12,9 +12,9 @@ if File.exist?(file)
 
     config.death_handlers << ->(job, ex) do
       if ex.is_a?(Pender::Exception::RetryLater)
-        ex = Pender::Exception::RetryLimitHit.new(ex, {job: job})
+        ex = Pender::Exception::RetryLimitHit.new(ex)
       end
-      Sentry.capture_exception(ex)
+      PenderSentry.notify(ex, {job: job})
     end
   end
 

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -12,7 +12,7 @@ if File.exist?(file)
 
     config.death_handlers << ->(job, ex) do
       if ex.is_a?(Pender::Exception::RetryLater)
-        ex = Pender::Exception::RetryLimitHit.new(ex)
+        ex = Pender::Exception::RetryLimitHit.new(ex, {job: job})
       end
       Sentry.capture_exception(ex)
     end


### PR DESCRIPTION
## Description

We were notifying Sentry both through `Media.give_up` and through
configuration inside `03_sidekiq`. We are keeping only the one in `03_sidekiq.rb`.
It’s the most specific error and the right place.

In order to try to get more information, we are replacing
`Sentry.capture_exception(ex) by PenderSentry.notify(ex, { job: job })`

References: 3706, 3757, 3707

## How has this been tested?

I tried writing a test to make sure teh Archiver isn't notifying Sentry anymore:
test "MediaArchiver should not notify Sentry when the worker hits the maximum number of retries"
`rails test test/models/archiver_test.rb:746`

## Things to pay attention to during code review

I ran a bunch of tests to make sure the test is working, but I'm not sure about it: if it makes sense the way it's written, if it's even needed.

