### PR TITLE
Fix instagram embed not showing correctly in production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - CV2-5619-fix-instagram-embed-issues
 
 deploy_qa:
   image: python:3.7.7
@@ -45,6 +46,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/pender/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - CV2-5619-fix-instagram-embed-issues
 
 build_live:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest

--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -124,7 +124,7 @@ class RequestHelper
       proxy = self.valid_proxy
       if proxy || force
         country = force ? 'us' : PenderConfig.get('hosts', {}, :json).dig(uri.host, 'country')
-        if uri.host.match?(/(facebook|tiktok|instagram)\.com/)
+        if uri.host.match?(/(tiktok)\.com/)
           proxy['user'] = proxy['user_prefix'] + proxy['country_prefix'] + 'us' + proxy['session_prefix'] + Random.rand(100000).to_s
         elsif country
           proxy['user'] = proxy['user_prefix'] + proxy['country_prefix'] + country

--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -51,7 +51,6 @@ module Parser
       end
 
       @parsed_data['description'] ||= url
-      @parsed_data['html'] = html_for_instagram_post(parsed_data.dig('username'), doc, url) || ''
       parsed_data
     end
 

--- a/app/models/parser/instagram_profile.rb
+++ b/app/models/parser/instagram_profile.rb
@@ -47,7 +47,6 @@ module Parser
       end
 
       @parsed_data['description'] ||= url
-      @parsed_data['html'] = html_for_instagram_profile(doc, url) || ''
       parsed_data
     end
 

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -62,31 +62,6 @@ class MediasControllerTest < ActionController::TestCase
     assert_equal first_parsed_at, second_parsed_at
   end
 
-  test "should return error message on hash if url does not exist" do
-    authenticate_with_token
-    get :index, params: { url: 'https://www.instagram.com/kjdahsjkdhasjdkhasjk/', format: :json }
-    assert_response 200
-    data = JSON.parse(@response.body)['data']
-    assert_not_nil data['error']['message']
-    assert_equal Lapis::ErrorCodes::const_get('UNKNOWN'), data['error']['code']
-    assert_equal 'instagram', data['provider']
-    assert_equal 'profile', data['type']
-    assert_not_nil data['embed_tag']
-  end
-
-  # TODO Must be fixed on #8794
-  #test "should return error message on hash if url does not exist 4" do
-  #  authenticate_with_token
-  #  get :index, params: { url: 'https://www.instagram.com/p/blih_blih/', format: :json
-  #  assert_response 200
-  #  data = JSON.parse(@response.body)['data']
-  #  assert_equal 'RuntimeError: Net::HTTPNotFound: Not Found', data['error']['message']
-  #  assert_equal 5, data['error']['code']
-  #  assert_equal 'instagram', data['provider']
-  #  assert_equal 'item', data['type']
-  #  assert_not_nil data['embed_tag']
-  #end
-
   test "should return error message on hash if url does not exist 5" do
     authenticate_with_token
     get :index, params: { url: 'http://example.com/blah_blah', format: :json }


### PR DESCRIPTION
## Description

Currently the instagram embed for post and profile URLs is not showing correctly in production environments  (that use https). Here we are fixing that by allowing instagram urls through our security policy

References: CV2-5619

## How has this been tested?

Confirmed that embeds are working.



## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

