### PR TITLE
3865 – Fix issue where death handler was getting NilClass instead of Exception

### DIFF
--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -13,8 +13,10 @@ if File.exist?(file)
     config.death_handlers << ->(job, original_exception) do
       if original_exception.is_a?(Pender::Exception::RetryLater)
         limit_hit_exception = Pender::Exception::RetryLimitHit.new(original_exception)
+        PenderSentry.notify(limit_hit_exception, { job: job, original_exception: original_exception.cause.inspect })
+      else
+        PenderSentry.notify(original_exception, { job: job })
       end
-      PenderSentry.notify(limit_hit_exception, {job: job, original_exception: original_exception.cause.inspect})
     end
   end
 


### PR DESCRIPTION
## Description
We were getting some errors on Sentry where we expected the argument to be an Exception, but got NilClass. We think that was happening because some errors where happening during a delayed job (`get_archive_org_status`), so our `handle_archiving_exceptions` wasn't handling those.

Meaning they would be retried multiple times without being re-raised as RetryLater. When they hit the death handler limit_hit_exception would be nil because they would fail `if original_exception.is_a?(Pender::Exception::RetryLater)`

We are now handling errors inside `get_archive_org_status`, but we are adding the else to the death handler as an extra safety measure. We want to see what kind of errors we get for a while and then decide if this i needed or not, and what the best way to handle this is.

References: 3865

## How has this been tested?

I raised some errors and saw if the death handlers was working correctly.
