### PR TITLE
Raise exceptions when errors occur while fetching oembed data

### DIFF
--- a/app/models/oembed_item.rb
+++ b/app/models/oembed_item.rb
@@ -36,7 +36,7 @@ class OembedItem
       response = http.request(request)
     rescue StandardError => e
       Rails.logger.warn level: 'WARN', message: '[Parser] Could not send oembed request', url: request_url, oembed_url: oembed_uri&.to_s
-      return e
+      raise e
     end
 
     if attempts < 5 && RequestHelper::REDIRECT_HTTP_CODES.include?(response.code)

--- a/test/models/oembed_item_test.rb
+++ b/test/models/oembed_item_test.rb
@@ -118,4 +118,14 @@ class OembedItemUnitTest < ActiveSupport::TestCase
     item = OembedItem.new('http://example.com/original', 'http://example.com/oembed')
     assert !item.get_data.blank?
   end
+
+  test ".get_data assigns error when Zlib::DataError is raised" do
+    WebMock.stub_request(:get, /example.com\/oembed/).to_raise(Zlib::DataError.new("fake zlib error"))
+    
+    data = OembedItem.new(request_url, 'https://example.com/oembed').get_data
+  
+    assert data[:error].present?, "Expected an error in the data when Zlib::DataError is raised"
+    assert_match /Zlib::DataError/, data[:error][:message]
+    assert_match /fake zlib error/, data[:error][:message]
+  end
 end


### PR DESCRIPTION
## Description

### Raise exceptions when errors occur while fetching oembed data
Currently, we are returning an exception instead of raising it.

References: CV2-6027

## How has this been tested?

- Ensured that any exception when fetching oembeds is raised
- Added a test to verify and enforce this


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

