### PR TITLE
3718 – Update how we retry tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ before_install:
 before_script:
 - docker-compose exec pender test/setup-parallel
 script:
-- docker-compose exec pender bundle exec rake "parallel:test[3]"
-- docker-compose exec pender bundle exec rake parallel:spec
+- docker-compose exec -e TEST_RETRY_COUNT=5 pender bundle exec rake "parallel:test[3]"
+- docker-compose exec -e TEST_RETRY_COUNT=5 pender bundle exec rake parallel:spec
 after_script:
 - docker-compose exec pender cat tmp/performance.csv
 - docker-compose exec -e TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST -e TRAVIS_TEST_RESULT=$TRAVIS_TEST_RESULT -e TRAVIS_BRANCH=$TRAVIS_BRANCH -e CC_TEST_REPORTER_ID=$CC_TEST_REPORTER_ID -e GIT_COMMIT_SHA=$GIT_COMMIT_SHA -e GIT_COMMITTED_AT=$GIT_COMMITTED_AT pender test/test-coverage

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ require 'minitest/retry'
 require 'minitest/mock'
 require 'mocha/minitest'
 
-Minitest::Retry.use!(retry_count: 5)
+Minitest::Retry.use!(retry_count: ENV['TEST_RETRY_COUNT'].to_i || 0)
 
 Minitest::Retry.on_failure do |_klass, _test_name|
   sleep 10


### PR DESCRIPTION
## Description

When running locally we might not want the tests to retry, to do this
we would need to comment out the retry lines. We want to make this easier
on the developer

Converting the env variable to an integer because ENV[] on ruby returns a string
https://ruby-doc.org/core-3.0.0/ENV.html

References: 3718

## How has this been tested?

Changed a test to make it fail. 
Ran tests locally without setting `TEST_RETRY_COUNT`, test failed and didn't retry.
Set the env var inside the container (`export TEST_RETRY_COUNT=5`) and ran the tests again, it retried 5 times.

