### PR TITLE
Add safe navigation operator to fix sentry issue

### DIFF
--- a/app/views/medias/index.js.erb
+++ b/app/views/medias/index.js.erb
@@ -50,7 +50,7 @@
       frame.setAttribute(attr, attrs[attr]);
     }
     frame.innerHTML = 'Your browser does not support iframes';
-    
+
     placeholder.parentNode.insertBefore(frame, placeholder.nextSibling);
 
     if (blockquote) {
@@ -85,7 +85,7 @@
             f = frame.getBoundingClientRect(),
             h = window.innerHeight || document.documentElement.clientHeight,
             w = window.innerWidth || document.documentElement.clientWidth;
-          if (isVisible(frame)) frame.contentWindow.postMessage(['lazyLoad', h, w, f.top, f.left, f.bottom, f.right].join(';'), '*');
+          if (isVisible(frame)) frame.contentWindow?.postMessage(['lazyLoad', h, w, f.top, f.left, f.bottom, f.right].join(';'), '*');
       }
     };
 


### PR DESCRIPTION
## Description

Fixes `Cannot read properties of null (reading 'postMessage')` found on Sentry.

References: CV2-4900

## How has this been tested?

Since the real cause is very hard to reproduce, I just tested manually that the pender embeds are still working after the change.
I also verified compatibility of the safe navigation operator with browsers and it's supported since 2020 in Chrome and Firefox, so I'm assuming it's safe to use, since I don't think there's any sort of backward compatibility preprocessing in Pender.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

