### PR TITLE
3843 – Unrelated instagram links from the same page being matched

### DIFF
--- a/app/models/concerns/provider_instagram.rb
+++ b/app/models/concerns/provider_instagram.rb
@@ -9,6 +9,10 @@ module ProviderInstagram
     def ignored_urls
       [
         {
+          pattern: /^https:\/\/(www\.)?instagram\.com/,
+          reason: :login_page
+        },
+        {
           pattern: /^https:\/\/www\.instagram\.com\/accounts\/login/,
           reason: :login_page
         },

--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -3,6 +3,7 @@ module Parser
     include ProviderInstagram
 
     INSTAGRAM_ITEM_URL = /^https?:\/\/(www\.)?instagram\.com\/(p|tv|reel)\/([^\/]+)/
+    INSTAGRAM_HOME_URL = /^https?:\/\/(www\.)?instagram\.com\/?$/
     
     class << self
       def type
@@ -10,14 +11,14 @@ module Parser
       end
 
       def patterns
-        [INSTAGRAM_ITEM_URL]
+        [INSTAGRAM_ITEM_URL, INSTAGRAM_HOME_URL]
       end
     end
     
     private
 
     # Main function for class
-    def parse_data_for_parser(doc, _original_url, _jsonld_array)
+    def parse_data_for_parser(doc, original_url, _jsonld_array)      
       id = url.match(INSTAGRAM_ITEM_URL)[3]
       @parsed_data.merge!(external_id: id)
 

--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -18,7 +18,7 @@ module Parser
     private
 
     # Main function for class
-    def parse_data_for_parser(doc, original_url, _jsonld_array)      
+    def parse_data_for_parser(doc, original_url, _jsonld_array)
       id = url.match(INSTAGRAM_ITEM_URL)[3]
       @parsed_data.merge!(external_id: id)
 


### PR DESCRIPTION
## Description

One of our users saw a bug where some unrelated items were being matched. 

This happened because even though they linked to different urls their data was the same (the title for all of them were the instagram home url). They were also being parsed by page and not instagram item parser.

References: 3843

## How has this been tested?

Added a live test (`test "should parse Instagram item when the final url is instagram.com"`) and a stubbed test (`test "should return url as title when redirected to instagram main page"`).
