### PR TITLE
3875 – Remove facebook_test_app variable

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -127,6 +127,7 @@ test:
   storage_video_bucket:
   storage_video_asset_path:
   storage_medias_asset_path: 'http://localhost:9000/check-test/medias'
+  facebook_app: # '<FACEBOOK APP ID>:<FACEBOOK APP SECRET>'
   otel_log_level: off
   otel_traces_sampler:
   sentry_dsn:

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -5,7 +5,7 @@ class MetricsIntegrationTest < ActiveSupport::TestCase
 
   test "should get metrics from Facebook" do
     begin
-      fb_config = PenderConfig.get('facebook_test_app') || PenderConfig.get('facebook_app')
+      fb_config = PenderConfig.get('facebook_app')
       PenderConfig.current = nil
       key = create_api_key application_settings: { config: { facebook_app: fb_config }}
 


### PR DESCRIPTION
## Description

While working on updating our ssm values, we came accross the variable facebook_test_app.
WWe only used it in one test, we weren't declaring it in our config file. 
Besides, since we can specify the values by environment, I think the different variable name is not needed.

References: 3875

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

