### PR TITLE
6000 – Handle ArchiveOrg error:blocked-url

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -30,23 +30,23 @@ module MediaArchiveOrgArchiver
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
 
-          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
-            PenderSentry.notify(
-              Pender::Exception::TooManyCaptures.new(body["message"]),
-              url: url,
-              response_body: body
-            )
-          elsif body['status_ext'] == 'error:blocked-url'
-            PenderSentry.notify(
-              Pender::Exception::BlockedUrl.new(body["message"]),
-              url: url,
-              response_body: body
-            )
+          if body['message']&.include?('The same snapshot') ||
+             body['status_ext'] == 'error:too-many-daily-captures' ||
+             body['status_ext'] == 'error:blocked-url'
+              PenderSentry.notify(
+                custom_exception(body['status_ext'], body["message"]),
+                url: url,
+                response_body: body
+              )
           else
             raise Pender::Exception::ArchiveOrgError, "(#{body['status_ext']}) #{body['message']}"
           end
         end
       end
+    end
+
+    def custom_exception(status_ext, message)
+      status_ext == 'error:blocked-url' ?  Pender::Exception::BlockedUrl.new(message) : Pender::Exception::TooManyCaptures.new(message)
     end
 
     def get_available_archive_org_snapshot(url, key_id)

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -34,7 +34,7 @@ module MediaArchiveOrgArchiver
              body['status_ext'] == 'error:too-many-daily-captures' ||
              body['status_ext'] == 'error:blocked-url'
               PenderSentry.notify(
-                custom_exception(body['status_ext'], body["message"]),
+                custom_exception(body['status_ext'], body['message']),
                 url: url,
                 response_body: body
               )

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -30,23 +30,23 @@ module MediaArchiveOrgArchiver
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
 
-          if body['message']&.include?('The same snapshot') ||
-             body['status_ext'] == 'error:too-many-daily-captures' ||
-             body['status_ext'] == 'error:blocked-url'
-              PenderSentry.notify(
-                custom_exception(body['status_ext'], body['message']),
-                url: url,
-                response_body: body
-              )
+          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
+            PenderSentry.notify(
+              Pender::Exception::TooManyCaptures.new(body['message']),
+              url: url,
+              response_body: body
+            )
+          elsif body['status_ext'] == 'error:blocked-url'
+            PenderSentry.notify(
+              Pender::Exception::BlockedUrl.new(body['message']),
+              url: url,
+              response_body: body
+            )
           else
             raise Pender::Exception::ArchiveOrgError, "(#{body['status_ext']}) #{body['message']}"
           end
         end
       end
-    end
-
-    def custom_exception(status_ext, message)
-      status_ext == 'error:blocked-url' ?  Pender::Exception::BlockedUrl.new(message) : Pender::Exception::TooManyCaptures.new(message)
     end
 
     def get_available_archive_org_snapshot(url, key_id)

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -29,7 +29,9 @@ module MediaArchiveOrgArchiver
         else
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
-          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
+          if body['message']&.include?('The same snapshot') ||
+             body['status_ext'] == 'error:too-many-daily-captures' ||
+             body['message']&.include?('error:blocked-url')
             PenderSentry.notify(
               Pender::Exception::TooManyCaptures.new(body["message"]),
               url: url,

--- a/lib/pender/exception/blocked_url.rb
+++ b/lib/pender/exception/blocked_url.rb
@@ -1,0 +1,5 @@
+module Pender
+  module Exception
+    class BlockedUrl < StandardError; end
+  end
+end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -203,6 +203,36 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
   end
 
+  test "when Archive.org fails with blocked-url it should NOT retry, and should nofity Sentry" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: '[archive_org]: (error:blocked-url) This URL is in the Save Page Now service block list and cannot be captured.', url: url})
+
+    m = Media.new url: url, key: api_key
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
+    end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+    assert_equal 1, sentry_call_count
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
+
   test "when Archive.org fails to make/complete a request it should retry and update data with error" do
     api_key = create_api_key_with_webhook
     url = 'https://meedan.com/post/annual-report-2022'

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -180,30 +180,67 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
   end
 
-  test "when Archive.org fails with Pender::Exception::TooManyCaptures it should NOT retry, it should update data with snapshot (if available) and error" do
+  test "when Archive.org fails with the same snapshot has been made... it should NOT retry, and should notify Sentry" do
     api_key = create_api_key_with_webhook
     url = 'https://example.com/'
 
     Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+    Media.stubs(:get_available_archive_org_snapshot).returns({ message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url })
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 12 hours, 13 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
 
     m = Media.new url: url, key: api_key
-    assert_nothing_raised do
-      m.as_json(archivers: 'archive_org')
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
     end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+    assert_equal 1, sentry_call_count
 
     media_data = Pender::Store.current.read(Media.get_id(url), :json)
     assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-    assert_match /The same snapshot/, media_data.dig('archives', 'archive_org', 'error', 'message')
-    assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
   end
 
-  test "when Archive.org fails with blocked-url it should NOT retry, and should nofity Sentry" do
+  test "when Archive.org fails with too-many-daily-captures it should NOT retry, and should notify Sentry" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url})
+
+    m = Media.new url: url, key: api_key
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
+    end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+    assert_equal 1, sentry_call_count
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
+
+  test "when Archive.org fails with blocked-url it should NOT retry, and should notify Sentry" do
     api_key = create_api_key_with_webhook
     url = 'https://example.com/'
 

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -208,12 +208,12 @@ class ArchiverTest < ActiveSupport::TestCase
     url = 'https://example.com/'
 
     Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+    Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
 
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: '[archive_org]: (error:blocked-url) This URL is in the Save Page Now service block list and cannot be captured.', url: url})
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status: 'error', status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
 
     m = Media.new url: url, key: api_key
 


### PR DESCRIPTION
## Description

When an URL can't be captured ArchiveOrg might send one of the following:

```
{
message: This URL is in the Save Page Now service block list and cannot be captured. Please email us at "info@archive.org" if you would like to discuss this more.,
status: error,
status_ext: error:blocked-url
}
```

```
{
message: We’re currently facing some limitations when it comes to archiving this site. We apologize for any inconvenience this might cause and appreciate your understanding. Please email us at "info@archive.org" if you would like to discuss this more.,
status: error,
status_ext: error:blocked-url
}
```

In both cases, it doesn't make sense for us to retry. We can treat this as a custom exception (`Pender::Exception::BlockedUrl`) and just notify Sentry.

References: CV2-6000

## How has this been tested?

I added a test  and tested manually:
- Through swagger, I made a request to a twitter url with archiver set to `archive_org`
- I checked Sidekiq to see if it would retry
- I set development to notify Sentry
- I checked Sentry to see if it was correctly notified

## Things to pay attention to during code review

I tried to de-duplicate some code by creating a `custom_exception` method: https://github.com/meedan/pender/blob/e50d1e0a3d676ef68461981ca25a9b47353f3fce/app/models/concerns/media_archive_org_archiver.rb#L33-L50

But I'm not too sure about this one.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

