### PR TITLE
Update version pins for Python ecs deploy dependencies including six and urllib

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - bugfix/debug-deploy-errors
 
 deploy_qa:
   image: python:3-alpine
@@ -50,7 +49,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - bugfix/debug-deploy-errors
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - bugfix/debug-deploy-errors
 
 deploy_qa:
   image: python:3-alpine
@@ -35,10 +36,8 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install botocore==1.31.58
-    - pip install boto3==1.28.58
-    - pip install ecs-deploy==1.14.0
-    - pip install awscli==1.29.59
+    - pip install ecs-deploy
+    - pip install awscli
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA --exclusive-env -e qa-pender-c APP pender -e qa-pender-c DEPLOY_ENV qa -e qa-pender-c AWS_REGION $AWS_DEFAULT_REGION --timeout 3600 --exclusive-secrets `cat qa-pender-c.env.args`
@@ -47,6 +46,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - bugfix/debug-deploy-errors
 
 build_live:
   image: docker:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,8 +36,12 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install ecs-deploy
-    - pip install awscli
+    - pip install urllib3==2.0.6
+    - pip install six==1.16.0
+    - pip install botocore==1.31.62
+    - pip install boto3==1.28.62
+    - pip install ecs-deploy==1.14.0
+    - pip install awscli==1.29.59
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/pender/##' > env.qa.names
     - rm -f qa-pender-c.env.args; for NAME in `cat env.qa.names`; do echo -n "-s qa-pender-c $NAME /qa/pender/$NAME " >> qa-pender-c.env.args; done
     - ecs deploy ecs-qa  qa-pender --image qa-pender-c $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA --exclusive-env -e qa-pender-c APP pender -e qa-pender-c DEPLOY_ENV qa -e qa-pender-c AWS_REGION $AWS_DEFAULT_REGION --timeout 3600 --exclusive-secrets `cat qa-pender-c.env.args`
@@ -82,8 +86,10 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
   script:
     - apk add --no-cache curl jq python3 py3-pip git
-    - pip install botocore==1.31.58
-    - pip install boto3==1.28.58
+    - pip install urllib3==2.0.6
+    - pip install six==1.16.0
+    - pip install botocore==1.31.62
+    - pip install boto3==1.28.62
     - pip install ecs-deploy==1.14.0
     - pip install awscli==1.29.59
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/pender/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/pender/##' > env.live.names


### PR DESCRIPTION
## Description

This pull request updates version pins for deployment dependencies including the six and urllib3 packages.

References: DEVOPS-502

## How has this been tested?

I performed a deployment into QA with these versions to confirm the fix.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] My changes generate no new warnings

