### PR TITLE
3908 – Improve Metrics Update

### DIFF
--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -13,6 +13,7 @@ module Metrics
       613, # Calls to graph_url_engagement_count have exceeded the rate of 10 calls per 3600 seconds
     ]
 
+    # we are going to update once in 2 days
     NUMBER_OF_DAYS_TO_UPDATE = 1
 
     def schedule_fetching_metrics_from_facebook(data, url, key_id)
@@ -21,7 +22,7 @@ module Metrics
       MetricsWorker.perform_in(30.seconds, url, key_id.to_s, '0', facebook_id)
       NUMBER_OF_DAYS_TO_UPDATE.times do |index|
         attempt_num = index + 1
-        MetricsWorker.perform_in(attempt_num * 24.hours, url, key_id.to_s, attempt_num.to_s, facebook_id)
+        MetricsWorker.perform_in(attempt_num * 48.hours, url, key_id.to_s, attempt_num.to_s, facebook_id)
       end
     end
 

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -13,7 +13,7 @@ module Metrics
       613, # Calls to graph_url_engagement_count have exceeded the rate of 10 calls per 3600 seconds
     ]
 
-    NUMBER_OF_DAYS_TO_UPDATE = 9
+    NUMBER_OF_DAYS_TO_UPDATE = 1
 
     def schedule_fetching_metrics_from_facebook(data, url, key_id)
       facebook_id = data['uuid'] if is_a_facebook_post?(data)

--- a/app/workers/metrics_worker.rb
+++ b/app/workers/metrics_worker.rb
@@ -1,9 +1,7 @@
 class MetricsWorker
   include Sidekiq::Worker
 
-  # approximately ~17hrs from start
-  # https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry
-  sidekiq_options retry: 13
+  sidekiq_options retry_for: 17.hours
 
   def perform(url, key_id, count, facebook_id = nil)
     Metrics.get_metrics_from_facebook(url, key_id, count, facebook_id)

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -78,17 +78,13 @@ class MetricsUnitTest < ActiveSupport::TestCase
     Semaphore.new(facebook_app_id).unlock
   end
 
-<<<<<<< HEAD
-  test 'should queue ten days of metrics updates, including a near-term background job to request initial from facebook' do
-=======
   test 'should schedule metrics updates a couple of days after initial request, including a near-term background job to request initial from facebook' do
->>>>>>> 90268ed (update test to reflect updated behavior)
     stub_facebook_oauth_request
     stub_facebook_metrics_request
 
     current_time = Time.now
 
-    assert_difference 'MetricsWorker.jobs.size', 10 do
+    assert_difference 'MetricsWorker.jobs.size', 2 do
       Metrics.schedule_fetching_metrics_from_facebook({}, 'https://example.com/trending-article', key.id)
     end
 

--- a/test/models/metrics_test.rb
+++ b/test/models/metrics_test.rb
@@ -78,7 +78,11 @@ class MetricsUnitTest < ActiveSupport::TestCase
     Semaphore.new(facebook_app_id).unlock
   end
 
+<<<<<<< HEAD
   test 'should queue ten days of metrics updates, including a near-term background job to request initial from facebook' do
+=======
+  test 'should schedule metrics updates a couple of days after initial request, including a near-term background job to request initial from facebook' do
+>>>>>>> 90268ed (update test to reflect updated behavior)
     stub_facebook_oauth_request
     stub_facebook_metrics_request
 
@@ -97,8 +101,9 @@ class MetricsUnitTest < ActiveSupport::TestCase
 
     assert MetricsWorker.jobs.count, 1
     second_job = MetricsWorker.jobs.first
+
     assert Time.at(second_job['at']) > current_time + 12.hours
-    assert Time.at(second_job['at']) < current_time + 36.hours
+    assert Time.at(second_job['at']) < current_time + 49.hours
     assert_nil second_job['enqueued_at']
   end
 


### PR DESCRIPTION
## Description

Context:
* Today, we schedule metrics to be updated for a single URL everyday for a few days. When it fails, this means that the error propagation gets exponential
* We don’t have “metrics on metrics”, so we can’t really compare the number of errors with the number of requests

Scope:
* Log every time metrics are requested, differentiating between first request and updates:
    * **In our logs we are already differentiating between first attempt and update numbers by logging the `update_number`. The first attempt is logged as `update_number: 0`. So there was no need to add extra logging.** 
* Reduce the number of times we update metrics
    * **Reduced to one update in two days.**

References: 3908

## How has this been tested?

Ran the metrics_test file and updated a test (`rails test test/models/metrics_test.rb:81`).
Also just ran the code and took a look at the logs and sidekiq.

## Things to pay attention to during code review

While testing this I wasn't able to make one successful metrics request, they all failed:
```
"error_message":"(425) CUSTOM","error_class":"Pender::Exception::RetryLater"
```

