### PR TITLE
Fix broken oembed_item_test

### DIFF
--- a/app/models/oembed_item.rb
+++ b/app/models/oembed_item.rb
@@ -36,7 +36,7 @@ class OembedItem
       response = http.request(request)
     rescue StandardError => e
       Rails.logger.warn level: 'WARN', message: '[Parser] Could not send oembed request', url: request_url, oembed_url: oembed_uri&.to_s
-      return nil
+      return e
     end
 
     if attempts < 5 && RequestHelper::REDIRECT_HTTP_CODES.include?(response.code)


### PR DESCRIPTION
## Description

When fixing CV2-4053, we broke an existing oembed test where we are now returning `nil` instead of an actual error message. This change is a fix for that break.

References: CV2-4053

## How has this been tested?

I have confirmed that all tests in `oembed_item_test` are passing successfully.

## Things to pay attention to during code review

- Confirm that all tests in `oembed_item_test` are passing successfully.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

