### PR TITLE
[wip] 3886 – Clean up archiver tests

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -6,7 +6,7 @@ module MediaArchiveOrgArchiver
   end
 
   def archive_to_archive_org(url, key_id)
-    ArchiverWorker.perform_in(30.seconds, url, :archive_org, key_id)
+    ArchiverWorker.perform_in(30.seconds, url, 'archive_org', key_id)
   end
 
   module ClassMethods

--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -93,8 +93,6 @@ module MediaArchiver
       rescue StandardError => error
         error_type = 'ARCHIVER_ERROR'
         params.merge!({code: Lapis::ErrorCodes::const_get(error_type), message: error.message})
-        data = { error: { message: params[:message], code: Lapis::ErrorCodes::const_get(error_type) }}
-        Media.notify_webhook_and_update_cache(archiver, params[:url], data, params[:key_id])
         retry_archiving_after_failure(archiver, params)
       end
     end

--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -68,15 +68,11 @@ module MediaArchiver
 
     def notify_webhook_and_update_cache(archiver, url, data, key_id)
       settings = Media.api_key_settings(key_id)
+
       id = Media.get_id(url)
-      location = Pender::Store.current.read(id, :json).to_h.dig('archives', archiver, 'location')
-      error = data.dig(:error)
-      if location
-        hash = { archives: { archiver => { location: location, error: error } } }
-        Media.update_cache(url, hash)
-      else
-        Media.update_cache(url, { archives: { archiver => data  } })
-      end
+      archiver_data = Pender::Store.current.read(id, :json).to_h.dig('archives', archiver).to_h
+      archiver_data.delete('error')
+      Media.update_cache(url, { archives: { archiver => archiver_data.merge(data) } })
       Media.notify_webhook(archiver, url, data, settings)
     end
 

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -39,6 +39,7 @@ module MediaPermaCcArchiver
       if perma_cc_key.nil?
         data = { error: { message: 'Missing authentication key', code: Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY') }}
         Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
+        return true
       else
         return false
       end

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -30,7 +30,7 @@ module MediaPermaCcArchiver
           data = { location: 'http://perma.cc/' + body['guid'] }
           Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
         else
-          raise Pender::Exception::RetryLater, "(#{response.code}) #{response.message}"
+          raise Pender::Exception::PermaCcError, "(#{response.code}) #{response.message}"
         end
       end
     end

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -6,7 +6,7 @@ module MediaPermaCcArchiver
   end
 
   def archive_to_perma_cc(url, key_id)
-    ArchiverWorker.perform_in(30.seconds, url, :perma_cc, key_id)
+    ArchiverWorker.perform_in(30.seconds, url, 'perma_cc', key_id)
   end
 
   module ClassMethods

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -30,7 +30,7 @@ module MediaPermaCcArchiver
           data = { location: 'http://perma.cc/' + body['guid'] }
           Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
         else
-          data = { error: { message: response.message, code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }}
+          data = { error: { message: "(#{response.code}) #{response.message}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }}
           Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
           if response&.body.include?("You've reached your usage limit")
             PenderSentry.notify(

--- a/lib/pender/exception/perma_cc_error.rb
+++ b/lib/pender/exception/perma_cc_error.rb
@@ -1,0 +1,5 @@
+module Pender
+  module Exception
+    class PermaCcError < StandardError; end
+  end
+end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -30,6 +30,7 @@ class ArchiverTest < ActiveSupport::TestCase
     create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
   end
 
+  # I don't really understand what this test is doing
   test "should skip screenshots" do
     stub_configs({'archiver_skip_hosts' => '' })
 

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -108,7 +108,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid' }.to_json)
 
     media = create_media url: url, key: api_key
     data = media.as_json(archivers: 'perma_cc')
@@ -359,7 +359,7 @@ class ArchiverTest < ActiveSupport::TestCase
     m = Media.new url: url, key: api_key
     id = Media.get_id(m.url)
 
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-FIRST' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-FIRST' }.to_json)
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'perma_cc')
@@ -368,7 +368,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal ['perma_cc'], cached.keys
     assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
 
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-SECOND' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-SECOND' }.to_json)
 
     m.as_json(archivers: 'perma_cc')
 
@@ -394,7 +394,7 @@ class ArchiverTest < ActiveSupport::TestCase
     id = Media.get_id(m.url)
 
     Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-FIRST' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-FIRST' }.to_json)
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'perma_cc')
@@ -403,7 +403,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal ['perma_cc'], cached.keys
     assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
 
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-SECOND' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-SECOND' }.to_json)
 
     m.as_json(force: true, archivers: 'perma_cc')
 
@@ -462,7 +462,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     id = Media.get_id(url)
@@ -499,7 +499,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
 
     # First archiver request responses
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
 
@@ -509,7 +509,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
 
     # Second archiver request responses
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-2' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-2' }.to_json)
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp2'}.to_json)
 
@@ -547,7 +547,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive_to_perma_cc)
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:any, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m = Media.new url: url, key: api_key

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -61,9 +61,9 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
     media = create_media url: url, key: api_key
     data = media.as_json(archivers: 'archive_org')
@@ -85,8 +85,8 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>صفحة باللغة العربية</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
     assert_nothing_raised do
       m = create_media url: url, key: api_key
@@ -108,7 +108,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid' })
 
     media = create_media url: url, key: api_key
     data = media.as_json(archivers: 'perma_cc')
@@ -131,7 +131,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(status: 200, body: { message: 'The same snapshot had been made 12 hours, 13 minutes ago. You can make new capture of this URL after 24 hours.', url: url}.to_json)
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 12 hours, 13 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
 
     media = create_media url: url, key: api_key
     data = media.as_json(archivers: 'archive_org')
@@ -197,7 +197,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." })
 
     m = Media.new url: url
     data = m.as_json(archivers: 'none')
@@ -224,7 +224,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." })
 
     m = Media.new url: url, key: api_key
     assert_raises StandardError do
@@ -257,9 +257,9 @@ class ArchiverTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0'}.to_json)
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0'})
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'error', status_ext: 'error:not-found', message: 'The server cannot find the requested resource'}.to_json)
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'error', status_ext: 'error:not-found', message: 'The server cannot find the requested resource'})
 
     assert_raises Pender::Exception::RetryLater do
       Media.send_to_archive_org(url.to_s, api_key.id)
@@ -286,8 +286,8 @@ class ArchiverTest < ActiveSupport::TestCase
     id = Media.get_id(m.url)
 
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:any, /web.archive.org\/save/).to_return(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'}.to_json)
+    WebMock.stub_request(:any, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'archive_org')
@@ -296,7 +296,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal ['archive_org'], cached.keys
     assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
 
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'}.to_json)
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'archive_org')
@@ -323,8 +323,8 @@ class ArchiverTest < ActiveSupport::TestCase
     id = Media.get_id(m.url)
 
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:any, /web.archive.org\/save/).to_return(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'}.to_json)
+    WebMock.stub_request(:any, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'archive_org')
@@ -333,7 +333,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal ['archive_org'], cached.keys
     assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
 
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'}.to_json)
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(force: true, archivers: 'archive_org')
@@ -359,7 +359,7 @@ class ArchiverTest < ActiveSupport::TestCase
     m = Media.new url: url, key: api_key
     id = Media.get_id(m.url)
 
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-FIRST' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'perma_cc')
@@ -368,7 +368,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal ['perma_cc'], cached.keys
     assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
 
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-SECOND' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
 
     m.as_json(archivers: 'perma_cc')
 
@@ -394,7 +394,7 @@ class ArchiverTest < ActiveSupport::TestCase
     id = Media.get_id(m.url)
 
     Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-FIRST' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m.as_json(archivers: 'perma_cc')
@@ -403,7 +403,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal ['perma_cc'], cached.keys
     assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
 
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-SECOND' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
 
     m.as_json(force: true, archivers: 'perma_cc')
 
@@ -426,8 +426,8 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:any, /web.archive.org\/save/).to_return(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'archive-timestamp'}.to_json)
+    WebMock.stub_request(:any, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp'})
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     id = Media.get_id(url)
@@ -462,7 +462,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     id = Media.get_id(url)
@@ -471,8 +471,8 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal({'perma_cc' => {"location" => 'http://perma.cc/perma-cc-guid-1'}}, Pender::Store.current.read(id, :json)[:archives])
 
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
     m.as_json(archivers: 'perma_cc, archive_org')
     assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
@@ -499,9 +499,9 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
 
     # First archiver request responses
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
     id = Media.get_id(url)
     m = create_media url: url, key: api_key
@@ -509,9 +509,9 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
 
     # Second archiver request responses
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-2' }.to_json)
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp2'}.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-2' })
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp2'})
 
     m.as_json
     assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
@@ -547,7 +547,7 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.unstub(:archive_to_perma_cc)
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     m = Media.new url: url, key: api_key
@@ -948,7 +948,7 @@ class ArchiverTest < ActiveSupport::TestCase
     encoded_uri = RequestHelper.encode_url(url)
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}}.to_json)
+    WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return_json(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}})
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     snapshot = Media.get_available_archive_org_snapshot(encoded_uri, api_key)
@@ -964,7 +964,7 @@ class ArchiverTest < ActiveSupport::TestCase
     url = 'https://example.com/'
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json)
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}})
 
     assert_nil Media.get_available_archive_org_snapshot(url, nil)
   ensure
@@ -982,7 +982,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(body: { guid: 'perma-cc-guid-1' }.to_json)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 425, body: '')
 
     m = Media.new url: url, key: api_key

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -2,9 +2,7 @@ require 'test_helper'
 
 class ArchiverTest < ActiveSupport::TestCase
   def teardown
-    super
-
-    FileUtils.rm_rf(File.join(Rails.root, 'tmp', 'videos'))
+    isolated_teardown
   end
 
   def quietly_redefine_constant(klass, constant, new_value)
@@ -784,7 +782,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
     assert_match /#{PenderConfig.get('storage_endpoint')}\/default-bucket\d*\/video/, Media.archiving_folder
 
-    api_key.application_settings[:config][:storage_video_bucket] = 'bucket-for-videos'; api_keya.save
+    api_key.application_settings[:config][:storage_video_bucket] = 'bucket-for-videos'; api_key.save
     ApiKey.current = api_key
     Pender::Store.current = nil
     PenderConfig.current = nil

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -175,7 +175,6 @@ class ArchiverTest < ActiveSupport::TestCase
       media.as_json(archivers: 'archive_org')
     end
     media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    
     assert_equal '(500) Random Error.', media_data.dig('archives', 'archive_org', 'error', 'message') 
     assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
   ensure
@@ -254,7 +253,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
     media_data = Pender::Store.current.read(Media.get_id(url), :json)
     assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
-    assert_equal 'Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
+    assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
   ensure
     WebMock.disable!
   end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -566,6 +566,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should call youtube-dl and call video upload when archive video" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     api_key = create_api_key_with_webhook
     url = 'https://www.bbc.com/news/av/world-us-canada-57176620'
@@ -588,6 +589,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should return false and add error to data when video archiving is not supported" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     api_key = create_api_key_with_webhook
     
@@ -619,11 +621,13 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should check if non-ascii URL support video download" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     Media.unstub(:supported_video?)
     assert !Media.supported_video?('http://example.com/pages/category/Musician-Band/चौधरी-कमला-बाड़मेर-108960273957085')
   end
 
   test "should notify if URL was already parsed and has a location on data when archive video" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     api_key = create_api_key_with_webhook
     url = 'https://www.bbc.com/news/av/world-us-canada-57176620'
@@ -648,6 +652,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
   # FIXME Mocking Youtube-DL to avoid `HTTP Error 429: Too Many Requests`
   test "should archive video info subtitles, thumbnails and update cache" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     
     api_key = create_api_key_with_webhook
@@ -686,6 +691,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should raise retry error when video archiving fails" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     Sidekiq::Testing.fake!
     api_key = create_api_key_with_webhook
@@ -713,6 +719,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should update media with error when supported video call raises on video archiving" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     Sidekiq::Testing.fake!
     api_key = create_api_key_with_webhook
@@ -740,6 +747,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should update media with error when video download fails when video archiving" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     api_key = create_api_key_with_webhook
     url = 'https://www.tiktok.com/@scout2015/video/6771039287917038854'
@@ -767,6 +775,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should generate the public archiving folder for videos" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     api_key = create_api_key application_settings: { config: { storage_endpoint: 'http://minio:9000', storage_bucket: 'default-bucket', storage_video_asset_path: nil, storage_video_bucket: nil }}
     ApiKey.current = api_key
 
@@ -814,6 +823,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should send to video archiver when call archive to video" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     Media.any_instance.unstub(:archive_to_video)
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
@@ -829,6 +839,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should get proxy to download video from api key if present" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.youtube.com/watch?v=unv9aPZYF6E'
@@ -848,6 +859,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should use api key config when archiving video if present" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://www.youtube.com/watch?v=o1V1LnUU5VM'

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -136,9 +136,6 @@ class ArchiverTest < ActiveSupport::TestCase
     media = create_media url: url, key: api_key
     data = media.as_json(archivers: 'archive_org')
     
-    id = Media.get_id(media.url)
-    cached = Pender::Store.current.read(id, :json)[:archives]
-
     assert_match /The same snapshot/, data.dig('archives', 'archive_org', 'error', 'message') 
     assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
   ensure

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -35,10 +35,11 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should archive to Archive.org" do
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns(nil)
     WebMock.enable!
     url = 'https://example.com/'
+    
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns(nil)
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
@@ -46,24 +47,49 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
 
     a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-    m = create_media url: url, key: a
-    data = m.as_json(archivers: 'archive_org')
+    media = create_media url: url, key: a
+    data = media.as_json(archivers: 'archive_org')
     assert_equal "https://web.archive.org/web/timestamp/#{url}", data['archives']['archive_org']['location']
   ensure
     WebMock.disable!
   end
 
-  test "should archive Arabics url to Archive.org" do
-    Media.any_instance.unstub(:archive_to_archive_org)
-    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-
-    url = 'http://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
+  test "when archive.org fails to archive, it should add to data the available archive.org snapshot and the error" do
     WebMock.enable!
-    allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
-    WebMock.disable_net_connect!(allow: allowed_sites)
+    url = 'https://example.com/'
+    
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+    
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return(status: 200, body: { message: 'The same snapshot had been made 12 hours, 13 minutes ago. You can make new capture of this URL after 24 hours.', url: url}.to_json)
+    
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    media = create_media url: url, key: a
+    id = Media.get_id(media.url)
+    data = media.as_json(archivers: 'archive_org')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+
+    assert_match /The same snapshot/, data.dig('archives', 'archive_org', 'error', 'message') 
+    assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
+  ensure
+    WebMock.disable!
+  end
+
+  test "should archive Arabics url to Archive.org" do
+    WebMock.enable!
+    url = 'http://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
+    
+    Media.any_instance.unstub(:archive_to_archive_org)
+    
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>صفحة باللغة العربية</html>')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
     WebMock.stub_request(:post, /web.archive.org\/save/).to_return(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' }.to_json)
     WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return(body: {status: 'success', timestamp: 'timestamp'}.to_json)
+    
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
 
     assert_nothing_raised do
       m = create_media url: url, key: a
@@ -135,8 +161,9 @@ class ArchiverTest < ActiveSupport::TestCase
 
   test "should update media with error when archive to Archive.org fails too many times" do
     WebMock.enable!
-    allowed_sites = lambda{ |uri| uri.host != 'web.archive.org' }
-    WebMock.disable_net_connect!(allow: allowed_sites)
+    url = 'https://www.facebook.com/permalink.php?story_fbid=1649526595359937&id=100009078379548'
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
     Media.any_instance.stubs(:follow_redirections)
@@ -146,7 +173,6 @@ class ArchiverTest < ActiveSupport::TestCase
     Media.any_instance.stubs(:archive)
 
     a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-    url = 'https://www.facebook.com/permalink.php?story_fbid=1649526595359937&id=100009078379548'
 
     assert_raises Pender::Exception::RetryLater do
       m = Media.new url: url
@@ -159,6 +185,43 @@ class ArchiverTest < ActiveSupport::TestCase
       media_data = Pender::Store.current.read(Media.get_id(url), :json)
       assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'archive_org', 'error', 'code')
       assert_equal "#{data[:code]} #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
+    end
+  ensure
+    WebMock.disable!
+  end
+
+  test "should update media with error when Archive.org can't archive the url" do
+    WebMock.enable!
+    unreachable_url = 'http://localhost:3333/unreachable-url'
+    invalid_host = 'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html'
+    urls = {
+      'http://localhost:3333/unreachable-url' => {status_ext: 'error:invalid-url-syntax', message: 'URL syntax is not valid'},
+      'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html' => {status_ext: 'error:invalid-host-resolution', message: 'Cannot resolve host'},
+    }
+
+    WebMock.stub_request(:get, unreachable_url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:get, invalid_host).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    Media.any_instance.stubs(:follow_redirections)
+    Media.any_instance.stubs(:get_canonical_url).returns(true)
+    Media.any_instance.stubs(:try_https)
+    Media.any_instance.stubs(:parse)
+    Media.any_instance.stubs(:archive)
+
+    a = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+
+    urls.each_pair do |url, data|
+      m = Media.new url: url
+      m.as_json(archivers: 'none')
+      assert_nil m.data.dig('archives', 'archive_org')
+      WebMock.stub_request(:any, /web.archive.org\/save/).to_return(body: {status: 'error', status_ext: data[:status_ext], message: data[:message]}.to_json)
+      WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+
+      Media.send_to_archive_org(url.to_s, a.id)
+      media_data = Pender::Store.current.read(Media.get_id(url), :json)
+      assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+      assert_equal "(#{data[:status_ext]}) #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
     end
   ensure
     WebMock.disable!


### PR DESCRIPTION
## Description

We had a lot of tests that were making real requests that weren't relevant to this test. So we decided to do a refactoring of the tests. What we did:

1. mock all requests
2. add new tests when needed
3. use one setup and teardown for all tests
4. skip tests related to video-archiving (we don't use this feature anymore, it will be dealt with in another ticket)
5. general clean up

While working on the tests there were a few issues that appearead, and I ended up dealing with them here:

1. skip_perma_cc_archiver should return true if key.nil? ([commit](https://github.com/meedan/pender/pull/411/commits/cec003512da8ca2d5232f3e1dca7fe644af8060a))
2. mock perma_cc failed test and fix perma_cc error raising ([commit](https://github.com/meedan/pender/pull/411/commits/ea22647217781834e7f24fcf5380479c558b0447))*
3. stop overwritting data in media_archiver ([commit](https://github.com/meedan/pender/pull/411/commits/6ab43245b13832f850023ada6fb89cb91d8e6b53)) **
4. deal with sidekiq warning ([commit](https://github.com/meedan/pender/pull/411/commits/8c3a93cd13dde826c1a82988ceb91857f7e099b6))
5. add location and error instead os overwriting everything ([commit](https://github.com/meedan/pender/pull/411/commits/637d417c7e3124b80aad45415b0d558ac0b147d7)) **
6. update how we update cache ([commit](https://github.com/meedan/pender/pull/411/commits/15d5eb5b0d4ef2cee941534dd9865fca272ee542)) **

_* I started this one here, but opened a different [PR](https://github.com/meedan/pender/pull/412), so we could get it done faster_
_** 3, 5 and 6 are all related to the same issue_

Looking back these 'few' issues should have been their own separate thing 🙃 

References: 3886