### PR TITLE
Update when to archive to archive.org and perma.cc

### DIFF
--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -40,14 +40,8 @@ module MediaPermaCcArchiver
         data = { error: { message: 'Missing authentication key', code: Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY') }}
         Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
       else
-        id = Media.get_id(url)
-        data = Pender::Store.current.read(id, :json)
-        return if data.nil? || data.dig(:archives, :perma_cc).nil?
-
-        settings = Media.api_key_settings(key_id)
-        Media.notify_webhook('perma_cc', url, data, settings)
+        return false
       end
-      return true
     end
   end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -77,12 +77,12 @@ class Media
       handle_exceptions(self, StandardError) { self.parse }
       self.data['title'] = self.url if self.data['title'].blank?
       data = self.data.merge(Media.required_fields(self)).with_indifferent_access
+      self.archive(options.delete(:archivers))
       if data[:error].blank?
         Pender::Store.current.write(id, :json, cleanup_data_encoding(data))
       end
       self.upload_images
     end
-    self.archive(options.delete(:archivers))
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
     Pender::Store.current.read(id, :json) || cleanup_data_encoding(data)
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -84,7 +84,7 @@ class Media
       self.upload_images
     end
     archive_if_conditions_are_met(options, id, cache)
-    Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
+    # Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 
@@ -284,14 +284,11 @@ class Media
   end
 
   def archive_if_conditions_are_met(options, id, cache)
-    total_of_archivers_in_options = options&.dig(:archivers)&.split(',')&.size.to_i
-    total_of_archivers_in_cache = cache.read(id, :json)['archives']&.size.to_i
-
     if options.delete(:force) || 
       cache.read(id, :json).nil? ||
       cache.read(id, :json).dig('archives').blank? ||
-      # if the user adds a new archiver, and the cache exists only for the old archiver it refreshes the cache
-      !options&.dig(:archivers).nil? && (total_of_archivers_in_options > total_of_archivers_in_cache)
+      # if the user adds a new  or changes the archiver, and the cache exists only for the old archiver it refreshes the cache
+      options&.dig(:archivers) != cache.read(id, :json)['archives'].keys.join
         self.archive(options.delete(:archivers))
     end
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -84,7 +84,7 @@ class Media
       self.upload_images
     end
     archive_if_conditions_are_met(options, id, cache)
-    # Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
+    Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -289,7 +289,8 @@ class Media
 
     if options.delete(:force) || 
       cache.read(id, :json).nil? ||
-      cache.read(id, :json)&.dig('archives')&.empty? ||
+      cache.read(id, :json).dig('archives').blank? ||
+      # if the user adds a new archiver, and the cache exists only for the old archiver it refreshes the cache
       !options&.dig(:archivers).nil? && (total_of_archivers_in_options > total_of_archivers_in_cache)
         self.archive(options.delete(:archivers))
     end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -82,11 +82,8 @@ class Media
         cache.write(id, :json, cleanup_data_encoding(data))
       end
       self.upload_images
-      self.archive(options.delete(:archivers))
     end
-    if cache.read(id, :json)&.dig('archives')&.empty?
-      self.archive(options.delete(:archivers))
-    end
+    archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
@@ -284,5 +281,17 @@ class Media
   def set_error(**error_hash)
     return if error_hash.empty?
     self.data[:error] = error_hash
+  end
+
+  def archive_if_conditions_are_met(options, id, cache)
+    total_of_archivers_in_options = options&.dig(:archivers)&.split(',')&.size.to_i
+    total_of_archivers_in_cache = cache.read(id, :json)['archives']&.size.to_i
+
+    if options.delete(:force) || 
+      cache.read(id, :json).nil? ||
+      cache.read(id, :json)&.dig('archives')&.empty? ||
+      !options&.dig(:archivers).nil? && (total_of_archivers_in_options > total_of_archivers_in_cache)
+        self.archive(options.delete(:archivers))
+    end
   end
 end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -37,11 +37,10 @@ class ArchiverTest < ActiveSupport::TestCase
   test "should archive to Archive.org" do
     Media.any_instance.unstub(:archive_to_archive_org)
     Media.stubs(:get_available_archive_org_snapshot).returns(nil)
-    url = 'https://g1.globo.com/'
     WebMock.enable!
-    allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
-    WebMock.disable_net_connect!(allow: allowed_sites)
+    url = 'https://example.com/'
 
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -283,7 +283,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should archive to perma.cc and store the URL on archives if perma_cc_key is present" do
     Media.any_instance.unstub(:archive_to_perma_cc)
-    
+
     WebMock.enable!
     url = 'https://example.com'
 


### PR DESCRIPTION
## Description

We realized we needed to update how we deal with when to archive, and that we should check for those conditions only in Media, `media_perma_cc_archiver` and `media_archive_org_archiver` should only worry about archiving to their respective site.

References: 3707

## How has this been tested?

The tests are currently passing. For perma_cc: I updated one(`"should not try to archive on Perma.cc if already present in cache and no refresh is requested"`) and added another (`"should try to archive on Perma.cc if already present in cache and but refresh is requested"`).

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- are the conditionals making sense? is there anything I missed?
- is there any logic left inside `media_perma_cc_archiver` or `media_archive_org_archiver` related to this that should be moved?
