### PR TITLE
Archive.org should get the closest snapshot and send it as a fallback

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -47,9 +47,17 @@ module MediaArchiveOrgArchiver
         location = body.dig('archived_snapshots', 'closest', 'url')
         data = { location: location }
         Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
+<<<<<<< HEAD
         return true
       end
       nil
+=======
+        data
+      else
+        Rails.logger.info level: 'INFO', message: '[archive_org] no available snapshot', url: url
+        nil
+      end
+>>>>>>> d4b52df (return the closest snapshot and error if requests errors)
     end
 
     def get_archive_org_status(job_id, url, key_id)

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -13,7 +13,7 @@ module MediaArchiveOrgArchiver
     def send_to_archive_org(url, key_id, _supported = nil)
       handle_archiving_exceptions('archive_org', { url: url, key_id: key_id }) do
         encoded_uri = RequestHelper.encode_url(url)
-        return if Media.get_available_archive_org_snapshot(encoded_uri, key_id)
+        snapshot_data = Media.get_available_archive_org_snapshot(encoded_uri, key_id)
         http, request = Media.archive_org_request('https://web.archive.org/save', 'Post')
         request.set_form_data(
           "capture_screenshot" => "1",
@@ -32,7 +32,7 @@ module MediaArchiveOrgArchiver
             url: url,
             response_body: body
           )
-          data = { error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }}
+          data = snapshot_data.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         end
       end
@@ -47,17 +47,10 @@ module MediaArchiveOrgArchiver
         location = body.dig('archived_snapshots', 'closest', 'url')
         data = { location: location }
         Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
-<<<<<<< HEAD
-        return true
-      end
-      nil
-=======
         data
       else
-        Rails.logger.info level: 'INFO', message: '[archive_org] no available snapshot', url: url
         nil
       end
->>>>>>> d4b52df (return the closest snapshot and error if requests errors)
     end
 
     def get_archive_org_status(job_id, url, key_id)

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -32,7 +32,7 @@ module MediaArchiveOrgArchiver
             url: url,
             response_body: body
           )
-          data = snapshot_data.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
+          data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         end
       end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -54,6 +54,30 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.disable!
   end
 
+  test "when archive.org fails to archive, it should add to data the available archive.org snapshot and the error" do
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+    WebMock.enable!
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(status: 200, body: { message: 'The same snapshot had been made 12 hours, 13 minutes ago. You can make new capture of this URL after 24 hours.', url: url}.to_json)
+    
+    media = create_media url: url, key: a
+    id = Media.get_id(media.url)
+    data = media.as_json(archivers: 'archive_org')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+
+    assert_match /The same snapshot/, data.dig('archives', 'archive_org', 'error', 'message') 
+    assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
+  ensure
+    WebMock.disable!
+  end
+
   test "should archive Arabics url to Archive.org" do
     Media.any_instance.unstub(:archive_to_archive_org)
     a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -713,32 +713,29 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.disable!
   end
 
-  test "should return true and get available snapshot if page was already archived on Archive.org" do
-    url = 'https://example.com/'
-    m = Media.new url: url
-    m.as_json
-
+  test "should get and return the available snapshot if page was already archived on Archive.org" do
     WebMock.enable!
-    allowed_sites = lambda{ |uri| uri.host != 'archive.org' }
-    WebMock.disable_net_connect!(allow: allowed_sites)
+    url = 'https://example.com/'
+    api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    encoded_uri = RequestHelper.encode_url(url)
 
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
     WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}}.to_json)
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    assert_equal true, Media.get_available_archive_org_snapshot(url, nil)
-    data = m.as_json
-    assert_equal 'http://web.archive.org/web/20210223111252/http://example.com/' , data['archives']['archive_org']['location']
+    snapshot = Media.get_available_archive_org_snapshot(encoded_uri, api_key)
+    assert_equal 'http://web.archive.org/web/20210223111252/http://example.com/' , snapshot[:location]
   ensure
     WebMock.disable!
   end
 
   test "should return nil if page was not previously archived on Archive.org" do
     WebMock.enable!
-    allowed_sites = lambda{ |uri| uri.host != 'archive.org' }
-    WebMock.disable_net_connect!(allow: allowed_sites)
+    url = 'https://example.com/'
 
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json)
 
-    url = 'https://example.com/'
     assert_nil Media.get_available_archive_org_snapshot(url, nil)
   ensure
     WebMock.disable!


### PR DESCRIPTION
## Description

We want to send the closest snapshot as a fallback. So if our request errors we send both the error and the snapshot (if one is available)

References: 3707

## How has this been tested?

We have a test that checks if `get_available_archive_org_snapshot` method returns the snapshot url. And we have another test to check if when the request fails it sets the closest snapshot as a fallback while also sending the error (`when archive.org fails to archive, it should add to data the available archive.org snapshot and the error`).
