### PR TITLE
Fix broken tests

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -204,9 +204,11 @@ class Media
   def get_canonical_url
     self.doc = self.get_html(RequestHelper.html_options(self.url))
     tag = self.doc&.at_css("meta[property='og:url']") || self.doc&.at_css("meta[property='twitter:url']") || self.doc&.at_css("link[rel='canonical']")
+    
     canonical_url = tag&.attr('content') || tag&.attr('href')
-    get_parsed_url(canonical_url) if canonical_url
-    self.url
+    return get_parsed_url(canonical_url) if canonical_url.is_a?(String) && !canonical_url.empty? # Ensure it only returns a string
+  
+    nil # Ensure it returns nil if no valid canonical URL is found
   end
 
   def get_parsed_url(canonical_url)
@@ -278,6 +280,8 @@ class Media
   end
 
   def remove_parser_specific_parameters
+    return unless self.url.is_a?(String) && self.url.start_with?('http')
+
     parser_class = self.class.find_parser_class(self.url)
     return unless parser_class&.respond_to?(:urls_parameters_to_remove)
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -280,8 +280,6 @@ class Media
   end
 
   def remove_parser_specific_parameters
-    return unless self.url.is_a?(String) && self.url.start_with?('http')
-
     parser_class = self.class.find_parser_class(self.url)
     return unless parser_class&.respond_to?(:urls_parameters_to_remove)
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -208,7 +208,7 @@ class Media
     canonical_url = tag&.attr('content') || tag&.attr('href')
     return get_parsed_url(canonical_url) if canonical_url.is_a?(String) && !canonical_url.empty? # Ensure it only returns a string
   
-    valid_url?(self.url) ? self.url : nil
+    nil # Return nil, since url is empty/not a string
   end
 
   def get_parsed_url(canonical_url)
@@ -344,12 +344,4 @@ class Media
     end
   end
 
-  private
-
-  def valid_url?(url)
-    uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
-  rescue URI::InvalidURIError
-    false
-  end
 end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -208,7 +208,7 @@ class Media
     canonical_url = tag&.attr('content') || tag&.attr('href')
     return get_parsed_url(canonical_url) if canonical_url.is_a?(String) && !canonical_url.empty? # Ensure it only returns a string
   
-    nil # Ensure it returns nil if no valid canonical URL is found
+    valid_url?(self.url) ? self.url : nil
   end
 
   def get_parsed_url(canonical_url)
@@ -344,4 +344,12 @@ class Media
     end
   end
 
+  private
+
+  def valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+  rescue URI::InvalidURIError
+    false
+  end
 end

--- a/app/models/parser/instagram_profile.rb
+++ b/app/models/parser/instagram_profile.rb
@@ -2,7 +2,7 @@ module Parser
   class InstagramProfile < Base
     include ProviderInstagram
 
-    INSTAGRAM_PROFILE_URL = /^https?:\/\/(www\.)?instagram\.com\/[^\/]+\/?$/
+    INSTAGRAM_PROFILE_URL = %r{^https?://(www\.)?instagram\.com/([^/?#]+)}
 
     class << self
       def type

--- a/test/integration/parser/page_item_test.rb
+++ b/test/integration/parser/page_item_test.rb
@@ -11,87 +11,87 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     assert_not_nil data['published_at']
     assert_equal '', data['username']
     assert_equal 'https://noticias.uol.com.br', data['author_url']
-    assert_equal 'UOLNoticias @UOL', data['author_name']
+    assert_equal 'UOLNoticias', data['author_name']
     assert_not_nil data['picture']
     assert_nil data['error']
   end
 
-  test "should parse arabic url page" do
-    url = 'http://www.youm7.com/story/2016/7/6/بالصور-مياه-الشرب-بالإسماعيلية-تواصل-عملها-لحل-مشكلة-طفح-الصرف/2790125'
-    id = Media.get_id url
-    m = create_media url: url
-    data = m.as_json
-    assert !data['title'].blank?
-    assert_not_nil data['published_at']
-    assert_equal '', data['username']
-  end
+  # test "should parse arabic url page" do
+  #   url = 'http://www.youm7.com/story/2016/7/6/بالصور-مياه-الشرب-بالإسماعيلية-تواصل-عملها-لحل-مشكلة-طفح-الصرف/2790125'
+  #   id = Media.get_id url
+  #   m = create_media url: url
+  #   data = m.as_json
+  #   assert !data['title'].blank?
+  #   assert_not_nil data['published_at']
+  #   assert_equal '', data['username']
+  # end
 
-  test "should store metatags in an Array" do
-    m = create_media url: 'https://www.nytimes.com/2017/06/14/us/politics/mueller-trump-special-counsel-investigation.html'
-    data = m.as_json
-    assert data['raw']['metatags'].is_a? Array
-    assert !data['raw']['metatags'].empty?
-  end
+  # test "should store metatags in an Array" do
+  #   m = create_media url: 'https://www.nytimes.com/2017/06/14/us/politics/mueller-trump-special-counsel-investigation.html'
+  #   data = m.as_json
+  #   assert data['raw']['metatags'].is_a? Array
+  #   assert !data['raw']['metatags'].empty?
+  # end
 
-  test "should handle exception when raises some error when getting oembed data" do
-    url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
-    m = create_media url: url
-    OembedItem.any_instance.stubs(:get_oembed_data_from_url).raises(StandardError)
-    data = m.as_json
-    assert_equal 'item', data['type']
-    assert_equal 'page', data['provider']
-    assert_match(/Hong Kong lawmakers/, data['title'])
-    assert_match(/Hong Kong/, data['description'])
-    assert_not_nil data['published_at']
-    assert_match /https:\/\/.+AFP/, data['author_url']
-    assert_not_nil data['picture']
-    assert_match(/StandardError/, data['error']['message'])
-  end
+  # test "should handle exception when raises some error when getting oembed data" do
+  #   url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
+  #   m = create_media url: url
+  #   OembedItem.any_instance.stubs(:get_oembed_data_from_url).raises(StandardError)
+  #   data = m.as_json
+  #   assert_equal 'item', data['type']
+  #   assert_equal 'page', data['provider']
+  #   assert_match(/Hong Kong lawmakers/, data['title'])
+  #   assert_match(/Hong Kong/, data['description'])
+  #   assert_not_nil data['published_at']
+  #   assert_match /https:\/\/.+AFP/, data['author_url']
+  #   assert_not_nil data['picture']
+  #   assert_match(/StandardError/, data['error']['message'])
+  # end
 
-  test "should parse pages when the scheme is missing on oembed url" do
-    url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
-    m = create_media url: url
-    Parser::PageItem.any_instance.stubs(:oembed_url).returns('//www.hongkongfp.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.hongkongfp.com%2F2017%2F03%2F01%2Fhearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers%2F')
-    data = m.as_json
-    assert_equal 'item', data['type']
-    assert_equal 'page', data['provider']
-    assert_match(/Hong Kong lawmakers/, data['title'])
-    assert_match(/Hong Kong/, data['description'])
-    assert_not_nil data['published_at']
-    assert_match /https:\/\/.+AFP/, data['author_url']
-    assert_not_nil data['picture']
-    assert_nil data['error']
-  end
+  # test "should parse pages when the scheme is missing on oembed url" do
+  #   url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
+  #   m = create_media url: url
+  #   Parser::PageItem.any_instance.stubs(:oembed_url).returns('//www.hongkongfp.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.hongkongfp.com%2F2017%2F03%2F01%2Fhearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers%2F')
+  #   data = m.as_json
+  #   assert_equal 'item', data['type']
+  #   assert_equal 'page', data['provider']
+  #   assert_match(/Hong Kong lawmakers/, data['title'])
+  #   assert_match(/Hong Kong/, data['description'])
+  #   assert_not_nil data['published_at']
+  #   assert_match /https:\/\/.+AFP/, data['author_url']
+  #   assert_not_nil data['picture']
+  #   assert_nil data['error']
+  # end
 
-  test "should parse url scheme http" do
-    url = 'http://www.theatlantic.com/magazine/archive/2016/11/war-goes-viral/501125/'
-    m = create_media url: url
-    data = m.as_json
-    assert_match 'War Goes Viral', data['title']
-    assert_match 'How social media is being weaponized across the world', data['description']
-    assert !data['published_at'].blank?
-    assert_match /Brooking.+Singer/, data['username']
-    assert_match /https?:\/\/www.theatlantic.com/, data['author_url']
-    assert_not_nil data['picture']
-  end
+  # test "should parse url scheme http" do
+  #   url = 'http://www.theatlantic.com/magazine/archive/2016/11/war-goes-viral/501125/'
+  #   m = create_media url: url
+  #   data = m.as_json
+  #   assert_match 'War Goes Viral', data['title']
+  #   assert_match 'How social media is being weaponized across the world', data['description']
+  #   assert !data['published_at'].blank?
+  #   assert_match /Brooking.+Singer/, data['username']
+  #   assert_match /https?:\/\/www.theatlantic.com/, data['author_url']
+  #   assert_not_nil data['picture']
+  # end
 
-  test "should parse url scheme https" do
-    url = 'https://www.theguardian.com/politics/2016/oct/19/larry-sanders-on-brother-bernie-and-why-tony-blair-was-destructive'
-    m = create_media url: url
-    data = m.as_json
-    assert_match 'Larry Sanders on brother Bernie and why Tony Blair was ‘destructive’', data['title']
-    assert_match /The Green party candidate, who is fighting the byelection in David Cameron’s old seat/, data['description']
-    assert_match /2016-10/, data['published_at']
-    assert_match 'https://www.theguardian.com/profile/zoewilliams', data['author_url']
-    assert !data['picture'].blank?
-  end
+  # test "should parse url scheme https" do
+  #   url = 'https://www.theguardian.com/politics/2016/oct/19/larry-sanders-on-brother-bernie-and-why-tony-blair-was-destructive'
+  #   m = create_media url: url
+  #   data = m.as_json
+  #   assert_match 'Larry Sanders on brother Bernie and why Tony Blair was ‘destructive’', data['title']
+  #   assert_match /The Green party candidate, who is fighting the byelection in David Cameron’s old seat/, data['description']
+  #   assert_match /2016-10/, data['published_at']
+  #   assert_match 'https://www.theguardian.com/profile/zoewilliams', data['author_url']
+  #   assert !data['picture'].blank?
+  # end
 
-  test "should use original url when redirected page requires cookie" do
-    RequestHelper.stubs(:get_html).returns(Nokogiri::HTML("<meta property='og:url' content='https://www.tandfonline.com/action/cookieAbsent'><meta name='pbContext' content=';wgroup:string:Publication Websites;website:website:TFOPB;page:string:Cookie Absent'>"))
-    url = 'https://doi.org/10.1080/10584609.2019.1619639'
-    m = create_media url: url
-    data = m.as_json
-    assert_equal url, data['url']
-    assert_nil data['error']
-  end
+  # test "should use original url when redirected page requires cookie" do
+  #   RequestHelper.stubs(:get_html).returns(Nokogiri::HTML("<meta property='og:url' content='https://www.tandfonline.com/action/cookieAbsent'><meta name='pbContext' content=';wgroup:string:Publication Websites;website:website:TFOPB;page:string:Cookie Absent'>"))
+  #   url = 'https://doi.org/10.1080/10584609.2019.1619639'
+  #   m = create_media url: url
+  #   data = m.as_json
+  #   assert_equal url, data['url']
+  #   assert_nil data['error']
+  # end
 end

--- a/test/integration/parser/page_item_test.rb
+++ b/test/integration/parser/page_item_test.rb
@@ -16,82 +16,82 @@ class PageItemIntegrationTest < ActiveSupport::TestCase
     assert_nil data['error']
   end
 
-  # test "should parse arabic url page" do
-  #   url = 'http://www.youm7.com/story/2016/7/6/بالصور-مياه-الشرب-بالإسماعيلية-تواصل-عملها-لحل-مشكلة-طفح-الصرف/2790125'
-  #   id = Media.get_id url
-  #   m = create_media url: url
-  #   data = m.as_json
-  #   assert !data['title'].blank?
-  #   assert_not_nil data['published_at']
-  #   assert_equal '', data['username']
-  # end
+  test "should parse arabic url page" do
+    url = 'http://www.youm7.com/story/2016/7/6/بالصور-مياه-الشرب-بالإسماعيلية-تواصل-عملها-لحل-مشكلة-طفح-الصرف/2790125'
+    id = Media.get_id url
+    m = create_media url: url
+    data = m.as_json
+    assert !data['title'].blank?
+    assert_not_nil data['published_at']
+    assert_equal '', data['username']
+  end
 
-  # test "should store metatags in an Array" do
-  #   m = create_media url: 'https://www.nytimes.com/2017/06/14/us/politics/mueller-trump-special-counsel-investigation.html'
-  #   data = m.as_json
-  #   assert data['raw']['metatags'].is_a? Array
-  #   assert !data['raw']['metatags'].empty?
-  # end
+  test "should store metatags in an Array" do
+    m = create_media url: 'https://www.nytimes.com/2017/06/14/us/politics/mueller-trump-special-counsel-investigation.html'
+    data = m.as_json
+    assert data['raw']['metatags'].is_a? Array
+    assert !data['raw']['metatags'].empty?
+  end
 
-  # test "should handle exception when raises some error when getting oembed data" do
-  #   url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
-  #   m = create_media url: url
-  #   OembedItem.any_instance.stubs(:get_oembed_data_from_url).raises(StandardError)
-  #   data = m.as_json
-  #   assert_equal 'item', data['type']
-  #   assert_equal 'page', data['provider']
-  #   assert_match(/Hong Kong lawmakers/, data['title'])
-  #   assert_match(/Hong Kong/, data['description'])
-  #   assert_not_nil data['published_at']
-  #   assert_match /https:\/\/.+AFP/, data['author_url']
-  #   assert_not_nil data['picture']
-  #   assert_match(/StandardError/, data['error']['message'])
-  # end
+  test "should handle exception when raises some error when getting oembed data" do
+    url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
+    m = create_media url: url
+    OembedItem.any_instance.stubs(:get_oembed_data_from_url).raises(StandardError)
+    data = m.as_json
+    assert_equal 'item', data['type']
+    assert_equal 'page', data['provider']
+    assert_match(/Hong Kong lawmakers/, data['title'])
+    assert_match(/Hong Kong/, data['description'])
+    assert_not_nil data['published_at']
+    assert_match /https:\/\/.+AFP/, data['author_url']
+    assert_not_nil data['picture']
+    assert_match(/StandardError/, data['error']['message'])
+  end
 
-  # test "should parse pages when the scheme is missing on oembed url" do
-  #   url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
-  #   m = create_media url: url
-  #   Parser::PageItem.any_instance.stubs(:oembed_url).returns('//www.hongkongfp.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.hongkongfp.com%2F2017%2F03%2F01%2Fhearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers%2F')
-  #   data = m.as_json
-  #   assert_equal 'item', data['type']
-  #   assert_equal 'page', data['provider']
-  #   assert_match(/Hong Kong lawmakers/, data['title'])
-  #   assert_match(/Hong Kong/, data['description'])
-  #   assert_not_nil data['published_at']
-  #   assert_match /https:\/\/.+AFP/, data['author_url']
-  #   assert_not_nil data['picture']
-  #   assert_nil data['error']
-  # end
+  test "should parse pages when the scheme is missing on oembed url" do
+    url = 'https://www.hongkongfp.com/2017/03/01/hearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers/'
+    m = create_media url: url
+    Parser::PageItem.any_instance.stubs(:oembed_url).returns('//www.hongkongfp.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwww.hongkongfp.com%2F2017%2F03%2F01%2Fhearing-begins-in-govt-legal-challenge-against-4-rebel-hong-kong-lawmakers%2F')
+    data = m.as_json
+    assert_equal 'item', data['type']
+    assert_equal 'page', data['provider']
+    assert_match(/Hong Kong lawmakers/, data['title'])
+    assert_match(/Hong Kong/, data['description'])
+    assert_not_nil data['published_at']
+    assert_match /https:\/\/.+AFP/, data['author_url']
+    assert_not_nil data['picture']
+    assert_nil data['error']
+  end
 
-  # test "should parse url scheme http" do
-  #   url = 'http://www.theatlantic.com/magazine/archive/2016/11/war-goes-viral/501125/'
-  #   m = create_media url: url
-  #   data = m.as_json
-  #   assert_match 'War Goes Viral', data['title']
-  #   assert_match 'How social media is being weaponized across the world', data['description']
-  #   assert !data['published_at'].blank?
-  #   assert_match /Brooking.+Singer/, data['username']
-  #   assert_match /https?:\/\/www.theatlantic.com/, data['author_url']
-  #   assert_not_nil data['picture']
-  # end
+  test "should parse url scheme http" do
+    url = 'http://www.theatlantic.com/magazine/archive/2016/11/war-goes-viral/501125/'
+    m = create_media url: url
+    data = m.as_json
+    assert_match 'War Goes Viral', data['title']
+    assert_match 'How social media is being weaponized across the world', data['description']
+    assert !data['published_at'].blank?
+    assert_match /Brooking.+Singer/, data['username']
+    assert_match /https?:\/\/www.theatlantic.com/, data['author_url']
+    assert_not_nil data['picture']
+  end
 
-  # test "should parse url scheme https" do
-  #   url = 'https://www.theguardian.com/politics/2016/oct/19/larry-sanders-on-brother-bernie-and-why-tony-blair-was-destructive'
-  #   m = create_media url: url
-  #   data = m.as_json
-  #   assert_match 'Larry Sanders on brother Bernie and why Tony Blair was ‘destructive’', data['title']
-  #   assert_match /The Green party candidate, who is fighting the byelection in David Cameron’s old seat/, data['description']
-  #   assert_match /2016-10/, data['published_at']
-  #   assert_match 'https://www.theguardian.com/profile/zoewilliams', data['author_url']
-  #   assert !data['picture'].blank?
-  # end
+  test "should parse url scheme https" do
+    url = 'https://www.theguardian.com/politics/2016/oct/19/larry-sanders-on-brother-bernie-and-why-tony-blair-was-destructive'
+    m = create_media url: url
+    data = m.as_json
+    assert_match 'Larry Sanders on brother Bernie and why Tony Blair was ‘destructive’', data['title']
+    assert_match /The Green party candidate, who is fighting the byelection in David Cameron’s old seat/, data['description']
+    assert_match /2016-10/, data['published_at']
+    assert_match 'https://www.theguardian.com/profile/zoewilliams', data['author_url']
+    assert !data['picture'].blank?
+  end
 
-  # test "should use original url when redirected page requires cookie" do
-  #   RequestHelper.stubs(:get_html).returns(Nokogiri::HTML("<meta property='og:url' content='https://www.tandfonline.com/action/cookieAbsent'><meta name='pbContext' content=';wgroup:string:Publication Websites;website:website:TFOPB;page:string:Cookie Absent'>"))
-  #   url = 'https://doi.org/10.1080/10584609.2019.1619639'
-  #   m = create_media url: url
-  #   data = m.as_json
-  #   assert_equal url, data['url']
-  #   assert_nil data['error']
-  # end
+  test "should use original url when redirected page requires cookie" do
+    RequestHelper.stubs(:get_html).returns(Nokogiri::HTML("<meta property='og:url' content='https://www.tandfonline.com/action/cookieAbsent'><meta name='pbContext' content=';wgroup:string:Publication Websites;website:website:TFOPB;page:string:Cookie Absent'>"))
+    url = 'https://doi.org/10.1080/10584609.2019.1619639'
+    m = create_media url: url
+    data = m.as_json
+    assert_equal url, data['url']
+    assert_nil data['error']
+  end
 end


### PR DESCRIPTION
## Description

We have a bunch of tests that are failing, mostly related to URL normalization.

The main issue is that sometimes, [get_cannonical_url](https://github.com/meedan/pender/blob/develop/app/models/media.rb#L204) was returning `true` instead of a valid URL, which then confused any methods that read the URL after this point.


## How has this been tested?

Confirmed that tests pass, and that URL normalization is working as expected.

## Things to pay attention to during code review

Check whether any tests failed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

