### PR TITLE
Catch and log http errors

### DIFF
--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -28,7 +28,7 @@ class RequestHelper
         get_html(url, set_error_callback, header_options, true)
       rescue Zlib::DataError, Zlib::BufError
         get_html(url, set_error_callback, self.html_options(url).merge('Accept-Encoding' => 'identity'))
-      rescue EOFError => e
+      rescue EOFError, Net::ReadTimeout => e
         PenderSentry.notify(e, url: url)
         Rails.logger.warn level: 'WARN', message: '[Parser] Could not get html', url: url, error_class: e.class, error_message: e.message
         return nil

--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -28,6 +28,10 @@ class RequestHelper
         get_html(url, set_error_callback, header_options, true)
       rescue Zlib::DataError, Zlib::BufError
         get_html(url, set_error_callback, self.html_options(url).merge('Accept-Encoding' => 'identity'))
+      rescue EOFError => e
+        PenderSentry.notify(e, url: url)
+        Rails.logger.warn level: 'WARN', message: '[Parser] Could not get html', url: url, error_class: e.class, error_message: e.message
+        return nil
       rescue RuntimeError => e
         if !redirect_https_to_http?(header_options, e.message)
           PenderSentry.notify(e, url: url)

--- a/app/models/oembed_item.rb
+++ b/app/models/oembed_item.rb
@@ -32,7 +32,12 @@ class OembedItem
 
     headers = { 'User-Agent' => 'Mozilla/5.0 (compatible; Pender/0.1; +https://github.com/meedan/pender)' }.merge(RequestHelper.get_cf_credentials(uri))
     request = Net::HTTP::Get.new(uri.request_uri, headers)
-    response = http.request(request)
+    begin
+      response = http.request(request)
+    rescue StandardError => e
+      Rails.logger.warn level: 'WARN', message: '[Parser] Could not send oembed request', url: request_url, oembed_url: oembed_uri&.to_s
+      return nil
+    end
 
     if attempts < 5 && RequestHelper::REDIRECT_HTTP_CODES.include?(response.code)
       response = get_oembed_data_from_url(construct_absolute_path(request_url, response.header['location']), attempts: attempts + 1)

--- a/test/integration/parsers/page_item_test.rb
+++ b/test/integration/parsers/page_item_test.rb
@@ -58,7 +58,7 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     data = m.as_json
     assert_equal 'item', data['type']
     assert_equal 'page', data['provider']
-    assert_match(/Hong Kong Free Press/, data['title'])
+    assert_match(/Hong Kong lawmakers/, data['title'])
     assert_match(/Hong Kong/, data['description'])
     assert_not_nil data['published_at']
     assert_match /https:\/\/.+AFP/, data['author_url']
@@ -73,7 +73,7 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     data = m.as_json
     assert_equal 'item', data['type']
     assert_equal 'page', data['provider']
-    assert_match(/Hong Kong Free Press/, data['title'])
+    assert_match(/Hong Kong lawmakers/, data['title'])
     assert_match(/Hong Kong/, data['description'])
     assert_not_nil data['published_at']
     assert_match /https:\/\/.+AFP/, data['author_url']

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -424,6 +424,19 @@ class MediaTest < ActiveSupport::TestCase
     end
   end
 
+  test "should not reach the end of file caused by Net::Http::Proxy" do
+    logger_output = StringIO.new
+    Rails.logger = Logger.new(logger_output)
+    m = create_media url: 'https://www.nbcnews.com/'
+    parsed_url = RequestHelper.parse_url(m.url)
+    header_options = RequestHelper.html_options(m.url).merge(read_timeout: PenderConfig.get('timeout', 30).to_i)
+    OpenURI.stubs(:open_uri).with(parsed_url, header_options).raises(EOFError)
+    assert_nothing_raised do
+      m.send(:get_html, header_options)
+    end
+    assert_includes logger_output.string, "[Parser] Could not get html"
+  end
+
   test "should parse page when json+ld tag content is an empty array" do
     Media.any_instance.stubs(:doc).returns(Nokogiri::HTML('<script data-rh="true" type="application/ld+json">[]</script>'))
     url = 'https://www.nytimes.com/2019/10/13/world/middleeast/syria-turkey-invasion-isis.html'

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -437,6 +437,19 @@ class MediaTest < ActiveSupport::TestCase
     assert_includes logger_output.string, "[Parser] Could not get html"
   end
 
+  test "should not throw read time out errors caused by Net::Http::Proxy" do
+    logger_output = StringIO.new
+    Rails.logger = Logger.new(logger_output)
+    m = create_media url: 'https://www.nbcnews.com/'
+    parsed_url = RequestHelper.parse_url(m.url)
+    header_options = RequestHelper.html_options(m.url).merge(read_timeout: PenderConfig.get('timeout', 30).to_i)
+    OpenURI.stubs(:open_uri).with(parsed_url, header_options).raises(Net::ReadTimeout)
+    assert_nothing_raised do
+      m.send(:get_html, header_options)
+    end
+    assert_includes logger_output.string, "[Parser] Could not get html"
+  end
+
   test "should parse page when json+ld tag content is an empty array" do
     Media.any_instance.stubs(:doc).returns(Nokogiri::HTML('<script data-rh="true" type="application/ld+json">[]</script>'))
     url = 'https://www.nytimes.com/2019/10/13/world/middleeast/syria-turkey-invasion-isis.html'

--- a/test/models/oembed_item_test.rb
+++ b/test/models/oembed_item_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'stringio'
 
 class OembedItemUnitTest < ActiveSupport::TestCase
   def setup
@@ -93,6 +94,16 @@ class OembedItemUnitTest < ActiveSupport::TestCase
     item = OembedItem.new('https://example.com', '/foo')
 
     assert_equal 'https://example.com/foo', item.oembed_uri.to_s
+  end
+
+  test "logs oembed request failures" do
+    logger_output = StringIO.new
+    Rails.logger = Logger.new(logger_output)
+    WebMock.stub_request(:get, /example.com\/unreachable/).to_raise(StandardError)
+
+    OembedItem.new('https://example.com', '/unreachable').get_data
+
+    assert_includes logger_output.string, "[Parser] Could not send oembed request"
   end
 
   test "sets empty oembed_uri if URI is bunk for some reason" do


### PR DESCRIPTION
# Catch and log HTTP errors when calling oembed URLs

## Description

Catch and log HTTP exceptions when sending oembed requests in order to prevent generic issues in sentry.

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

