### PR TITLE
Fixing issues with code coverage report generation and upload to Code Climate

### DIFF
--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -100,7 +100,6 @@ jobs:
         GIT_SHA: ${{ github.sha }}
         GIT_COMMITED_AT: ${{ github.event.head_commit.timestamp }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        CODEBUILD_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
       run: |
         docker compose -f docker-test.yml exec -T pender cat tmp/performance.csv
         docker compose -f docker-test.yml exec -T pender ls -l coverage/

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -112,9 +112,13 @@ jobs:
         mkdir -p /tmp/go/src/github.com/codeclimate
         git clone -b 0.10.3 https://github.com/codeclimate/test-reporter /tmp/go/src/github.com/codeclimate/test-reporter
         cd test
-        echo '------ .resultset.json START ------'
+        echo '------ .resultset.json START 1 ------'
         cat .resultset.json # Debugging
-        echo '------- .resultset.json END -------'
+        echo '------- .resultset.json END 1 -------'
+        sed -i 's/\/app\//\/home\/runner\/work\/pender\//g' .resultset.json # Convert container-paths to local-paths
+        echo '------ .resultset.json START 2 ------'
+        cat .resultset.json # Debugging
+        echo '------- .resultset.json END 2 -------'
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
         cat codeclimate.json
         # cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -115,7 +115,7 @@ jobs:
         echo '------ .resultset.json START ------'
         cat .resultset.json # Debugging
         echo '------- .resultset.json END -------'
-        GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json --input-type simplecov --output codeclimate.json
+        GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage -t simplecov --output codeclimate.json .resultset.json
         cat codeclimate.json
         # cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -
 

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
     - develop
+    - dmou/test-consolidate-dockerfiles
 
 permissions:
   id-token: write

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -100,25 +100,25 @@ jobs:
         GIT_SHA: ${{ github.sha }}
         GIT_COMMITED_AT: ${{ github.event.head_commit.timestamp }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        CODEBUILD_GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
       run: |
         docker compose -f docker-test.yml exec -T pender cat tmp/performance.csv
         docker compose -f docker-test.yml exec -T pender ls -l coverage/
         docker cp pender-pender-1:/app/pender/tmp/performance.csv performance.csv
         docker cp pender-pender-1:/app/pender/coverage/.resultset.json test/.resultset.json
 
-        # Pulled from test/test-coverage
+        # pulled from test/test-coverage
         printf '#!/bin/bash\ngo run /tmp/go/src/github.com/codeclimate/test-reporter/main.go $@\n' > test/cc-test-reporter && chmod +x test/cc-test-reporter
         export GOPATH=/tmp/go
         go env -w GO111MODULE=off
         mkdir -p /tmp/go/src/github.com/codeclimate
         git clone -b 0.10.3 https://github.com/codeclimate/test-reporter /tmp/go/src/github.com/codeclimate/test-reporter
         cd test
-        sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
-        GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
+        sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # convert container-paths to local-paths
+        GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json
         sed -i 's/\/home\/runner\/work\/pender\///g' codeclimate.json
         cp codeclimate.json ../coverage/
-        GIT_BRANCH=$GIT_BRANCH_NAME ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID -i codeclimate.json -d
+        ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID -i codeclimate.json
 
     - name: Reset cache
       id: reset-cache

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -105,7 +105,7 @@ jobs:
         docker cp pender-pender-1:/app/pender/tmp/performance.csv performance.csv
         docker cp pender-pender-1:/app/pender/coverage/.resultset.json test/.resultset.json
 
-        # pulled from test/test-coverage
+        # Pulled from test/test-coverage
         printf '#!/bin/bash\ngo run /tmp/go/src/github.com/codeclimate/test-reporter/main.go $@\n' > test/cc-test-reporter && chmod +x test/cc-test-reporter
         export GOPATH=/tmp/go
         go env -w GO111MODULE=off
@@ -115,7 +115,8 @@ jobs:
         sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
         sed -i 's/\/home\/runner\/work\/pender\///g' codeclimate.json
-        ./cc-test-reporter upload-coverage -r $cc_test_reporter_id -i codeclimate.json -d
+        cp codeclimate.json coverage/
+        ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID -i codeclimate.json -d
 
     - name: Reset cache
       id: reset-cache

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -114,7 +114,6 @@ jobs:
         cd test
         sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
-        cat codeclimate.json
         cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -
 
     - name: Reset cache

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
     - develop
-    - dmou/test-consolidate-dockerfiles
 
 permissions:
   id-token: write

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -114,7 +114,8 @@ jobs:
         cd test
         sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
-        cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -
+        sed -i 's/\/home\/runner\/work\/pender\///g' codeclimate.json
+        ./cc-test-reporter upload-coverage -r $cc_test_reporter_id -i codeclimate.json -d
 
     - name: Reset cache
       id: reset-cache

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -116,7 +116,7 @@ jobs:
         sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
         sed -i 's/\/home\/runner\/work\/pender\///g' codeclimate.json
-        cp codeclimate.json coverage/
+        cp codeclimate.json ../coverage/
         ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID -i codeclimate.json -d
 
     - name: Reset cache

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -100,6 +100,7 @@ jobs:
         GIT_SHA: ${{ github.sha }}
         GIT_COMMITED_AT: ${{ github.event.head_commit.timestamp }}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        GIT_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
       run: |
         docker compose -f docker-test.yml exec -T pender cat tmp/performance.csv
         docker compose -f docker-test.yml exec -T pender ls -l coverage/
@@ -117,7 +118,7 @@ jobs:
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
         sed -i 's/\/home\/runner\/work\/pender\///g' codeclimate.json
         cp codeclimate.json ../coverage/
-        ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID -i codeclimate.json -d
+        GIT_BRANCH=$GIT_BRANCH_NAME ./cc-test-reporter upload-coverage -r $CC_TEST_REPORTER_ID -i codeclimate.json -d
 
     - name: Reset cache
       id: reset-cache

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -99,6 +99,7 @@ jobs:
       env:
         GIT_SHA: ${{ github.sha }}
         GIT_COMMITED_AT: ${{ github.event.head_commit.timestamp }}
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       run: |
         docker compose -f docker-test.yml exec -T pender cat tmp/performance.csv
         docker compose -f docker-test.yml exec -T pender ls -l coverage/

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -111,6 +111,9 @@ jobs:
         mkdir -p /tmp/go/src/github.com/codeclimate
         git clone -b 0.10.3 https://github.com/codeclimate/test-reporter /tmp/go/src/github.com/codeclimate/test-reporter
         cd test
+        echo '------ .resultset.json START ------'
+        cat .resultset.json # Debugging
+        echo '------- .resultset.json END -------'
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json --input-type simplecov --output codeclimate.json
         cat codeclimate.json
         # cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -115,7 +115,7 @@ jobs:
         echo '------ .resultset.json START ------'
         cat .resultset.json # Debugging
         echo '------- .resultset.json END -------'
-        GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage -t simplecov --output codeclimate.json .resultset.json
+        GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
         cat codeclimate.json
         # cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -
 

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-    - dmou/test-consolidate-dockerfiles
+    - caio/test-consolidate-dockerfiles
   pull_request:
     branches:
     - develop

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -115,7 +115,7 @@ jobs:
         echo '------ .resultset.json START 1 ------'
         cat .resultset.json # Debugging
         echo '------- .resultset.json END 1 -------'
-        sed -i 's/\/app\//\/home\/runner\/work\/pender\//g' .resultset.json # Convert container-paths to local-paths
+        sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
         echo '------ .resultset.json START 2 ------'
         cat .resultset.json # Debugging
         echo '------- .resultset.json END 2 -------'

--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-    - caio/test-consolidate-dockerfiles
+    - dmou/test-consolidate-dockerfiles
   pull_request:
     branches:
     - develop
@@ -112,16 +112,10 @@ jobs:
         mkdir -p /tmp/go/src/github.com/codeclimate
         git clone -b 0.10.3 https://github.com/codeclimate/test-reporter /tmp/go/src/github.com/codeclimate/test-reporter
         cd test
-        echo '------ .resultset.json START 1 ------'
-        cat .resultset.json # Debugging
-        echo '------- .resultset.json END 1 -------'
         sed -i 's/\/app\/pender/\/home\/runner\/work\/pender\/pender/g' .resultset.json # Convert container-paths to local-paths
-        echo '------ .resultset.json START 2 ------'
-        cat .resultset.json # Debugging
-        echo '------- .resultset.json END 2 -------'
         GIT_COMMIT_SHA=$GIT_SHA GIT_COMMITTED_AT=$GIT_COMMITTED_AT ./cc-test-reporter format-coverage .resultset.json -t simplecov -o codeclimate.json -d
         cat codeclimate.json
-        # cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -
+        cat codeclimate.json | sed 's/\/app\///g' | ./cc-test-reporter upload-coverage -r $cc_test_reporter_id --input -
 
     - name: Reset cache
       id: reset-cache


### PR DESCRIPTION
## Description

Fixes the steps that generate and upload the code coverage report to Code Climate.

The main issue was that previously, we ran the tests, prepared the coverage report, and uploaded it all within the Docker container. Now, however, the tests run inside the Docker container, while the coverage report is prepared outside of it, leading to a mismatch in file paths. The solution I implemented was to use sed to replace the paths, changing `/app/pender` to `/home/runner/work/pender`. I also needed to copy `codeclimate.json` to the coverage directory and set the `$CC_TEST_REPORTER_ID` environment variable.

Reference: CV2-5020.

## How has this been tested?

Code Coverage report was generated and uploaded to Code Climate as expected:

![Captura de tela de 2024-11-06 22-06-44](https://github.com/user-attachments/assets/1e4918f5-b587-4658-8454-d18f196446bb)

![Captura de tela de 2024-11-06 22-06-55](https://github.com/user-attachments/assets/b3fce3a5-a10e-4357-b3e2-a5c640662564)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)