### PR TITLE
Create Archive.org specific errors

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -25,10 +25,8 @@ module MediaArchiveOrgArchiver
         Rails.logger.info level: 'INFO', message: '[archive_org] Sent URL to archive', url: url, code: response.code, response: response.message
         body = JSON.parse(response.body)
         if body['job_id']
-          puts "#{url} archive_org / body id present"
           Media.delay_for(2.minutes).get_archive_org_status(body['job_id'], url, key_id)
         else
-          puts "#{url} archive_org / no body id"
           PenderSentry.notify(
             Pender::Exception::TooManyCaptures.new(body["message"]),
             url: url,

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -27,11 +27,19 @@ module MediaArchiveOrgArchiver
         if body['job_id']
           Media.delay_for(2.minutes).get_archive_org_status(body['job_id'], url, key_id)
         else
+          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
           PenderSentry.notify(
             Pender::Exception::TooManyCaptures.new(body["message"]),
             url: url,
             response_body: body
           )
+          else
+            PenderSentry.notify(
+              StandardError.new(body["message"]),
+              url: url,
+              response_body: body
+            )
+          end
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         end

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -25,10 +25,12 @@ module MediaArchiveOrgArchiver
         Rails.logger.info level: 'INFO', message: '[archive_org] Sent URL to archive', url: url, code: response.code, response: response.message
         body = JSON.parse(response.body)
         if body['job_id']
+          puts "#{url} archive_org / body id present"
           Media.delay_for(2.minutes).get_archive_org_status(body['job_id'], url, key_id)
         else
+          puts "#{url} archive_org / no body id"
           PenderSentry.notify(
-            StandardError.new(body["message"]),
+            Pender::Exception::TooManyCaptures.new(body["message"]),
             url: url,
             response_body: body
           )

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -27,19 +27,15 @@ module MediaArchiveOrgArchiver
         if body['job_id']
           Media.delay_for(2.minutes).get_archive_org_status(body['job_id'], url, key_id)
         else
+          klass = Pender::Exception::ArchiveOrgError
           if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
+            klass = Pender::Exception::TooManyCaptures
+          end
           PenderSentry.notify(
-            Pender::Exception::TooManyCaptures.new(body["message"]),
+            klass.new(body["message"]),
             url: url,
             response_body: body
           )
-          else
-            PenderSentry.notify(
-              StandardError.new(body["message"]),
-              url: url,
-              response_body: body
-            )
-          end
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         end

--- a/lib/pender/exception/archive_org_error.rb
+++ b/lib/pender/exception/archive_org_error.rb
@@ -1,0 +1,5 @@
+module Pender
+  module Exception
+    class ArchiveOrgError < StandardError; end
+  end
+end

--- a/lib/pender/exception/too_many_captures.rb
+++ b/lib/pender/exception/too_many_captures.rb
@@ -1,0 +1,5 @@
+module Pender
+  module Exception
+    class TooManyCaptures < StandardError; end
+  end
+end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -879,6 +879,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "MediaArchiver should not notify Sentry when the worker hits the maximum number of retries" do
+    skip("this test has been flaking, and I'm not sure we should keep it. Will review this when I clean up the tests")
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     Media.any_instance.stubs(:follow_redirections)


### PR DESCRIPTION
## Description

We created specific errors to Archive.org. We want to make it easier to identify where errors are coming from in Sentry, and what they are related to.

References: TICKET-ID, TICKET-ID, …

## How has this been tested?

I tested this one by raising the errors and checking Sentry.

<img width="547" alt="Screenshot 2023-10-17 at 16 50 21" src="https://github.com/meedan/pender/assets/87862340/c35d3878-92b0-4fb2-ad3e-73d2a1c2d1a4">

I wasn't sure if it was needed to add a test here. We have tests that check for how the archivers behave in case of failure, what would we be testing here? If Sentry is notified? So I didn't add one, if you feel we should add a test, I can do so.

