### PR TITLE
CV2-6208 – Update Facebook tests

### DIFF
--- a/test/integration/parser/facebook_item_test.rb
+++ b/test/integration/parser/facebook_item_test.rb
@@ -35,7 +35,7 @@ class FacebookItemIntegrationTest < ActiveSupport::TestCase
     assert_equal 'facebook', data['provider']
     assert_equal 'item', data['type']
     assert_equal '111111111111111_1111111111111111', data['external_id']
-    assert_equal 'https://www.facebook.com/111111111111111/posts/1111111111111111', data['title']
+    assert_match(/facebook.com\/111111111111111\/posts\/1111111111111111/, data['title'])
     assert_equal '', data['username']
     assert_equal '', data['author_name']
     assert_equal '', data['author_picture']

--- a/test/integration/parser/facebook_profile_test.rb
+++ b/test/integration/parser/facebook_profile_test.rb
@@ -36,7 +36,7 @@ class FacebookProfileIntegrationTest < ActiveSupport::TestCase
     media = create_media url: 'https://www.facebook.com/pages/fakepage/1111111111111'
     data = media.as_json
 
-    assert_equal 'https://www.facebook.com/pages/fakepage/1111111111111', data['title']
+    assert_match(/facebook.com\/pages\/fakepage\/1111111111111/, data['title'])
     assert_equal 'fakepage', data['username']
     assert data['description'].blank?
     assert data['picture'].blank?


### PR DESCRIPTION
## Description

A couple tests started failing because the url now has a query appended. Since this isn't an issue we are just updating the tests to be less specific.

```
Failure:
FacebookItemIntegrationTest#test_should_return_data_even_if_post_does_not_exist [/app/test/integration/parser/facebook_item_test.rb:38]:
--- expected
+++ actual
@@ -1 +1 @@
-"https://www.facebook.com/111111111111111/posts/1111111111111111"
+"https://web.facebook.com/111111111111111/posts/1111111111111111?absolute_url_processed=1&_rdc=1&_rdr"

Failure:
FacebookProfileIntegrationTest#test_should_return_data_even_if_Facebook_page_does_not_exist [/app/test/integration/parser/facebook_profile_test.rb:39]:
--- expected
+++ actual
@@ -1 +1 @@
-"https://www.facebook.com/pages/fakepage/1111111111111"
+"https://web.facebook.com/pages/fakepage/1111111111111?absolute_url_processed=1&_rdc=1&_rdr"
```

References: CV2-6208

## How has this been tested?

```
rails test test/integration/parser/facebook_profile_test.rb
rails test test/integration/parser/facebook_item_test.rb
```

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

