### PR TITLE
Log all requests made to Crowdtangle

### DIFF
--- a/app/models/concerns/media_crowdtangle_item.rb
+++ b/app/models/concerns/media_crowdtangle_item.rb
@@ -17,6 +17,7 @@ module MediaCrowdtangleItem
 
         begin
           response = http.request(request)
+          Rails.logger.info level: 'INFO', message: '[Parser] Requesting data from Crowdtangle', url: uri.to_s
           raise CrowdtangleResponseError if response.nil? || response.code != '200' || response.body.blank?
           JSON.parse(response.body)
         rescue CrowdtangleResponseError, JSON::ParserError => error

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'stringio'
 
 class FacebookItemUnitTest < ActiveSupport::TestCase
   def setup
@@ -163,6 +164,16 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
     })
 
     Parser::FacebookItem.new('https://www.facebook.com/123456789276277/posts/1127489833985824').parse_data(empty_doc, 'https://www.facebook.com/fakeaccount/posts/original-123456789')
+  end
+
+  test "logs requests sent to crowdtangle" do
+    logger_output = StringIO.new
+    Rails.logger = Logger.new(logger_output)
+
+    WebMock.stub_request(:get, /api.crowdtangle.com\/post/).to_return(status: 200, body: crowdtangle_response)
+    Parser::FacebookItem.new('https://www.facebook.com/123456789276277/posts/1127489833985824').parse_data(empty_doc, throwaway_url)
+
+    assert_includes("[Parser] Requesting data from Crowdtangle", logger_output.string)
   end
 
   test "sets information from crowdtangle" do


### PR DESCRIPTION
Currently, we only log requests made to Crowdtangle when there is a failure. In this change, we are adding logging whenever we make any request to Crowdtangle. This will make it possible to keep track of how many requests we are doing.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context – why has this been changed/fixed.

References: CV2-3892

## How has this been tested?

Tested by sending a request to parse a Facebook URL. This should log both successful and failed requests.

## Things to pay attention to during code review

Confirm whether the tests in `test/models/parser/facebook_item_test.rb:173-174` are acceptable.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

