### PR TITLE
Upgrade rack-cors to version 2.0.2 or later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'open_uri_redirections', require: false
 gem 'postrank-uri', git: 'https://github.com/postrank-labs/postrank-uri.git', ref: '485ac46', require: false # Ruby 3.0 support, as of 2/6/23 no gem relaease
 gem 'retryable'
 gem 'puma', '5.6.8'
-gem 'rack-cors', :require => 'rack/cors'
+gem 'rack-cors', '>= 2.0.2', :require => 'rack/cors'
 gem 'rails-perftest'
 gem 'sidekiq', '< 8'
 gem 'redis', '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.3)
     rack (2.2.8.1)
-    rack-cors (2.0.1)
+    rack-cors (2.0.2)
       rack (>= 2.0.0)
     rack-protection (2.0.1)
       rack
@@ -454,7 +454,7 @@ DEPENDENCIES
   postrank-uri!
   puma (= 5.6.8)
   rack (>= 1.6.11)
-  rack-cors
+  rack-cors (>= 2.0.2)
   rack-protection (= 2.0.1)
   railroady
   rails (~> 6.1.7)

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -419,7 +419,7 @@ class MediasControllerTest < ActionController::TestCase
   test "should parse multiple URLs sent as list" do
     authenticate_with_token
     url1 = 'https://meedan.com/check'
-    url2 = 'https://meedan.com/mission'
+    url2 = 'https://meedan.com/about-us'
     id1 = Media.get_id(url1)
     id2 = Media.get_id(url2)
     assert_nil Pender::Store.current.read(id1, :json)


### PR DESCRIPTION
Upgrade rack-cors to version 2.0.2 or later, as recommended by Dependabot.

## Description

Upgrade rack-cors to version 2.0.2 or later, as recommended by Dependabot.


References: https://github.com/meedan/pender/security/dependabot/70

## How has this been tested?

Confirmed that all tests pass



## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

