### PR TITLE
6037 – Increase interval between retries

### DIFF
--- a/app/sidekiq/archiver_status_job.rb
+++ b/app/sidekiq/archiver_status_job.rb
@@ -2,11 +2,8 @@
 # 1. I used sidekiqs own retrying/backing off formula as a starting point
 #  https://github.com/sidekiq/sidekiq/wiki/Error-Handling#automatic-job-retry
 # 2. start retrying:
-  # aprox. after a minute, that should be more than enough (it usually doesn't take that long)
-# 3. interval:
-  # just add a bit of more time, instead of 15, 60.
-  # It’s a small change but helps us start a bit later, a makes the intervals a bit longer.
-  # I think this is enough to help, as this happens when we are waiting for the request to be processed by archive_org
+  # I think ramping up to 4.5 and starting and always adding 5 minutes might be enough.
+  # It starts later and increases the intervals faster# 3. interval:
 # 4. for how long:
   # 24 hours.
   # If we haven’t been able to get the status after 24 hours should it seems wasteful to keep trying
@@ -16,7 +13,7 @@ class ArchiverStatusJob
   sidekiq_options retry_for: 24.hours, queue: 'archiving'
 
   sidekiq_retry_in do |count|
-    (count ** 4) + 60 + (rand(10) * (count + 1))
+    (count ** 4.5) + 300 + (rand(10) * (count + 1))
   end
 
   def perform(job_id, url, key_id)


### PR DESCRIPTION
## Description
When looking through Sentry errors we thought we could maybe look into the retry intervals and duration, and see if there was anything to update.

Before we would wait 1 minute to start, I think we could increase it. So I copied the both the start and interval from the archiver_worker. We wait longer to start and between retries.

References: CV2-6037

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

