### PR TITLE
Fix Gemfile.lock mismatch with Gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
     parallel (1.23.0)
     parallel_tests (4.2.1)
       parallel
-    pg (1.1.0)
+    pg (1.5.8)
     prometheus-client (4.2.2)
     psych (3.3.4)
     public_suffix (4.0.7)
@@ -454,7 +454,7 @@ DEPENDENCIES
   opentelemetry-instrumentation-sidekiq
   opentelemetry-sdk
   parallel_tests
-  pg (= 1.1)
+  pg (~> 1.4)
   postrank-uri!
   prometheus-client
   psych (< 4)


### PR DESCRIPTION
Fix Gemfile.lock mismatch with Gemfile. 



## Description

This mismatch was introduced in https://github.com/meedan/pender/pull/477  where we updated the pg gem version in Gemfile and did not update the same in Gemfile.lock

References: CV2-4958


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

