### PR TITLE
4520 – Add metrics to code and create Honeycomb status dashboard: parser requests [WIP]

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -86,7 +86,7 @@ class Media
     end
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:media_request_total, labels: { parser: data[:provider], host: URI(data[:url]).host, error: data[:error].nil? ? 'none' : data[:error] })
+    MetricsService.increment_counter(:parsing_requests_total, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -86,7 +86,7 @@ class Media
     end
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:media_request_total, labels: { service: 'pender', parser: self.data['provider'] })
+    MetricsService.increment_counter(:media_request_total, labels: { parser: data[:provider] })
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -85,9 +85,14 @@ class Media
       self.upload_images
     end
     archive_if_conditions_are_met(options, id, cache)
-    Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:parsing_requests_total, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
-    cache.read(id, :json) || cleanup_data_encoding(data)
+    # Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
+    MetricsService.increment_counter(:parser_requests_total, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
+    if data[:error].nil?
+      MetricsService.increment_counter(:parser_requests_success, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host })
+    else
+      MetricsService.increment_counter(:parser_requests_error, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host })
+    end
+      cache.read(id, :json) || cleanup_data_encoding(data)
   end
 
   PARSERS = [

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -85,14 +85,9 @@ class Media
       self.upload_images
     end
     archive_if_conditions_are_met(options, id, cache)
-    # Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:parser_requests_total, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
-    if data[:error].nil?
-      MetricsService.increment_counter(:parser_requests_success, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host })
-    else
-      MetricsService.increment_counter(:parser_requests_error, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host })
-    end
-      cache.read(id, :json) || cleanup_data_encoding(data)
+    Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
+    parser_requests_metrics
+    cache.read(id, :json) || cleanup_data_encoding(data)
   end
 
   PARSERS = [
@@ -331,4 +326,18 @@ class Media
         self.archive(options.delete(:archivers))
     end
   end
+
+  def parser_requests_metrics
+    MetricsService.increment_counter(:parser_requests_total)
+    MetricsService.increment_counter(:parser_requests_per_parser, labels: { parser_name: data[:provider], parsing_status: data[:error].nil? ?  'success' : 'error' })
+    MetricsService.increment_counter(:parser_requests, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
+    if data[:error].nil?
+      MetricsService.increment_counter(:parser_requests_success)
+      MetricsService.increment_counter(:parser_requests_success_per_parser, labels: { parser_name: data[:provider] })
+    else
+      MetricsService.increment_counter(:parser_requests_error)
+      MetricsService.increment_counter(:parser_requests_error_per_parser, labels: { parser_name: data[:provider] })
+    end
+  end
+
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -330,15 +330,15 @@ class Media
   def parser_requests_metrics
     url = RequestHelper.normalize_url(self.url)
 
-    MetricsService.increment_counter(:parser_requests_total)
-    MetricsService.increment_counter(:parser_requests_per_parser, labels: { parser_name: data[:provider], parsing_status: data[:error].nil? ?  'success' : 'error' })
-    MetricsService.increment_counter(:parser_requests, labels: { parser_name: data[:provider], parsed_host: URI(url).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
+    MetricsService.increment_counter(:pender_parser_requests_total)
+    MetricsService.increment_counter(:pender_parser_requests_per_parser, labels: { parser_name: data[:provider], parsing_status: data[:error].nil? ?  'success' : 'error' })
+    MetricsService.increment_counter(:pender_parser_requests, labels: { parser_name: data[:provider], parsed_host: URI(url).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
     if data[:error].nil?
-      MetricsService.increment_counter(:parser_requests_success)
-      MetricsService.increment_counter(:parser_requests_success_per_parser, labels: { parser_name: data[:provider] })
+      MetricsService.increment_counter(:pender_parser_requests_success)
+      MetricsService.increment_counter(:pender_parser_requests_success_per_parser, labels: { parser_name: data[:provider] })
     else
-      MetricsService.increment_counter(:parser_requests_error)
-      MetricsService.increment_counter(:parser_requests_error_per_parser, labels: { parser_name: data[:provider] })
+      MetricsService.increment_counter(:pender_parser_requests_error)
+      MetricsService.increment_counter(:pender_parser_requests_error_per_parser, labels: { parser_name: data[:provider] })
     end
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -86,7 +86,7 @@ class Media
     end
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:media_request_total, labels: { parser: data[:provider], host: URI(data[:url]).host })
+    MetricsService.increment_counter(:media_request_total, labels: { parser: data[:provider], host: URI(data[:url]).host, error: data[:error].nil? ? 'none' : data[:error] })
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -86,7 +86,7 @@ class Media
     end
     archive_if_conditions_are_met(options, id, cache)
     Metrics.schedule_fetching_metrics_from_facebook(self.data, self.url, ApiKey.current&.id)
-    MetricsService.increment_counter(:media_request_total, labels: { parser: data[:provider] })
+    MetricsService.increment_counter(:media_request_total, labels: { parser: data[:provider], host: URI(data[:url]).host })
     cache.read(id, :json) || cleanup_data_encoding(data)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -328,9 +328,11 @@ class Media
   end
 
   def parser_requests_metrics
+    url = RequestHelper.normalize_url(self.url)
+
     MetricsService.increment_counter(:parser_requests_total)
     MetricsService.increment_counter(:parser_requests_per_parser, labels: { parser_name: data[:provider], parsing_status: data[:error].nil? ?  'success' : 'error' })
-    MetricsService.increment_counter(:parser_requests, labels: { parser_name: data[:provider], parsed_host: URI(data[:url]).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
+    MetricsService.increment_counter(:parser_requests, labels: { parser_name: data[:provider], parsed_host: URI(url).host, parsing_status: data[:error].nil? ?  'success' : 'error' })
     if data[:error].nil?
       MetricsService.increment_counter(:parser_requests_success)
       MetricsService.increment_counter(:parser_requests_success_per_parser, labels: { parser_name: data[:provider] })

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,11 +1,11 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:parser_requests_total, 'Count parsing requests, gets the full total - does not break them by labels', labels: [:service_name])
-  MetricsService.custom_counter(:parser_requests_success, 'Count successful parsing requests', labels: [:service_name])
-  MetricsService.custom_counter(:parser_requests_error, 'Count errored parsing requests', labels: [:service_name])
+  MetricsService.custom_counter(:pender_parser_requests_total, 'Count parsing requests, gets the full total - does not break them by labels', labels: [:service_name])
+  MetricsService.custom_counter(:pender_parser_requests_success, 'Count successful parsing requests', labels: [:service_name])
+  MetricsService.custom_counter(:pender_parser_requests_error, 'Count errored parsing requests', labels: [:service_name])
 
-  MetricsService.custom_counter(:parser_requests_per_parser, 'Count parsing requests per parser', labels: [:service_name, :parser_name, :parsing_status])
-  MetricsService.custom_counter(:parser_requests_success_per_parser, 'Count successful parsing requests per parser', labels: [:service_name, :parser_name])
-  MetricsService.custom_counter(:parser_requests_error_per_parser, 'Count errored parsing requests per parser', labels: [:service_name, :parser_name])
+  MetricsService.custom_counter(:pender_parser_requests_per_parser, 'Count parsing requests per parser', labels: [:service_name, :parser_name, :parsing_status])
+  MetricsService.custom_counter(:pender_parser_requests_success_per_parser, 'Count successful parsing requests per parser', labels: [:service_name, :parser_name])
+  MetricsService.custom_counter(:pender_parser_requests_error_per_parser, 'Count errored parsing requests per parser', labels: [:service_name, :parser_name])
 
-  MetricsService.custom_counter(:parser_requests, 'Count parsing requests - broken by labels', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
+  MetricsService.custom_counter(:pender_parser_requests, 'Count parsing requests - broken by labels', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
 end

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,3 +1,3 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:service, :parser])
+  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:service, :parser, :host])
 end

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,5 +1,11 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:parser_requests_total, 'Count every parsing request made', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
-  MetricsService.custom_counter(:parser_requests_success, 'Count every successful parsing request made', labels: [:service_name, :parser_name, :parsed_host])
-  MetricsService.custom_counter(:parser_requests_error, 'Count every errored parsing request made', labels: [:service_name, :parser_name, :parsed_host])
+  MetricsService.custom_counter(:parser_requests_total, 'Count parsing requests, gets the full total - does not break them by labels', labels: [:service_name])
+  MetricsService.custom_counter(:parser_requests_success, 'Count successful parsing requests', labels: [:service_name])
+  MetricsService.custom_counter(:parser_requests_error, 'Count errored parsing requests', labels: [:service_name])
+
+  MetricsService.custom_counter(:parser_requests_per_parser, 'Count parsing requests per parser', labels: [:service_name, :parser_name, :parsing_status])
+  MetricsService.custom_counter(:parser_requests_success_per_parser, 'Count successful parsing requests per parser', labels: [:service_name, :parser_name])
+  MetricsService.custom_counter(:parser_requests_error_per_parser, 'Count errored parsing requests per parser', labels: [:service_name, :parser_name])
+
+  MetricsService.custom_counter(:parser_requests, 'Count parsing requests - broken by labels', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
 end

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,3 +1,3 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:service, :parser, :host])
+  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:service, :parser, :host, :error])
 end

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,3 +1,5 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:parsing_requests_total, 'Count every request made', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
+  MetricsService.custom_counter(:parser_requests_total, 'Count every parsing request made', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
+  MetricsService.custom_counter(:parser_requests_success, 'Count every successful parsing request made', labels: [:service_name, :parser_name, :parsed_host])
+  MetricsService.custom_counter(:parser_requests_error, 'Count every errored parsing request made', labels: [:service_name, :parser_name, :parsed_host])
 end

--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,3 +1,3 @@
 Rails.application.reloader.to_prepare do
-  MetricsService.custom_counter(:media_request_total, 'Count every request made', labels: [:service, :parser, :host, :error])
+  MetricsService.custom_counter(:parsing_requests_total, 'Count every request made', labels: [:service_name, :parser_name, :parsed_host, :parsing_status])
 end

--- a/lib/metrics_service.rb
+++ b/lib/metrics_service.rb
@@ -6,7 +6,8 @@ class MetricsService
       counter = Prometheus::Client::Counter.new(
         name, 
         docstring: description,
-        labels: labels
+        labels: labels,
+        preset_labels: { service: 'pender' }
         )
       prometheus_registry.register(counter)
     end

--- a/lib/metrics_service.rb
+++ b/lib/metrics_service.rb
@@ -7,7 +7,7 @@ class MetricsService
         name, 
         docstring: description,
         labels: labels,
-        preset_labels: { service: 'pender' }
+        preset_labels: { service_name: 'pender' }
         )
       prometheus_registry.register(counter)
     end

--- a/test/integration/parsers/page_item_test.rb
+++ b/test/integration/parsers/page_item_test.rb
@@ -26,24 +26,6 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     assert_equal '', data['username']
   end
 
-  test "should parse url with arabic or already encoded chars" do
-    urls = [
-      'https://www.aljazeera.net/news/2023/2/9/الشرطة-السويدية-ترفض-منح-إذن-لحرق',
-      'https://www.aljazeera.net/news/2023/2/9/%D8%A7%D9%84%D8%B4%D8%B1%D8%B7%D8%A9-%D8%A7%D9%84%D8%B3%D9%88%D9%8A%D8%AF%D9%8A%D8%A9-%D8%AA%D8%B1%D9%81%D8%B6-%D9%85%D9%86%D8%AD-%D8%A5%D8%B0%D9%86-%D9%84%D8%AD%D8%B1%D9%82'
-    ]
-    urls.each do |url|
-      m = create_media url: url
-      data = m.as_json
-      assert_equal 'الشرطة السويدية ترفض منح إذن جديد لحرق المصحف الشريف أمام السفارة التركية.. فما السبب؟', data['title']
-      assert_equal 'رفضت الشرطة السويدية منح إذن لحرق المصحف الشريف أمام السفارة التركية، قائلة إن ذلك من شأنه “إثارة اضطرابات خطيرة للأمن القومي”.', data['description']
-      assert_equal '', data['published_at']
-      assert_equal '', data['username']
-      assert_match /^https?:\/\/www\.aljazeera\.net$/, data['author_url']
-      assert_nil data['error']
-      assert_not_nil data['picture']
-    end
-  end
-
   test "should store metatags in an Array" do
     m = create_media url: 'https://www.nytimes.com/2017/06/14/us/politics/mueller-trump-special-counsel-investigation.html'
     data = m.as_json
@@ -103,18 +85,6 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     assert_match '@zoesqwilliams', data['username']
     assert_match 'https://twitter.com/zoesqwilliams', data['author_url']
     assert !data['picture'].blank?
-  end
-
-  test "should parse urls without utf encoding" do
-    urls = [
-      'https://www.aljazeera.net/news/2024/1/24/شهيد-بالضفة-والاحتلال-يعتقل-طفلا-حرر',
-      'https://www.aljazeera.net/news/2024/1/24/%D8%B4%D9%87%D9%8A%D8%AF-%D8%A8%D8%A7%D9%84%D8%B6%D9%81%D8%A9-%D9%88%D8%A7%D9%84%D8%A7%D8%AD%D8%AA%D9%84%D8%A7%D9%84-%D9%8A%D8%B9%D8%AA%D9%82%D9%84-%D8%B7%D9%81%D9%84%D8%A7-%D8%AD%D8%B1%D8%B1',
-    ]
-    urls.each do |url|
-      m = create_media url: url
-      data = m.as_json
-      assert data['error'].nil?
-    end
   end
 
   test "should use original url when redirected page requires cookie" do

--- a/test/lib/metrics_service_test.rb
+++ b/test/lib/metrics_service_test.rb
@@ -3,12 +3,12 @@ require 'test_helper'
 class MetricsServiceTest < ActiveSupport::TestCase
   test "custom_counter works for real" do
     assert_nothing_raised do
-      MetricsService.custom_counter(:custom_counter, 'Custom counter test', labels: [:test])
+      MetricsService.custom_counter(:custom_counter, 'Custom counter test', labels: [:service_name, :test])
     end
   end
 
   test "increment_counter works for real" do
-    MetricsService.custom_counter(:custom_counter_2, 'Custom counter test', labels: [:test])
+    MetricsService.custom_counter(:custom_counter_2, 'Custom counter test', labels: [:service_name, :test])
 
     assert_nothing_raised do
       MetricsService.increment_counter(:custom_counter_2, labels: [:test])
@@ -16,7 +16,7 @@ class MetricsServiceTest < ActiveSupport::TestCase
   end
 
   test "get_counter works for real" do
-    custom_counter = MetricsService.custom_counter(:custom_counter_3, 'Custom counter test', labels: [:test])
+    custom_counter = MetricsService.custom_counter(:custom_counter_3, 'Custom counter test', labels: [:service_name, :test])
 
     assert_nothing_raised do
       MetricsService.get_counter(custom_counter, labels: [:test])


### PR DESCRIPTION
## Description

We are now sending metrics related to parsing requests. We are keeping track of: service_name, parser_name, parsed_host and parsing_status.

What we want to answer:
1. total of parsing requests per x amount of time
2. total of parsing requests per x amount of time grouped by partner [TBD: not possible to do right now]
3. total of parsing requests per x amount of time grouped by parser
4. total of parsing requests of an unique host, which does not have a dedicated parser, per x amount of time
5. total of errors and total of successes of our parsing requests per x amount of time

References: 4396, 4520

## How has this been tested?

By building the boards, and making sure the data is getting to Honeycomb.

## Things to pay attention to during code review
### On why we are sending the data we are sending

I ended up splitting the metrics so we can get more granular data and more generic data. I did this because it was proving difficult to get the information we wanted on the Honeycomb side.

For some cases we wanted a SUM of the value send by the metric, but I think since the `otel-collector` sends the scraped data every 15 seconds we end up with a bunch of events. The SUM doesn't really show what we need. We can `zoom in` into specific points in time, and I have set the `default granularity` to match the `otel-collector`. All that helps, but doesn't get 100% what we would like.

I ended up using MAX instead of SUM. But that was an issue when we had more granular metrics and wanted to know, for example, the amount of parsing requests to the `page` parser, without breaking it up by `host`.

If we made 2 parsing requests to `page` but to different `hosts`, those would be split. And we would get the MAX 1 instead of 2.

So instead of this:
```
parser_requests{service_name="pender",parser_name="page",parsed_host="a.host",parsing_status="success"} 1.0
parser_requests{service_name="pender",parser_name="page",parsed_host="another.host",parsing_status="success"} 1.0
```

We also want this
```
parser_requests{service_name="pender",parser_name="page",parsing_status="success"} 2.0
```

### What the metrics endpoint is looking like
note: This are the metrics that are relevant to this PR.

```
# TYPE parser_requests_total counter
# HELP parser_requests_total Count parsing requests, gets the full total - does not break them by labels
parser_requests_total{service_name="pender"} 4.0

# TYPE parser_requests_success counter
# HELP parser_requests_success Count successful parsing requests
parser_requests_success{service_name="pender"} 3.0

# TYPE parser_requests_error counter
# HELP parser_requests_error Count errored parsing requests
parser_requests_error{service_name="pender"} 1.0

# TYPE parser_requests_per_parser counter
# HELP parser_requests_per_parser Count parsing requests per parser
parser_requests_per_parser{service_name="pender",parser_name="youtube",parsing_status="success"} 1.0
parser_requests_per_parser{service_name="pender",parser_name="page",parsing_status="success"} 2.0
parser_requests_per_parser{service_name="pender",parser_name="instagram",parsing_status="error"} 1.0

# TYPE parser_requests_success_per_parser counter
# HELP parser_requests_success_per_parser Count successful parsing requests per parser
parser_requests_success_per_parser{service_name="pender",parser_name="youtube"} 1.0
parser_requests_success_per_parser{service_name="pender",parser_name="page"} 2.0

# TYPE parser_requests_error_per_parser counter
# HELP parser_requests_error_per_parser Count errored parsing requests per parser
parser_requests_error_per_parser{service_name="pender",parser_name="instagram"} 1.0

# TYPE parser_requests counter
# HELP parser_requests Count parsing requests - broken by labels
parser_requests{service_name="pender",parser_name="youtube",parsed_host="www.youtube.com",parsing_status="success"} 1.0
parser_requests{service_name="pender",parser_name="page",parsed_host="sliding.toys",parsing_status="success"} 1.0
parser_requests{service_name="pender",parser_name="page",parsed_host="checkbox.toys",parsing_status="success"} 1.0
parser_requests{service_name="pender",parser_name="instagram",parsed_host="www.instagram.com",parsing_status="error"} 1.0
```

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

