### PR TITLE
6157 – Deal with Prometheus `has already been registered` error

### DIFF
--- a/config/initializers/metrics_registry.rb
+++ b/config/initializers/metrics_registry.rb
@@ -1,4 +1,4 @@
-Rails.application.reloader.to_prepare do
+Rails.application.config.after_initialize do
   MetricsService.custom_counter(:pender_parser_requests_total, 'Count parsing requests, gets the full total - does not break them by labels', labels: [:service_name])
   MetricsService.custom_counter(:pender_parser_requests_success, 'Count successful parsing requests', labels: [:service_name])
   MetricsService.custom_counter(:pender_parser_requests_error, 'Count errored parsing requests', labels: [:service_name])


### PR DESCRIPTION
## Description

For historical reasons `realoder.to_prepare` might run twice, we have had that happen in local development. When that happens it tries to register the custom_counter again, which causes an error: `/usr/local/bundle/gems/prometheus-client-4.2.3/lib/prometheus/client/registry.rb:26:in block in register': pender_parser_requests_total has already been registered (Prometheus::Client::Registry::AlreadyRegisteredError)`

 So we changed this to ensure this only runs once.

References: CV2-6157

## How has this been tested?

This error happened a few times for me and for Jay, but we I tried to test it, I was not able to manually reproduce it. I did make sure that metrics were running as expected, by making a few requests and looking at `localhost:3200/metrics` to make sure it was being updated correctly.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

