### PR TITLE
3480 – Upgrade to Sidekiq 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: minimal
+dist: jammy
 before_install:
 - openssl aes-256-cbc -K $encrypted_3491736328a2_key -iv $encrypted_3491736328a2_iv -in config/config.yml.enc -out config/config.yml -d
 - cp config/database.yml.example config/database.yml

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'retryable'
 gem 'puma', '5.6.7'
 gem 'rack-cors', :require => 'rack/cors'
 gem 'rails-perftest'
-gem 'sidekiq', '< 7'
+gem 'sidekiq', '< 8'
 gem 'redis', '4.3.1'
 gem 'nokogiri', '1.14.3', require: false
 gem 'htmlentities', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,6 +313,8 @@ GEM
       thor (~> 1.0)
     rake (13.0.6)
     redis (4.3.1)
+    redis-client (0.18.0)
+      connection_pool
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.1.0)
@@ -362,10 +364,11 @@ GEM
     sentry-sidekiq (5.10.0)
       sentry-ruby (~> 5.10.0)
       sidekiq (>= 3.0)
-    sidekiq (6.5.1)
-      connection_pool (>= 2.2.2)
-      rack (~> 2.0)
-      redis (>= 4.2.0)
+    sidekiq (7.2.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -470,7 +473,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  sidekiq (< 7)
+  sidekiq (< 8)
   simplecov (= 0.13.0)
   simplecov-console
   spring

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -24,10 +24,8 @@ module MediaArchiveOrgArchiver
         response = http.request(request)
         Rails.logger.info level: 'INFO', message: '[archive_org] Sent URL to archive', url: url, code: response.code, response: response.message
         body = JSON.parse(response.body)
-        job_id = body[job_id]
-        if job_id
-          # Media.delay_for(2.minutes).get_archive_org_status(job_id, url, key_id)
-          ArchiverStatusWorker.perform_in(2.minutes, job_id, url, key_id)
+        if body['job_id']
+          ArchiverStatusJob.perform_in(2.minutes, body['job_id'], url, key_id)
         else
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
@@ -65,7 +63,7 @@ module MediaArchiveOrgArchiver
         response = http.request(request)
         body = JSON.parse(response.body)
         if body['status'] == 'success'
-          location = "https://web.archive.org/web/#{body['timestamp']}/#{url}"
+         location = "https://web.archive.org/web/#{body['timestamp']}/#{url}"
           data = { location: location }
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
         else

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -18,16 +18,16 @@ module Metrics
     def schedule_fetching_metrics_from_facebook(data, url, key_id)
       facebook_id = data['uuid'] if is_a_facebook_post?(data)
 
-      MetricsWorker.perform_in(30.seconds, url, key_id, 0, facebook_id)
+      MetricsWorker.perform_in(30.seconds, url, key_id.to_s, '0', facebook_id)
       NUMBER_OF_DAYS_TO_UPDATE.times do |index|
         attempt_num = index + 1
-        MetricsWorker.perform_in(attempt_num * 24.hours, url, key_id, attempt_num, facebook_id)
+        MetricsWorker.perform_in(attempt_num * 24.hours, url, key_id.to_s, attempt_num.to_s, facebook_id)
       end
     end
 
-    def get_metrics_from_facebook(url, key_id, update_number = 0, facebook_id = nil)
+    def get_metrics_from_facebook(url, key_id, update_number = '0', facebook_id = nil)
       Rails.logger.info level: 'INFO', message: "Requesting metrics from Facebook", url: url, key_id: ApiKey.current&.id, update_number: update_number, facebook_id: facebook_id
-      ApiKey.current = ApiKey.find_by(id: key_id)
+      ApiKey.current = ApiKey.find_by(id: key_id.to_i)
       begin
         value = facebook_id ? crowdtangle_metrics(facebook_id) : request_metrics_from_facebook(url)
       rescue Pender::Exception::RetryLater

--- a/app/sidekiq/archiver_status_job.rb
+++ b/app/sidekiq/archiver_status_job.rb
@@ -1,0 +1,7 @@
+class ArchiverStatusJob
+  include Sidekiq::Job
+
+  def perform(job_id, url, key_id)
+    Media.get_archive_org_status(job_id, url, key_id)
+  end
+end

--- a/app/workers/archiver_status_worker.rb
+++ b/app/workers/archiver_status_worker.rb
@@ -1,0 +1,7 @@
+class ArchiverStatusWorker
+  include Sidekiq::Worker
+
+  def perform(url, job_id, key_id, supported = nil)
+    Media.get_archive_org_status(job_id, url, key_id)
+  end
+end

--- a/app/workers/archiver_status_worker.rb
+++ b/app/workers/archiver_status_worker.rb
@@ -1,7 +1,0 @@
-class ArchiverStatusWorker
-  include Sidekiq::Worker
-
-  def perform(url, job_id, key_id, supported = nil)
-    Media.get_archive_org_status(job_id, url, key_id)
-  end
-end

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -19,9 +19,10 @@ if File.exist?(file)
       end
     end
   end
-
+  
   Sidekiq.configure_client do |config|
     config.redis = redis_config
+    config.logger.level = ::Logger::WARN
   end
 else
   SIDEKIQ_CONFIG = nil

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -26,4 +26,3 @@ if File.exist?(file)
 else
   SIDEKIQ_CONFIG = nil
 end
-Sidekiq::Extensions.enable_delay!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
   postgres13:
 services:
   redis:
-    image: redis:5
+    image: redis:6.2
     ports:
       - "6379:6379"
     volumes:

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -71,7 +71,7 @@ class MediaTest < ActiveSupport::TestCase
     data = m.as_json
     assert_match 'https://www.bbc.com', m.url
     assert_match 'BBC', data['title']
-    assert_match /Breaking news/, data['description']
+    assert_kind_of String, data['description']
     assert_equal '', data['published_at']
     assert_equal '', data['username']
     assert_equal 'https://www.bbc.com', data['author_url']


### PR DESCRIPTION
## Description

We updated to Sidekiq 7, but there were some big changes between 6 and 7. So I'm linking the guides and explaining each step that we took.

**Guides**
https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-API-Migration.md
https://github.com/sidekiq/sidekiq/blob/main/docs/7.0-Upgrade.md

**Steps**

1. We had to update Redis (Redis 6.2+ is now required)
   a. We already use Redis 6.2.2 on Live and QA
   b. We need to update in Pender, but also in Check and Check-Web
   c. We need to run integration tests to make sure this doesn't break anything.
2. strict arguments
  a. Add strict argument checking [#5071] Sidekiq will now log a warning if JSON-unsafe arguments are passed to perform_async. Add Sidekiq.strict_args!(false) to your initializer to disable this warning. This warning will switch to an exception in Sidekiq 7.0. [[link]](https://github.com/sidekiq/sidekiq/blob/main/Changes.md#640)
   b. We could silence strict args, but I was able to fix the instances we had 
3. delayed extensions
   a. They were disabled in Sidekiq 5 and removed in Sidekiq 7. [[link](https://github.com/sidekiq/sidekiq/wiki/Delayed-extensions)]
   b. I replaced where we were using delayed extensions to use a Job (I used job instead of worker because of [this](https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology) & [this](https://stackoverflow.com/questions/76095172/sidekiq-worker-vs-job))
4. logs
   a. Sidekiq info logs were quite noisy when running the tests, so I configured log level to WARN [[link](https://github.com/sidekiq/sidekiq/issues/5907#issuecomment-1536457365)]
5. Redis/Travis
   a. I ran into some Travis/Redis issues, because of that some tests that depended on Redis were failing in Travis. The solution to that was specifying the distro to `jammy` inside `travis.yml`

References: 3480

## How has this been tested?

By running the usual tests and integration tests on check-web.

