### PR TITLE
Fixing CI error by making sure that directory exists before trying to rename it

### DIFF
--- a/.github/workflows/ci-test-pr.yml
+++ b/.github/workflows/ci-test-pr.yml
@@ -102,4 +102,4 @@ jobs:
       if: ${{ failure() || success() }}
       run: |
         rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        [ -d "/tmp/.buildx-cache-new" ] && mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## Description

There are two dependabot PRs failing with this error:

```
mv: cannot stat '/tmp/.buildx-cache-new': No such file or directory
Error: Process completed with exit code 1.
```

This PR tries to fix it.

References: No Jira ticket associated. Dependabot PRs mentioned above:

- https://github.com/meedan/pender/actions/runs/13766044983/job/38492640142?pr=527
- https://github.com/meedan/pender/actions/runs/13766049113/job/38492651335?pr=526

## How has this been tested?

The error above should be gone.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

