### PR TITLE
Correctly show facebook embed

### DIFF
--- a/app/models/parser/facebook_item.rb
+++ b/app/models/parser/facebook_item.rb
@@ -82,7 +82,6 @@ module Parser
 
     def html_for_facebook_post(username, html_page, request_url)
       return unless html_page
-      return if username && !['groups', 'flx'].include?(username)
       return unless not_an_event_page && not_a_group_post
 
       '<script>


### PR DESCRIPTION

## Description

Change conditions for when fb embed is shown, and add tests to ensure all viable URLs return embeds.

References: CV2-5257

## How has this been tested?

Tested by ensuring embed shows locally, and also that the tests are passing.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

