### PR TITLE
3724 – Testing ways to better error handle RetryLimitHit (Metrics)

### DIFF
--- a/config/initializers/02_sentry.rb
+++ b/config/initializers/02_sentry.rb
@@ -10,4 +10,7 @@ Sentry.init do |config|
 
   # Any exceptions we want to prevent sending to Sentry
   config.excluded_exceptions += ['Pender::Exception::RetryLater']
+
+  # report_after_job_retries when turned on, the SDK will only report the exception after all retries have failed.
+  config.sidekiq.report_after_job_retries = true
 end

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -10,11 +10,11 @@ if File.exist?(file)
   Sidekiq.configure_server do |config|
     config.redis = redis_config
 
-    config.death_handlers << ->(job, ex) do
-      if ex.is_a?(Pender::Exception::RetryLater)
-        ex = Pender::Exception::RetryLimitHit.new(ex)
+    config.death_handlers << ->(job, original_exception) do
+      if original_exception.is_a?(Pender::Exception::RetryLater)
+        limit_hit_exception = Pender::Exception::RetryLimitHit.new(original_exception)
       end
-      PenderSentry.notify(ex, {job: job})
+      PenderSentry.notify(limit_hit_exception, {job: job, original_exception: original_exception.cause})
     end
   end
 


### PR DESCRIPTION
## Description

We have been getting a lot of Metrics RetryLimitHit errors on Sentry. Unfortunately they don't tell us much. So we are trying to test ways of adding relevant Data to those Errors.

- added trying to send the `original_exception.cause` when we hit `RetryLimitHit`, hopefully this will give us some extra info
- added  `config.sidekiq.report_after_job_retries = true` which should make sure we are only getting the last retry( should only report the exception after all retries have failed). I think we are already only reporting the last retry, but added this to make sure. If we are reporting on more retries, this could help make it less noisy.

References: 3274

## How has this been tested?

I wasn't able to test this one, we will have to see on Live if there is any new relevant information sent to Sentry.