### PR TITLE
Add log to notify webhook

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -157,6 +157,7 @@ class Media
         # exception if request failed and still return a successful response if present.
         response.value || response
       rescue Net::HTTPExceptions => e
+        Rails.logger.warn level: 'WARN', message: '[Webhook Notification] HTTPException while trying to notify webhook', url: url, type: type, error_class: e.class, error_message: e.message, webhook_url: settings['webhook_url']
         raise Pender::Exception::RetryLater, "(#{response.code}) #{response.message}"
       rescue StandardError => e
         PenderSentry.notify(
@@ -165,11 +166,11 @@ class Media
           type: type,
           webhook_url: settings["webhook_url"]
         )
-        Rails.logger.warn level: 'WARN', message: 'Failed to notify webhook', url: url, type: type, error_class: e.class, error_message: e.message, webhook_url: settings['webhook_url']
+        Rails.logger.warn level: 'WARN', message: '[Webhook Notification] Failed to notify webhook', url: url, type: type, error_class: e.class, error_message: e.message, webhook_url: settings['webhook_url']
         return false
       end
     else
-      Rails.logger.warn level: 'WARN', message: 'Webhook settings not configured for API key', url: url, type: type, api_key: ApiKey.current&.id
+      Rails.logger.warn level: 'WARN', message: '[Webhook Notification] Webhook settings not configured for API key', url: url, type: type, api_key: ApiKey.current&.id
       return false
     end
   end


### PR DESCRIPTION
## Description

While looking at logs for webhook notification errors I thought it could be helpful:

- to add a log when we hit a Net::HTTPException error
- to add '[Webhook Notification]' so it is easier to group them if we want to

References: 4228

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

