### PR TITLE
3875 – Change trigger from push to pull_request

### DIFF
--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -1,6 +1,6 @@
 name: Build and Run Integration Test
 
-on: push
+on: pull_request
 
 permissions:
   id-token: write

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -1,6 +1,12 @@
 name: Build and Run Integration Test
 
-on: pull_request
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - develop
 
 permissions:
   id-token: write


### PR DESCRIPTION

## Description

The github-slack integration is looking for “pull request opened” events
but we had marked the event trigger for the workflow to be on push commits.
they have to match, so we are changing it to the pull_request event trigger
in the test workflow.

We might be able to change it on the slack integration, but I thought it
might be better to keep it the same as presto and timpani.

References: 3875

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

