### PR TITLE
4518 – Create metrics class abstraction using Prometheus ruby client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ gem 'addressable', '2.8.1'
 # Adding this removes some deprecation warnings, caused by double-loading of the net-protocol library
 # (see https://github.com/ruby/net-imap/issues/16). We *might* be able to remove this after upgrading to Ruby 3
 gem 'net-http'
+gem 'prometheus-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
     parallel_tests (4.2.1)
       parallel
     pg (1.1.0)
+    prometheus-client (4.2.2)
     public_suffix (4.0.7)
     puma (5.6.8)
       nio4r (~> 2.0)
@@ -454,6 +455,7 @@ DEPENDENCIES
   parallel_tests
   pg (= 1.1)
   postrank-uri!
+  prometheus-client
   puma (= 5.6.8)
   rack (>= 1.6.11)
   rack-cors (>= 2.0.2)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -85,7 +85,7 @@ class Media
     end
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:media_request_total, labels: { parser: self.data['provider'] })
+    MetricsService.increment_counter(:media_request_total, labels: { service: 'pender', parser: self.data['provider'] })
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -85,8 +85,8 @@ class Media
     end
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    cache.read(id, :json) || cleanup_data_encoding(data)
     MetricsService.increment_counter(:media_request_total, labels: { parser: self.data['provider'] })
+    cache.read(id, :json) || cleanup_data_encoding(data)
   end
 
   PARSERS = [

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -86,6 +86,7 @@ class Media
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
     cache.read(id, :json) || cleanup_data_encoding(data)
+    MetricsService.increment_counter(:media_request_total, labels: { parser: self.data['provider'] })
   end
 
   PARSERS = [

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,13 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
+require 'rack'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
+
+use Rack::Deflater
+use Prometheus::Middleware::Collector
+use Prometheus::Middleware::Exporter
 
 if Rails.env.profile?
   use Rack::RubyProf, path: 'tmp/profile'

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,0 +1,3 @@
+Rails.application.reloader.to_prepare do
+  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:parser])
+end

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,3 +1,3 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:parser])
+  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:service, :parser])
 end

--- a/lib/metrics_service.rb
+++ b/lib/metrics_service.rb
@@ -2,7 +2,7 @@ require 'prometheus/client'
 
 class MetricsService
   class << self
-    def custom_counter(name, description, labels: {})
+    def custom_counter(name, description, labels: [])
       counter = Prometheus::Client::Counter.new(
         name, 
         docstring: description,
@@ -11,14 +11,14 @@ class MetricsService
       prometheus_registry.register(counter)
     end
 
-    def increment_counter(name, labels: {})
+    def increment_counter(name, labels: [])
       counter = prometheus_registry.get(name)
       return if counter.nil?
 
       counter.increment(labels: labels)
     end
 
-    def get_counter(counter, labels: {})
+    def get_counter(counter, labels: [])
       counter.get(labels: labels)
     end
 

--- a/lib/metrics_service.rb
+++ b/lib/metrics_service.rb
@@ -1,0 +1,32 @@
+require 'prometheus/client'
+
+class MetricsService
+  class << self
+    def custom_counter(name, description, labels: {})
+      counter = Prometheus::Client::Counter.new(
+        name, 
+        docstring: description,
+        labels: labels
+        )
+      prometheus_registry.register(counter)
+    end
+
+    def increment_counter(name, labels: {})
+      counter = prometheus_registry.get(name)
+      return if counter.nil?
+
+      counter.increment(labels: labels)
+    end
+
+    def get_counter(counter, labels: {})
+      counter.get(labels: labels)
+    end
+
+    private
+
+    def prometheus_registry
+      Prometheus::Client.registry
+    end
+
+  end
+end

--- a/test/lib/metrics_service_test.rb
+++ b/test/lib/metrics_service_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class MetricsServiceTest < ActiveSupport::TestCase
+  test "custom_counter works for real" do
+    assert_nothing_raised do
+      MetricsService.custom_counter(:custom_counter, 'Custom counter test', labels: [:test])
+    end
+  end
+
+  test "increment_counter works for real" do
+    MetricsService.custom_counter(:custom_counter_2, 'Custom counter test', labels: [:test])
+
+    assert_nothing_raised do
+      MetricsService.increment_counter(:custom_counter_2, labels: [:test])
+    end
+  end
+
+  test "get_counter works for real" do
+    custom_counter = MetricsService.custom_counter(:custom_counter_3, 'Custom counter test', labels: [:test])
+
+    assert_nothing_raised do
+      MetricsService.get_counter(custom_counter, labels: [:test])
+    end
+  end
+end

--- a/test/models/parser/dropbox_test.rb
+++ b/test/models/parser/dropbox_test.rb
@@ -7,8 +7,8 @@ class DropboxIntegrationTest < ActiveSupport::TestCase
 
     assert_equal 'item', data['type']
     assert_equal 'dropbox', data['provider']
-    assert_equal 'How to use the Public folder.rtf', data['title']
     assert_equal 'Shared with Dropbox', data['description']
+    assert_match /How.to.use.the.Public.folder.rtf/, data['title']
     assert_not_nil data['picture']
     assert_nil data['error']
   end


### PR DESCRIPTION
## Description

- Added the gem `prometheus-client`.
- Created a class abstraction `MetricsService`, so it's easy for us to change between prometheus, otel, or whatever else we might think is best.
- Created some very basic methods to create and increment a custom counter.
- Created one metric `media_request_total` so we can start testing things.
- We create and register custom metrics once on initialization, and then call increment wherever it's needed
- The gem adds `http_server_request_duration_seconds histogram`, `http_server_requests_total counter` and `http_server_exceptions_total counter` by default.

References: 4396, 4518

## How has this been tested?

I added some very basic tests, just to make sure I was implementing the methods correctly. Please suggests any tests you think are needed.

And tested by making requests and checking the logs on the Prometheus endpoint:

<img width="1024" alt="Screenshot 2024-06-13 at 16 43 51" src="https://github.com/meedan/pender/assets/87862340/c4d15bea-637a-4161-ac85-d77d13d5169a">