### PR TITLE
Fixing cache when ID changes

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -72,18 +72,19 @@ class Media
   end
 
   def as_json(options = {})
-    if options.delete(:force) || Pender::Store.current.read(Media.get_id(self.url), :json).nil?
+    id = Media.get_id(self.url)
+    if options.delete(:force) || Pender::Store.current.read(id, :json).nil?
       handle_exceptions(self, StandardError) { self.parse }
       self.data['title'] = self.url if self.data['title'].blank?
       data = self.data.merge(Media.required_fields(self)).with_indifferent_access
       if data[:error].blank?
-        Pender::Store.current.write(Media.get_id(self.url), :json, cleanup_data_encoding(data))
+        Pender::Store.current.write(id, :json, cleanup_data_encoding(data))
       end
       self.upload_images
     end
     self.archive(options.delete(:archivers))
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    Pender::Store.current.read(Media.get_id(self.url), :json) || cleanup_data_encoding(data)
+    Pender::Store.current.read(id, :json) || cleanup_data_encoding(data)
   end
 
   PARSERS = [

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -690,7 +690,7 @@ class MediasControllerTest < ActionController::TestCase
   test "should refresh cache even if ID changes" do
     WebMock.enable!
     WebMock.disable_net_connect!(allow: [/minio/])
-    WebMock.stub_request(:get, /.*/).to_return(status: 200, body: '<html><title>Test</title></html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     Media.stubs(:get_id).returns('foo', 'bar', 'foo', 'bar')
     Pender::Store.current.write('foo', :json, { title: 'Meedan 1' })
     Pender::Store.current.write('bar', :json, { title: 'Meedan 2' })

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -690,6 +690,7 @@ class MediasControllerTest < ActionController::TestCase
   test "should refresh cache even if ID changes" do
     WebMock.enable!
     WebMock.disable_net_connect!(allow: [/minio/])
+    WebMock.stub_request(:get, /.*/).to_return(status: 200, body: '<html><title>Test</title></html>')
     Media.stubs(:get_id).returns('foo', 'bar', 'foo', 'bar')
     Pender::Store.current.write('foo', :json, { title: 'Meedan 1' })
     Pender::Store.current.write('bar', :json, { title: 'Meedan 2' })

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -686,6 +686,22 @@ class MediasControllerTest < ActionController::TestCase
     assert_equal url, JSON.parse(@response.body)['data']['title']
     assert_equal Lapis::ErrorCodes::const_get('DUPLICATED'), JSON.parse(@response.body)['data']['error']['code']
   end
+
+  test "should refresh cache even if ID changes" do
+    WebMock.enable!
+    WebMock.disable_net_connect!(allow: [/minio/])
+    Media.stubs(:get_id).returns('foo', 'bar', 'foo', 'bar')
+    Pender::Store.current.write('foo', :json, { title: 'Meedan 1' })
+    Pender::Store.current.write('bar', :json, { title: 'Meedan 2' })
+
+    url = 'https://meedan.com'
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html><title>Meedan 1</title></html>')
+
+    authenticate_with_token
+
+    get :index, params: { url: url, format: :json, refresh: 1 }
+    assert_equal 'Meedan 1', JSON.parse(@response.body)['data']['title']
+  end
 end
 
 class MediasControllerUnitTest < ActionController::TestCase


### PR DESCRIPTION
## Description

The URL ID, used as a cache key, is calculated in runtime, at different times, when writing and when reading. This means that the cache is written to a key but read from another one. This is a pretty edge case, but this PR turns it safer and more consistent.

Reference: CV2-3749.

## How has this been tested?

TDD. I added a test that first reproduced the issue. The test passed after the fix was implemented.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

