### PR TITLE
Retry ArchiveOrgErrors

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -36,7 +36,7 @@ module MediaArchiveOrgArchiver
               response_body: body
             )
           else
-            raise Pender::Exception::ArchiveOrgError
+            raise Pender::Exception::ArchiveOrgError, message = "(#{body['status_ext']}) #{body['message']}"
           end
         end
       end

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -27,17 +27,17 @@ module MediaArchiveOrgArchiver
         if body['job_id']
           Media.delay_for(2.minutes).get_archive_org_status(body['job_id'], url, key_id)
         else
-          klass = Pender::Exception::ArchiveOrgError
-          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
-            klass = Pender::Exception::TooManyCaptures
-          end
-          PenderSentry.notify(
-            klass.new(body["message"]),
-            url: url,
-            response_body: body
-          )
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
+          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
+            PenderSentry.notify(
+              Pender::Exception::TooManyCaptures.new(body["message"]),
+              url: url,
+              response_body: body
+            )
+          else
+            raise Pender::Exception::ArchiveOrgError
+          end
         end
       end
     end

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -36,7 +36,7 @@ module MediaArchiveOrgArchiver
               response_body: body
             )
           else
-            raise Pender::Exception::ArchiveOrgError, message = "(#{body['status_ext']}) #{body['message']}"
+            raise Pender::Exception::ArchiveOrgError, "(#{body['status_ext']}) #{body['message']}"
           end
         end
       end


### PR DESCRIPTION
## Description

We split archive org errors into two: Pender::Exception::TooManyCaptures and Pender::Exception::ArchiveOrgError. It makes sense for Pender::Exception::TooManyCaptures to not be retried, but Pender::Exception::ArchiveOrgError should. So we updated `send_to_archive_org` in `media_archive_org_archiver`.

References: 3707

## How has this been tested?

Test "should update media with error when Archive.org can't archive the url" makes sure we are getting the error data when we hit ArchiveOrgError. 
Test "when archive.org fails to archive, it should add to data the available archive.org snapshot (if available) and the error" makes sure we are getting the data (and snapshot) when we hit TooManyCaptures.
The tests here maybe should be renamed, but I'll look into that while going through the tests' refactoring. 
