### PR TITLE
Add logging to parsers and archivers inside media.rb

### DIFF
--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -16,6 +16,7 @@ module MediaArchiver
     Media.enabled_archivers(available, self).each do |name, rule|
       rule[:patterns].each do |pattern|
         if (rule[:modifier] == :only && !pattern.match(url).nil?) || (rule[:modifier] == :except && pattern.match(url).nil?)
+          Rails.logger.info level: 'INFO', message: '[Archiver] Archiving new URL', url: url, archiver: name
           self.public_send("archive_to_#{name}", url, ApiKey.current&.id)
         end
       end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -189,6 +189,7 @@ class Media
         self.url = self.parser.url
         self.get_oembed_data
         parsed = true
+        Rails.logger.info level: 'INFO', message: '[Parser] Parsing new URL', url: self.url, provider: self.provider, type: self.type
       end
       break if parsed
     end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -189,7 +189,7 @@ class Media
         self.url = self.parser.url
         self.get_oembed_data
         parsed = true
-        Rails.logger.info level: 'INFO', message: '[Parser] Parsing new URL', url: self.url, provider: self.provider, type: self.type
+        Rails.logger.info level: 'INFO', message: '[Parser] Parsing new URL', url: self.url, parser: self.parser.to_s, provider: self.provider, type: self.type
       end
       break if parsed
     end
@@ -290,7 +290,6 @@ class Media
       cache.read(id, :json).dig('archives').blank? ||
       # if the user adds a new  or changes the archiver, and the cache exists only for the old archiver it refreshes the cache
       options&.dig(:archivers) != cache.read(id, :json)['archives'].keys.join
-        Rails.logger.info level: 'INFO', message: '[Archiver] Archiving new URL', url: self.url
         self.archive(options.delete(:archivers))
     end
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -290,6 +290,7 @@ class Media
       cache.read(id, :json).dig('archives').blank? ||
       # if the user adds a new  or changes the archiver, and the cache exists only for the old archiver it refreshes the cache
       options&.dig(:archivers) != cache.read(id, :json)['archives'].keys.join
+        Rails.logger.info level: 'INFO', message: '[Archiver] Archiving new URL', url: self.url
         self.archive(options.delete(:archivers))
     end
   end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -388,21 +388,6 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal({'archive_org' => 'new-data'}, Pender::Store.current.read(id, :json)['archives'])
   end
 
-  test 'should log archiver information when archiving URLs' do
-    url = 'https://www.example.com'
-    m = create_media url: url
-  
-    log = StringIO.new
-    Rails.logger = Logger.new(log)
-  
-    m.as_json
-
-    Media.update_cache(m.url, { archives: { 'archive_org' => 'new-data' } })
-    
-    assert_match '[Archiver] Archiving new URL', log.string
-    assert_match url, log.string
-  end
-
   test "should add error on raw oembed and generate the default oembed when can't parse oembed" do
     oembed_response = 'mock'
     oembed_response.stubs(:code).returns('200')

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -1,4 +1,5 @@
 require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'test_helper')
+require 'stringio'
 
 class MediaTest < ActiveSupport::TestCase
   test "should create media" do
@@ -108,6 +109,20 @@ class MediaTest < ActiveSupport::TestCase
     id = Media.get_id m.url
     data = m.as_json
     assert_match /\/medias\/#{id}\/author_picture/, data['author_picture']
+  end
+
+  test 'should log parser information when parsing a new URL' do
+    url = 'https://twitter.com/search?q=twitter'
+    media = Media.new(url: url)
+  
+    log = StringIO.new
+    Rails.logger = Logger.new(log)
+  
+    media.as_json 
+    
+    assert_match '[Parser] Parsing new URL', log.string
+    assert_match url, log.string
+    assert_match media.type, log.string
   end
 
   test "should handle connection reset by peer error" do

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -388,6 +388,21 @@ class MediaTest < ActiveSupport::TestCase
     assert_equal({'archive_org' => 'new-data'}, Pender::Store.current.read(id, :json)['archives'])
   end
 
+  test 'should log archiver information when archiving URLs' do
+    url = 'https://www.example.com'
+    m = create_media url: url
+  
+    log = StringIO.new
+    Rails.logger = Logger.new(log)
+  
+    m.as_json
+
+    Media.update_cache(m.url, { archives: { 'archive_org' => 'new-data' } })
+    
+    assert_match '[Archiver] Archiving new URL', log.string
+    assert_match url, log.string
+  end
+
   test "should add error on raw oembed and generate the default oembed when can't parse oembed" do
     oembed_response = 'mock'
     oembed_response.stubs(:code).returns('200')


### PR DESCRIPTION
## Description

Add logging for all parser and archiver calls so that we can collect metrics of successful vs failed parser activity.

Fixes: CV2-4107

## How has this been tested?

I confirmed that we are logging any parser and archiver activity as `INFO` entries in the logfiles.

## Things to pay attention to during code review

 - Confirm that all URL parsing is being logged
 - Confirm that all archive calls are being logged

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

