### PR TITLE
CV2-6208 – Non-existent Facebook post or profile returns unexpected url

### DIFF
--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -10,7 +10,8 @@ module ProviderFacebook
       [
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/login/, reason: :login_page },
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/?$/, reason: :login_page },
-        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/cookie\/consent-page/, reason: :consent_page }
+        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/cookie\/consent-page/, reason: :consent_page },
+        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/.*\?absolute_url_processed=1&(fref=ts&)?_rdc=1&_rdr/, reason: :garbage },
       ]
     end
 


### PR DESCRIPTION
## Description

### Context
Instead of returning the expected url it now returns the url followed by a query.

```
Failure:
FacebookItemIntegrationTest#test_should_return_data_even_if_post_does_not_exist [/app/test/integration/parser/facebook_item_test.rb:38]:
--- expected
+++ actual
@@ -1 +1 @@
-"https://www.facebook.com/111111111111111/posts/1111111111111111"
+"https://web.facebook.com/111111111111111/posts/1111111111111111?absolute_url_processed=1&_rdc=1&_rdr"
```

```
Failure:
FacebookProfileIntegrationTest#test_should_return_data_even_if_Facebook_page_does_not_exist [/app/test/integration/parser/facebook_profile_test.rb:39]:
--- expected
+++ actual
@@ -1 +1 @@
-"https://www.facebook.com/pages/fakepage/1111111111111"
+"https://web.facebook.com/pages/fakepage/1111111111111?absolute_url_processed=1&_rdc=1&_rdr"
```

### Fix
This is caused by redirections. 
If we want to, we can ignore this by adding the url to the `ignored_urls` array inside `facebook_provider`.
I think we could ignore this redirect:

- we only end up with this extra query at the end, which could be confusing
- not following it does not seem to affect our results
- it seems to only be added to pages that do not exist

*Note:* I'm not sure what the we could name the reason. I left `:garbage` as a placeholder.

References: CV2-6208

## How has this been tested?

```
rails test test/integration/parser/facebook_profile_test.rb
rails test test/integration/parser/facebook_item_test.rb
```

## Things to pay attention to during code review

While playing around with tests I noticed that one of the tests returned an url with the query as well, but it was slightly different. 

```
-"https://www.facebook.com/pages/Meedan/105510962816034?fref=ts"
+"https://web.facebook.com/pages/Meedan/105510962816034?absolute_url_processed=1&fref=ts&_rdc=1&_rdr"
```

That is why I added `(fref=ts&)?` to the regex inside ignored_urls. It matches both cases.

```
/^https:\/\/([^\.]+\.)?facebook.com\/.*\?absolute_url_processed=1&(fref=ts&)?_rdc=1&_rdr/
```

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

