### PR TITLE
Update minitest to allow running tests by line number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,12 +17,12 @@ group :development do
 end
 group :test do
   gem 'parallel_tests'
-  gem "mocha", '~> 1.14.0', require: false
+  gem "mocha", "~> 2.7"
   gem 'simplecov', '0.13.0', require: false
   gem 'simplecov-console', require: false
   gem 'codeclimate-test-reporter', '1.0.8', group: :test, require: nil
   gem 'rails-controller-testing'
-  gem 'minitest', '5.10.1'
+  gem 'minitest', '5.19.0'
   gem 'minitest-retry'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,10 +224,11 @@ GEM
     mini_mime (1.1.5)
     mini_racer (0.16.0)
       libv8-node (~> 18.19.0.0)
-    minitest (5.10.1)
+    minitest (5.19.0)
     minitest-retry (0.2.3)
       minitest (>= 5.0)
-    mocha (1.14.0)
+    mocha (2.7.1)
+      ruby2_keywords (>= 0.0.5)
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
@@ -532,9 +533,9 @@ DEPENDENCIES
   loofah (= 2.21)
   memory_profiler
   mini_racer
-  minitest (= 5.10.1)
+  minitest (= 5.19.0)
   minitest-retry
-  mocha (~> 1.14.0)
+  mocha (~> 2.7)
   net-http
   net-protocol
   nokogiri (= 1.17.2)


### PR DESCRIPTION
## Description

Since updating to rails 7.2, we have been unable to run specific tests in a file, and we had to run all tests in a file. This change updates minitest to a version more compatible with rails 7.2, unlocking all functionality.

References: CV2-6264

## How has this been tested?

Confirmed that we can run specific tests in a file, as opposed to the entire file. For example, `rails test test/models/parser/instagram_item_test.rb:43`

## Things to pay attention to during code review

Confirm that minitest behaves as expected.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

