### PR TITLE
4076 – Adjust archive_org job retry schedule

### DIFF
--- a/app/sidekiq/archiver_status_job.rb
+++ b/app/sidekiq/archiver_status_job.rb
@@ -1,5 +1,10 @@
 class ArchiverStatusJob
   include Sidekiq::Job
+  sidekiq_options retry_for: 24.hours
+
+  sidekiq_retry_in do |count|
+    (count ** 4) + 60 + (rand(10) * (count + 1))
+  end
 
   def perform(job_id, url, key_id)
     Media.get_archive_org_status(job_id, url, key_id)

--- a/app/sidekiq/archiver_status_job.rb
+++ b/app/sidekiq/archiver_status_job.rb
@@ -1,4 +1,17 @@
-class ArchiverStatusJob
+# Notes on the rationale for retrying
+# 1. I used sidekiqs own retrying/backing off formula as a starting point
+#  https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry
+# 2. start retrying:
+  # aprox. after a minute, that should be more than enough (it usually doesn't take that long)
+# 3. interval:
+  # just add a bit of more time, instead of 15, 60.
+  # It’s a small change but helps us start a bit later, a makes the intervals a bit longer.
+  # I think this is enough to help, as this happens when we are waiting for the request to be processed by archive_org
+# 4. for how long:
+  # 24 hours.
+  # If we haven’t been able to get the status after 24 hours should it seems wasteful to keep trying
+
+  class ArchiverStatusJob
   include Sidekiq::Job
   sidekiq_options retry_for: 24.hours
 

--- a/app/workers/archiver_worker.rb
+++ b/app/workers/archiver_worker.rb
@@ -1,7 +1,13 @@
 class ArchiverWorker
   include Sidekiq::Worker
+  sidekiq_options retry_for: 24.hours
 
   sidekiq_retries_exhausted { |msg, e| retries_exhausted_callback(msg, e) }
+
+  sidekiq_retry_in do |count, exception, jobhash|
+    return unless exception.is_a? Pender::Exception::ArchiveOrgError
+    (count ** 4.5) + 300 + (rand(10) * (count + 1))
+  end
 
   def self.retries_exhausted_callback(msg, _e)
     Media.give_up(msg.with_indifferent_access)

--- a/app/workers/archiver_worker.rb
+++ b/app/workers/archiver_worker.rb
@@ -4,8 +4,7 @@ class ArchiverWorker
 
   sidekiq_retries_exhausted { |msg, e| retries_exhausted_callback(msg, e) }
 
-  sidekiq_retry_in do |count, exception, jobhash|
-    return unless exception.is_a? Pender::Exception::ArchiveOrgError
+  sidekiq_retry_in do |count|
     (count ** 4.5) + 300 + (rand(10) * (count + 1))
   end
 

--- a/app/workers/archiver_worker.rb
+++ b/app/workers/archiver_worker.rb
@@ -1,3 +1,20 @@
+# Notes on the rationale for retrying
+# 1. I used sidekiqs own retrying/backing off formula as a starting point
+#  https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry
+# 2. start retrying:
+  # after 5 minutes, because of archive.org: https://archive.org/details/toomanyrequests_20191110
+# 3. interval:
+  # I think ramping up to 4.5 and starting and always adding 5 minutes might be enough.
+  # It starts later and increases the intervals faster
+# 4. for how long:
+  # 24 hours.
+  # After that I think it becomes increasingly possible that the url is no longer the version the user might have wanted to store
+# 5. this schedule is for both archive.org and perma.cc
+  # because we are unable to specify by the exception (it's always RetryLater)
+  # We prioritized archive org schedule because:
+  #  - it’s the one we use the most
+  #  - it’s the one with the most problems
+
 class ArchiverWorker
   include Sidekiq::Worker
   sidekiq_options retry_for: 24.hours


### PR DESCRIPTION
## Description

We want our archive_org jobs to stop retrying too early, both for the `archiver_worker` as for the `archiver_status_job`. This means: 
- waiting at least 5 minutes before retrying a request to save page ([relevant info](https://archive.org/details/toomanyrequests_20191110)) 
- waiting more between retries
- stop retrying if it’s over a too long period of time (the page might change if it takes days to retry)
- consider if we want all archivers to have the same behavior (since both perma and archive use the same job)

### Changes
Obs.: For both I used sidekiqs own retrying/backing off formula as a starting point.(here)[https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry]

**`archiver_status_job`**:
- start retrying: aprox. after a minute, that should be more than enough (it _usually_ doesn't take that long)
- interval: just add a bit of more time, instead of 15, 60. It’s a small change but helps us start a bit later, a makes the intervals a bit longer, I think this is enough to help, as this happens when we are waiting for the request to be processed by archive_org
- how long: 24 hours. I’m not sure about this one, I think it makes more sense for the archiving job, but if we haven’t been able to get the status after 24 hours should we keep trying? It seems unnecessary, wasteful?, to keep trying for more than that.

**`archiver_worker`**
- start retrying: after 5 minutes
- interval: I think ramping up to 4.5 and starting and always adding 5 minutes might be enough. It starts later and increases the intervals faster
- for how long: 24 hours. I think this should be the maximum we try for. After that I think it becomes increasingly possible that the url is no longer the version the user might have wanted to store
- the schedule of perma cc and archive org will be the same
    - the exception is always RetryLater, so we are not able to diferentiate
    - I'm prioritizing archive org schedule because:
       - it’s the one we use the most
       - it’s the one with the most problems

References: 4076

## Note: on `Retry-After`
- A 429 Too many requests MIGHT return a Retry-After
    - [https://archive.org/developers/iarest.html?highlight=retry after](https://archive.org/developers/iarest.html?highlight=retry%20after)
    - The server may return a `Retry-After` header with the response. The client may use this value as a suggestion for the amount of time to pause.
- I’m not too sure if it’s worth implementing this if it might or might not be there, because:
    - although it could be super usefull
    - I think it will make backing off more complex?
    - we would need to pass this data to the worker, for it to use when it exists
    - and since what actually gets to the worker is the RetryLater, I don’t know how we could pass this forward

## How has this been tested?

I changed the times to be shorter so I could just make sure I was configuring sidekiq correctly.
