### PR TITLE
5215 – Don't use the proxy for Facebook and Instagram links

### DIFF
--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -124,7 +124,7 @@ class RequestHelper
       proxy = self.valid_proxy
       if proxy || force
         country = force ? 'us' : PenderConfig.get('hosts', {}, :json).dig(uri.host, 'country')
-        if uri.host.match?(/(facebook|tiktok|instagram)\.com/)
+        if uri.host.match?(/(tiktok)\.com/)
           proxy['user'] = proxy['user_prefix'] + proxy['country_prefix'] + 'us' + proxy['session_prefix'] + Random.rand(100000).to_s
         elsif country
           proxy['user'] = proxy['user_prefix'] + proxy['country_prefix'] + country

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -62,31 +62,6 @@ class MediasControllerTest < ActionController::TestCase
     assert_equal first_parsed_at, second_parsed_at
   end
 
-  test "should return error message on hash if url does not exist" do
-    authenticate_with_token
-    get :index, params: { url: 'https://www.instagram.com/kjdahsjkdhasjdkhasjk/', format: :json }
-    assert_response 200
-    data = JSON.parse(@response.body)['data']
-    assert_not_nil data['error']['message']
-    assert_equal Lapis::ErrorCodes::const_get('UNKNOWN'), data['error']['code']
-    assert_equal 'instagram', data['provider']
-    assert_equal 'profile', data['type']
-    assert_not_nil data['embed_tag']
-  end
-
-  # TODO Must be fixed on #8794
-  #test "should return error message on hash if url does not exist 4" do
-  #  authenticate_with_token
-  #  get :index, params: { url: 'https://www.instagram.com/p/blih_blih/', format: :json
-  #  assert_response 200
-  #  data = JSON.parse(@response.body)['data']
-  #  assert_equal 'RuntimeError: Net::HTTPNotFound: Not Found', data['error']['message']
-  #  assert_equal 5, data['error']['code']
-  #  assert_equal 'instagram', data['provider']
-  #  assert_equal 'item', data['type']
-  #  assert_not_nil data['embed_tag']
-  #end
-
   test "should return error message on hash if url does not exist 5" do
     authenticate_with_token
     get :index, params: { url: 'http://example.com/blah_blah', format: :json }


### PR DESCRIPTION
## Description

Removed proxy usage for Facebook and Instagram: since we are now using Apify to parse both, we don't need to use the proxy anymore.

References: CV2-5215, CV2-5664

## How has this been tested?

By running facebook and instagram tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

