### PR TITLE
3634 – Refactor Kwai testing

### DIFF
--- a/test/integration/parsers/kwai_test.rb
+++ b/test/integration/parsers/kwai_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class KwaiIntegrationTest < ActiveSupport::TestCase
+  test "should parse Kwai URL" do
+    m = create_media url: 'https://kwai-video.com/p/md02RsCS'
+    data = m.as_json
+
+    assert_kind_of String, data['title']
+    assert_kind_of String, data['description']
+    assert_equal 'Arthur Virgilio', data['username']
+    assert_equal 'Arthur Virgilio', data['author_name']
+    assert_equal 'kwai', data['provider']
+    assert_equal 'item', data['type']
+  end
+
+  test "should return data even if Kwai URL does not exist" do
+    m = create_media url: 'https://kwai-video.com/p/aaaaaaaa'
+    data = m.as_json
+
+    assert_equal 'https://kwai-video.com/p/aaaaaaaa', data['title']
+    assert data['description'].blank?
+    assert data['username'].blank?
+    assert_equal 'kwai', data['provider']
+    assert_equal 'item', data['type']
+    assert_nil data['error']
+  end
+end

--- a/test/models/parser/kwai_test.rb
+++ b/test/models/parser/kwai_test.rb
@@ -1,20 +1,5 @@
 require 'test_helper'
 
-class KwaiIntegrationTest < ActiveSupport::TestCase
-  test "should parse Kwai URL" do
-    m = create_media url: 'https://kwai-video.com/p/md02RsCS'
-    data = m.as_json
-
-    assert_equal 'Arthur Virgilio', data['username']
-    assert_equal 'item', data['type']
-    assert_equal 'kwai', data['provider']
-    assert_equal 'Arthur Virgilio', data['author_name']
-    assert_kind_of String, data['title']
-    assert_kind_of String, data['description']
-    assert_nil data['error']
-  end
-end
-
 class KwaiUnitTest <  ActiveSupport::TestCase
   def setup
     isolated_setup
@@ -30,7 +15,7 @@ class KwaiUnitTest <  ActiveSupport::TestCase
 
   test "matches known kwai URL patterns, and returns instance on success" do
     assert_nil Parser::KwaiItem.match?('https://example.com')
-    
+
     match_one = Parser::KwaiItem.match?('https://s.kw.ai/p/1mCb9SSh')
     assert_equal true, match_one.is_a?(Parser::KwaiItem)
     match_two = Parser::KwaiItem.match?('https://m.kwai.com/photo/150000228494834/5222636779124848117')
@@ -40,7 +25,7 @@ class KwaiUnitTest <  ActiveSupport::TestCase
     match_four = Parser::KwaiItem.match?('https://www.kwai.com/@AnonymouSScobar/video/5217288797260590112?page_source=guest_profile')
     assert_equal true, match_four.is_a?(Parser::KwaiItem)
   end
-  
+
   test "does not match kwai profile URL" do
     match_five = Parser::PageItem.match?('https://www.kwai.com/@AnonymouSScobar')
     assert_equal false, match_five.is_a?(Parser::KwaiItem)


### PR DESCRIPTION
## Description

This is part of a larger project to improve our testing.

**Context**
We have two issues:

- We want to be able to choose when to run integration tests.
- We have too many integration tests.

To fix this we need to go through all the parsers and:

- Split the integration from the unit tests, we now have a folder for them (test > integration > parsers).
- Go through the unit tests and make sure they are not making live http requests.
- Go through the integration tests, see which one of those should be integration tests (keep those at 2, 3 tests at the most), and refactor the rest to be unit tests. (ideally we want one to test a successful request and one to test a failure)

**Notes on the Kwai tests**

This one was pretty straight forward:
- I moved integration test to it's own file
- Created a new integration test that makes sure it returns data even if it fails
- No clean up was needed

References: 3634, 3629

