### PR TITLE
Remove code left behind when removing youtube-dl

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,13 +49,11 @@ class ActiveSupport::TestCase
     Rails.application.reload_routes!
     Media.any_instance.stubs(:archive_to_archive_org).returns(nil)
     Media.any_instance.stubs(:archive_to_perma_cc).returns(nil)
-    Media.any_instance.stubs(:archive_to_video).returns(nil)
     Media::ARCHIVERS['perma_cc'][:enabled] = true
     Media::ARCHIVERS['archive_org'][:enabled] = true
     ApiKey.current = Pender::Store.current = PenderConfig.current = nil
     clear_bucket
     Metrics.stubs(:request_metrics_from_facebook).returns({ 'share_count' => 123 })
-    Media.stubs(:supported_video?).returns(false)
   end
 
   # This will run after any test


### PR DESCRIPTION
When working on CV2-3885, we removed all references to youtube-dl since it is no longer supported, but we missed some code.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context – why has this been changed/fixed.

References: CV2-3885

## How has this been tested?

All CI checks are passing, and `grep`ing the repository does not have any references to `youtube-dl`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

