### PR TITLE
3796 – Add more details to original exception for RetryLimitHit

### DIFF
--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -31,7 +31,7 @@ module Metrics
       begin
         value = facebook_id ? crowdtangle_metrics(facebook_id) : request_metrics_from_facebook(url)
       rescue Pender::Exception::RetryLater
-        raise Pender::Exception::RetryLater, 'Metrics request failed'
+        raise Pender::Exception::RetryLater, message: 'Metrics request failed'
       rescue StandardError => e
         value = {}
         Rails.logger.warn level: 'WARN', message: "Metrics request failed: #{e.message}", url: url, key_id: ApiKey.current&.id

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -14,7 +14,7 @@ if File.exist?(file)
       if original_exception.is_a?(Pender::Exception::RetryLater)
         limit_hit_exception = Pender::Exception::RetryLimitHit.new(original_exception)
       end
-      PenderSentry.notify(limit_hit_exception, {job: job, original_exception: original_exception.cause})
+      PenderSentry.notify(limit_hit_exception, {job: job, original_exception: original_exception.cause.inspect})
     end
   end
 


### PR DESCRIPTION
## Description

When we do `original_exception.cause` we are only getting the message in Sentry,
but if we do `original_exception.cause.inspect` we get the whole error.


<img width="403" alt="Screenshot 2023-10-05 at 10 08 26" src="https://github.com/meedan/pender/assets/87862340/0f5b8d80-238d-497e-b3a9-1a265ea0548b">
<img width="648" alt="Screenshot 2023-10-05 at 10 08 11" src="https://github.com/meedan/pender/assets/87862340/f2688e19-4638-43f6-bcfb-1ef7b88f9795">

References: 3796

## How has this been tested?

- Set my local dev environment to notify Sentry 
- Set [retries](https://github.com/meedan/pender/blob/f773ef3f69cc7f7c72fb6d8ae04e38f3d09e6a17/app/workers/metrics_worker.rb#L6C3-L6C3) for the MetricsWorker to 1
- Raised `Pender::Exception::RetryLater, message: 'Original Error'` inside [get_metrics_from_facebook](https://github.com/meedan/pender/blob/f773ef3f69cc7f7c72fb6d8ae04e38f3d09e6a17/app/models/metrics.rb#L28)
- Ran requests as usual and watched the errors hit Sentry

