### PR TITLE
3909 – Add 'X-Priority-Reduced' to Archive.org request

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -81,7 +81,8 @@ module MediaArchiveOrgArchiver
       http.use_ssl = uri.scheme == "https"
       headers = {
         'Accept' => 'application/json',
-        'Authorization' => "LOW #{PenderConfig.get('archive_org_access_key')}:#{PenderConfig.get('archive_org_secret_key')}"
+        'Authorization' => "LOW #{PenderConfig.get('archive_org_access_key')}:#{PenderConfig.get('archive_org_secret_key')}",
+        'X-Priority-Reduced' => '1'
       }
       [http, "Net::HTTP::#{verb}".constantize.new(uri, headers)]
     end


### PR DESCRIPTION
## Description

Priority reduction

Clients wishing to avoid rate limiting may opt to schedule their change
task at a reduced priority. When the X-Accept-Reduced-Priority request
header is set to a true-ish value (e.g., 1), a client submitting a task
for execution can avoid rate limiting. If the user is being rate limited,
the task will be queued at a reduced priority rather than returning a 429
Too Many Requests.

If priority reduction occurs, the X-Priority-Reduced header is returned
with the 200 OK response. The header value is the task’s reduced priority
number (e.g., -7 or -9).

Clients should be prepared to receive a 429 Too Many Requests even if
the X-Accept-Reduced-Priority header is sent.

https://archive.org/developers/md-write.html#priority-reduction

References: 3909

## How has this been tested?

I ran the acrhiver tests to make sure nothing broke, but I'm not sure on how to test this.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

