### PR TITLE
3887 – Better error handling in PermaCC

### DIFF
--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -30,7 +30,15 @@ module MediaPermaCcArchiver
           data = { location: 'http://perma.cc/' + body['guid'] }
           Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
         else
-          raise Pender::Exception::PermaCcError, "(#{response.code}) #{response.message}"
+          if response&.body.include?("You've reached your usage limit")
+            PenderSentry.notify(
+              Pender::Exception::TooManyCaptures.new(response.message),
+              url: url,
+              response_body: response.body
+            )
+          else  
+            raise Pender::Exception::PermaCcError, "(#{response.code}) #{response.message}"
+          end
         end
       end
     end

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -30,16 +30,14 @@ module MediaPermaCcArchiver
           data = { location: 'http://perma.cc/' + body['guid'] }
           Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
         else
+          data = { error: { message: response.message, code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }}
+          Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
           if response&.body.include?("You've reached your usage limit")
             PenderSentry.notify(
               Pender::Exception::TooManyCaptures.new(response.message),
               url: url,
               response_body: response.body
             )
-            error_type = 'ARCHIVER_ERROR'
-            { url: url, key_id: key_id }.merge!({code: Lapis::ErrorCodes::const_get(error_type), message: response.message})
-            data = { error: { message: response.message, code: Lapis::ErrorCodes::const_get(error_type) }}
-            Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
           else  
             raise Pender::Exception::PermaCcError, "(#{response.code}) #{response.message}"
           end

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -30,7 +30,7 @@ module MediaPermaCcArchiver
           data = { location: 'http://perma.cc/' + body['guid'] }
           Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
         else
-          raise Pender::Exception::RetryLater, "(#{response.code}) #{response.message}"
+          raise Pender::Exception::PermaCcError, "(#{response.code}) #{response.message}"
         end
       end
     end

--- a/app/models/concerns/media_perma_cc_archiver.rb
+++ b/app/models/concerns/media_perma_cc_archiver.rb
@@ -36,6 +36,10 @@ module MediaPermaCcArchiver
               url: url,
               response_body: response.body
             )
+            error_type = 'ARCHIVER_ERROR'
+            { url: url, key_id: key_id }.merge!({code: Lapis::ErrorCodes::const_get(error_type), message: response.message})
+            data = { error: { message: response.message, code: Lapis::ErrorCodes::const_get(error_type) }}
+            Media.notify_webhook_and_update_cache('perma_cc', url, data, key_id)
           else  
             raise Pender::Exception::PermaCcError, "(#{response.code}) #{response.message}"
           end

--- a/lib/pender/exception/perma_cc_error.rb
+++ b/lib/pender/exception/perma_cc_error.rb
@@ -1,0 +1,5 @@
+module Pender
+  module Exception
+    class PermaCcError < StandardError; end
+  end
+end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -541,6 +541,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should call youtube-dl and call video upload when archive video" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
@@ -562,6 +563,10 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should return false and add error to data when video archiving is not supported" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
+    WebMock.enable!
+    api_key = create_api_key_with_webhook
+    
     Media.unstub(:supported_video?)
     Media.any_instance.stubs(:parse)
     Metrics.stubs(:schedule_fetching_metrics_from_facebook)
@@ -592,11 +597,13 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should check if non-ascii URL support video download" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     Media.unstub(:supported_video?)
     assert !Media.supported_video?('http://example.com/pages/category/Musician-Band/चौधरी-कमला-बाड़मेर-108960273957085')
   end
 
   test "should notify if URL was already parsed and has a location on data when archive video" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
@@ -621,6 +628,7 @@ class ArchiverTest < ActiveSupport::TestCase
 
   # FIXME Mocking Youtube-DL to avoid `HTTP Error 429: Too Many Requests`
   test "should archive video info subtitles, thumbnails and update cache" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
@@ -659,6 +667,8 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should raise retry error when video archiving fails" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
+    WebMock.enable!
     Sidekiq::Testing.fake!
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
@@ -685,6 +695,8 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should update media with error when supported video call raises on video archiving" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
+    WebMock.enable!
     Sidekiq::Testing.fake!
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
@@ -711,6 +723,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should update media with error when video download fails when video archiving" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
@@ -738,8 +751,9 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should generate the public archiving folder for videos" do
-    a = create_api_key application_settings: { config: { storage_endpoint: 'http://minio:9000', storage_bucket: 'default-bucket', storage_video_asset_path: nil, storage_video_bucket: nil }}
-    ApiKey.current = a
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
+    api_key = create_api_key application_settings: { config: { storage_endpoint: 'http://minio:9000', storage_bucket: 'default-bucket', storage_video_asset_path: nil, storage_video_bucket: nil }}
+    ApiKey.current = api_key
 
     assert_match /#{PenderConfig.get('storage_endpoint')}\/default-bucket\d*\/video/, Media.archiving_folder
 
@@ -785,6 +799,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should send to video archiver when call archive to video" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     Media.any_instance.unstub(:archive_to_video)
     Media.any_instance.stubs(:follow_redirections)
     Media.any_instance.stubs(:get_canonical_url).returns(true)
@@ -800,6 +815,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should get proxy to download video from api key if present" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
@@ -818,6 +834,7 @@ class ArchiverTest < ActiveSupport::TestCase
   end
 
   test "should use api key config when archiving video if present" do
+    skip('we are not supporting archiving videos with youtube-dl anymore, will remove this on a separate ticket')
     WebMock.enable!
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -479,6 +479,31 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.disable!
   end
 
+  test "when Perma.cc fails with Pender::Exception::TooManyCaptures it should update media with error and not retry" do
+    WebMock.enable!
+    WebMock.disable_net_connect!(allow: [/minio/])
+    Sidekiq::Testing.inline!
+    api_key = create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    url = 'https://example.com'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
+
+    m = Media.new url: url, key: api_key
+    assert_nothing_raised do
+      m.as_json(archivers: 'perma_cc')
+    end
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
+    assert_equal 'Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
+  ensure
+    WebMock.disable!
+  end
+
   test "should add disabled Perma.cc archiver error message if perma_key is not present" do
     WebMock.enable!
     url = 'https://example.com/'

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -504,20 +504,24 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.disable!
   end
 
-  test "should add disabled Perma.cc archiver error message if perma_key is not present" do
+  test "should add disabled Perma.cc archiver error message if perma_key is not defined" do
     WebMock.enable!
+    WebMock.disable_net_connect!(allow: [/minio/])
+    Sidekiq::Testing.inline!
+    api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
     url = 'https://example.com/'
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
     Media.any_instance.unstub(:archive_to_perma_cc)
     Media.stubs(:available_archivers).returns(['perma_cc'])
+    Metrics.stubs(:schedule_fetching_metrics_from_facebook).returns(nil)    
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, "https://example.com/webhook.php").to_return(status: 200, body: '')
 
+    m = Media.new url: url, key: api_key
+    m.as_json(archivers: 'perma_cc')
+    
     id = Media.get_id(url)
-
-    assert_raises Pender::Exception::RetryLater do
-      m = Media.new url: url, key: nil
-      m.as_json(archivers: 'perma_cc')
-    end
     cached = Pender::Store.current.read(id, :json)[:archives]
     assert_match 'missing authentication', cached.dig('perma_cc', 'error', 'message').downcase
     assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY'), cached.dig('perma_cc', 'error', 'code')


### PR DESCRIPTION
## Description

We want PermaCC to have specific errors, like ArchiveOrg, so we can better track and handle errors. So I created PermaCcError, and it's also using TooManyCaptures once we hit it's limit.

Importat: While working on tests I noticed that we were raising RetryLater when we errored in PermaCC, and that was causing it to behave in a different way then expected (it wasn't updating data and notifying the webhook, that would only happen when we hit the retry limit). So we now raise PermaCcError. It's retried, updates data and notifies the webhook.

Besides that, we don't want to retry when the archiving limit is hit. So when we hit TooManyCaptures it updates data and the webhook, but does not retry.

CV2-3886

## How has this been tested?

`test "when Perma.cc fails with Pender::Exception::PermaCcError it should update media with error and retry"`
`test "when Perma.cc fails with Pender::Exception::TooManyCaptures it should update media with error and not retry"`

## Things to pay attention to during code review

Not sure if it's something to pay attention, but it's something to note: I skipped the video archiving tests (since we are not using that feature anymore), hoping it would make the tests a bit faster but it didn't make much of a difference 😅 (the tests on the refactoring branch are much faster ❤️ )
