### PR TITLE
4482 – Handle Archive.org HTML errors

### DIFF
--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -87,6 +87,12 @@ module MediaArchiveOrgArchiver
               url: url,
               response_body: error.message
             )
+        else
+          PenderSentry.notify(
+            JSON::ParserError.new(error.message),
+            url: url,
+            response_body: error.message
+          )
         end
       rescue StandardError => error
         raise Pender::Exception::RetryLater, error.message

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -43,7 +43,7 @@ module MediaArchiveOrgArchiver
           data = snapshot_data.to_h.merge({ error: { message: "(#{body['status_ext']}) #{body['message']}", code: Lapis::ErrorCodes::const_get('ARCHIVER_ERROR') }})
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
 
-         if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
+          if body['message']&.include?('The same snapshot') || body['status_ext'] == 'error:too-many-daily-captures'
             PenderSentry.notify(
               Pender::Exception::TooManyCaptures.new(body['message']),
               url: url,

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -77,7 +77,7 @@ module MediaArchiveOrgArchiver
          location = "https://web.archive.org/web/#{body_json['timestamp']}/#{url}"
           data = { location: location }
           Media.notify_webhook_and_update_cache('archive_org', url, data, key_id)
-        elsif body&.include?("<html><body><h1>429 Too Many Requests</h1>") && response&.code == "500"
+        elsif body&.include?("429 Too Many Requests")
           PenderSentry.notify(
               Pender::Exception::RateLimitExceeded.new("429 Too Many Requests"),
               url: url,

--- a/app/models/concerns/media_archive_org_archiver.rb
+++ b/app/models/concerns/media_archive_org_archiver.rb
@@ -91,7 +91,7 @@ module MediaArchiveOrgArchiver
       rescue JSON::ParserError => error
         if error.message.include?("Too Many Requests")
           raise Pender::Exception::RateLimitExceeded, error.message
-        elsif error.message.include?("Item Not Avaiable")
+        elsif error.message.include?("Item Not Available")
           raise Pender::Exception::ItemNotAvailable, error.message
         else
           raise JSON::ParserError, error.message

--- a/app/models/concerns/media_archiver.rb
+++ b/app/models/concerns/media_archiver.rb
@@ -95,14 +95,12 @@ module MediaArchiver
         yield
       rescue Pender::Exception::RetryLater => error
         retry_archiving_after_failure(archiver, { message: error.message })
-      rescue Pender::Exception::TooManyCaptures =>  error
-        post_error_tasks(archiver, params, error)
-      rescue Pender::Exception::BlockedUrl => error
-        post_error_tasks(archiver, params, error)
-      rescue Pender::Exception::RateLimitExceeded => error
-        post_error_tasks(archiver, params, error)
-      rescue JSON::ParserError => error
-        post_error_tasks(archiver, params, error)
+      rescue Pender::Exception::BlockedUrl,
+             Pender::Exception::TooManyCaptures,
+             Pender::Exception::ItemNotAvailable,
+             Pender::Exception::RateLimitExceeded,
+             JSON::ParserError => error
+              post_error_tasks(archiver, params, error)
       rescue StandardError => error
         post_error_tasks(archiver, params, error, false)
         retry_archiving_after_failure(archiver, params)

--- a/lib/pender/exception/item_not_available.rb
+++ b/lib/pender/exception/item_not_available.rb
@@ -1,0 +1,5 @@
+module Pender
+  module Exception
+    class ItemNotAvailable < StandardError; end
+  end
+end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -29,705 +29,705 @@ class ArchiverTest < ActiveSupport::TestCase
     create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
   end
 
-  # I don't really understand what this test is doing
-  test "should skip screenshots" do
-    stub_configs({'archiver_skip_hosts' => '' })
+  # # I don't really understand what this test is doing
+  # test "should skip screenshots" do
+  #   stub_configs({'archiver_skip_hosts' => '' })
 
-    api_key = create_api_key
+  #   api_key = create_api_key
 
-    url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390'
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    m = create_media url: url, key: api_key
-    data = m.as_json
+  #   url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390'
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   m = create_media url: url, key: api_key
+  #   data = m.as_json
 
-    stub_configs({'archiver_skip_hosts' => 'checkmedia.org' })
+  #   stub_configs({'archiver_skip_hosts' => 'checkmedia.org' })
 
-    url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390?hide_tasks=1'
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    m = create_media url: url, key: api_key
-    data = m.as_json
-  end
+  #   url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390?hide_tasks=1'
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   m = create_media url: url, key: api_key
+  #   data = m.as_json
+  # end
 
-  test "should archive to Archive.org" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
+  # test "should archive to Archive.org" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
 
-    Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.any_instance.unstub(:archive_to_archive_org)
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
-    media = create_media url: url, key: api_key
-    data = media.as_json(archivers: 'archive_org')
+  #   media = create_media url: url, key: api_key
+  #   data = media.as_json(archivers: 'archive_org')
 
-    assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
-  end
+  #   assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
+  # end
 
-  test "should log archiver information when archiving URLs" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
-    log = StringIO.new
-    Rails.logger = Logger.new(log)
+  # test "should log archiver information when archiving URLs" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
+  #   log = StringIO.new
+  #   Rails.logger = Logger.new(log)
 
-    Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.any_instance.unstub(:archive_to_archive_org)
   
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
-    media = create_media url: url, key: api_key
-    media.as_json(archivers: 'archive_org')
+  #   media = create_media url: url, key: api_key
+  #   media.as_json(archivers: 'archive_org')
     
-    assert_match '[Archiver] Archiving new URL', log.string
-    assert_match url, log.string
-  end
+  #   assert_match '[Archiver] Archiving new URL', log.string
+  #   assert_match url, log.string
+  # end
   
-  test "should archive Arabics url to Archive.org" do
-    api_key = create_api_key_with_webhook
-    url = 'https://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>صفحة باللغة العربية</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
-
-    assert_nothing_raised do
-      m = create_media url: url, key: api_key
-      m.as_json
-    end
-  end
-
-  test "should archive to Perma.cc" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://example.com/'
-
-    Media.any_instance.unstub(:archive_to_perma_cc)
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid' })
-
-    media = create_media url: url, key: api_key
-    data = media.as_json(archivers: 'perma_cc')
-
-    assert_equal "http://perma.cc/perma-cc-guid", data.dig('archives', 'perma_cc', 'location') 
-  end
-
-  test "should update media with error when Archive.org can't archive the url" do
-    api_key = create_api_key_with_webhook
-    urls = {
-      'http://localhost:3333/unreachable-url' => {status_ext: 'error:invalid-url-syntax', message: 'URL syntax is not valid'},
-      'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html' => {status_ext: 'error:invalid-host-resolution', message: 'Cannot resolve host'},
-    }
-
-    Media.any_instance.stubs(:follow_redirections)
-    Media.any_instance.stubs(:get_canonical_url).returns(true)
-    Media.any_instance.stubs(:try_https)
-    Media.any_instance.stubs(:parse)
-    Media.any_instance.stubs(:archive)
-
-    urls.each_pair do |url, data|
-      m = Media.new url: url
-      m.as_json(archivers: 'none')
-      assert_nil m.data.dig('archives', 'archive_org')
-
-      WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-      WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-      WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: { status: 'error', status_ext: data[:status_ext], message: data[:message] })
-      WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: { "archived_snapshots": {} }.to_json, headers: {})
-
-      assert_raises StandardError do
-        Media.send_to_archive_org(url.to_s, api_key.id)
-      end
-      media_data = Pender::Store.current.read(Media.get_id(url), :json)
-      assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-      assert_equal "(#{data[:status_ext]}) #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
-      end
-  end
-
-  test "when Archive.org fails with Pender::Exception::ArchiveOrgError it should retry, update data with snapshot (if available) and error" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
-
-    media = create_media url: url, key: api_key
-    assert_raises StandardError do
-      media.as_json(archivers: 'archive_org')
-    end
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal '(500) Random Error.', media_data.dig('archives', 'archive_org', 'error', 'message') 
-    assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
-  end
-
-  test "when Archive.org fails with the same snapshot has been made... it should NOT retry, and should notify Sentry" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url })
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
-
-    m = Media.new url: url, key: api_key
-
-    sentry_call_count = 0
-    arguments_checker = Proc.new do |e|
-      sentry_call_count += 1
-    end
-
-    PenderSentry.stub(:notify, arguments_checker) do
-      assert_nothing_raised do
-        m.as_json(archivers: 'archive_org')
-      end
-    end
-    assert_equal 1, sentry_call_count
-
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  end
-
-  test "when Archive.org fails with too-many-daily-captures it should NOT retry, and should notify Sentry" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url })
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url})
-
-    m = Media.new url: url, key: api_key
-
-    sentry_call_count = 0
-    arguments_checker = Proc.new do |e|
-      sentry_call_count += 1
-    end
-
-    PenderSentry.stub(:notify, arguments_checker) do
-      assert_nothing_raised do
-        m.as_json(archivers: 'archive_org')
-      end
-    end
-    assert_equal 1, sentry_call_count
-
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  end
-
-  test "when Archive.org fails with blocked-url it should NOT retry, and should notify Sentry" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status: 'error', status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
-
-    m = Media.new url: url, key: api_key
-
-    sentry_call_count = 0
-    arguments_checker = Proc.new do |e|
-      sentry_call_count += 1
-    end
-
-    PenderSentry.stub(:notify, arguments_checker) do
-      assert_nothing_raised do
-        m.as_json(archivers: 'archive_org')
-      end
-    end
-    assert_equal 1, sentry_call_count
-
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  end
-
-  test "when Archive.org fails to make/complete a request it should retry and update data with error" do
-    api_key = create_api_key_with_webhook
-    url = 'https://meedan.com/post/annual-report-2022'
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:any, /archive.org/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-    m = create_media url: url, key: api_key
-    assert_raises StandardError do
-      data = m.as_json(archivers: 'archive_org')
-      assert_nil data.dig('archives', 'archive_org')
-    end
-
-    data = m.as_json
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'archive_org', 'error', 'code')
-    assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'archive_org', 'error', 'message')
-  end
-
-  test "when Perma.cc fails with Pender::Exception::PermaCcError it should update media with error and retry" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://example.com'
-
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "A random error." }.to_json)
-
-    m = Media.new url: url, key: api_key
-    assert_raises StandardError do
-      m.as_json(archivers: 'perma_cc')
-    end
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
-    assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
-  end
-
-  test "when Perma.cc fails with Pender::Exception::TooManyCaptures it should update media with error and not retry" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://example.com'
-
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
-
-    m = Media.new url: url, key: api_key
-    assert_nothing_raised do
-      m.as_json(archivers: 'perma_cc')
-    end
-
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
-    assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
-  end
-
-  test "when Perma.cc fails to make/complete a request it should retry and update data with error" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://meedan.com/post/annual-report-2022'
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /api.perma.cc/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
-
-    m = create_media url: url, key: api_key
-    assert_raises StandardError do
-      data = m.as_json(archivers: 'perma_cc')
-      assert_nil data.dig('archives', 'perma_cc')
-    end
-
-    data = m.as_json
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'perma_cc', 'error', 'code')
-    assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'perma_cc', 'error', 'message')
-  end
-
-  test "should update media with error when archive to Archive.org hits the limit of retries" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
-
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
-
-    media = Media.new url: url, key: api_key
-    assert_raises StandardError do
-      media.as_json(archivers: 'archive_org')
-    end
-    Media.give_up({ args: [url, 'archive_org', api_key], error_message: 'Gave Up', error_class: 'error class'})
-
-    media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'archive_org', 'error', 'code')
-    assert_equal "Gave Up", media_data.dig('archives', 'archive_org', 'error', 'message')
-  end
-
-  test "if a refresh is not requested and archive is present in cache should not archive on Archive.org" do
-    url = 'https://example.com/'
-    api_key = create_api_key_with_webhook
-
-    Media.any_instance.unstub(:archive_to_archive_org)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-
-    m = Media.new url: url, key: api_key
-    id = Media.get_id(m.url)
-
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-    m.as_json(archivers: 'archive_org')
-
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['archive_org'], cached.keys
-    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
-
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-    m.as_json(archivers: 'archive_org')
-
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['archive_org'], cached.keys
-    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
-  end
-
-  test "if a refresh is requested it should try to archive on Archive.org" do
-    url = 'https://example.com/'
-    api_key = create_api_key_with_webhook
+  # test "should archive Arabics url to Archive.org" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>صفحة باللغة العربية</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+
+  #   assert_nothing_raised do
+  #     m = create_media url: url, key: api_key
+  #     m.as_json
+  #   end
+  # end
+
+  # test "should archive to Perma.cc" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://example.com/'
+
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid' })
+
+  #   media = create_media url: url, key: api_key
+  #   data = media.as_json(archivers: 'perma_cc')
+
+  #   assert_equal "http://perma.cc/perma-cc-guid", data.dig('archives', 'perma_cc', 'location') 
+  # end
+
+  # test "should update media with error when Archive.org can't archive the url" do
+  #   api_key = create_api_key_with_webhook
+  #   urls = {
+  #     'http://localhost:3333/unreachable-url' => {status_ext: 'error:invalid-url-syntax', message: 'URL syntax is not valid'},
+  #     'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html' => {status_ext: 'error:invalid-host-resolution', message: 'Cannot resolve host'},
+  #   }
+
+  #   Media.any_instance.stubs(:follow_redirections)
+  #   Media.any_instance.stubs(:get_canonical_url).returns(true)
+  #   Media.any_instance.stubs(:try_https)
+  #   Media.any_instance.stubs(:parse)
+  #   Media.any_instance.stubs(:archive)
+
+  #   urls.each_pair do |url, data|
+  #     m = Media.new url: url
+  #     m.as_json(archivers: 'none')
+  #     assert_nil m.data.dig('archives', 'archive_org')
+
+  #     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #     WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: { status: 'error', status_ext: data[:status_ext], message: data[:message] })
+  #     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: { "archived_snapshots": {} }.to_json, headers: {})
+
+  #     assert_raises StandardError do
+  #       Media.send_to_archive_org(url.to_s, api_key.id)
+  #     end
+  #     media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #     assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  #     assert_equal "(#{data[:status_ext]}) #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
+  #     end
+  # end
+
+  # test "when Archive.org fails with Pender::Exception::ArchiveOrgError it should retry, update data with snapshot (if available) and error" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
+
+  #   media = create_media url: url, key: api_key
+  #   assert_raises StandardError do
+  #     media.as_json(archivers: 'archive_org')
+  #   end
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal '(500) Random Error.', media_data.dig('archives', 'archive_org', 'error', 'message') 
+  #   assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
+  # end
+
+  # test "when Archive.org fails with the same snapshot has been made... it should NOT retry, and should notify Sentry" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.stubs(:get_available_archive_org_snapshot).returns({ message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url })
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
+
+  #   m = Media.new url: url, key: api_key
+
+  #   sentry_call_count = 0
+  #   arguments_checker = Proc.new do |e|
+  #     sentry_call_count += 1
+  #   end
+
+  #   PenderSentry.stub(:notify, arguments_checker) do
+  #     assert_nothing_raised do
+  #       m.as_json(archivers: 'archive_org')
+  #     end
+  #   end
+  #   assert_equal 1, sentry_call_count
+
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  # end
+
+  # test "when Archive.org fails with too-many-daily-captures it should NOT retry, and should notify Sentry" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url })
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url})
+
+  #   m = Media.new url: url, key: api_key
+
+  #   sentry_call_count = 0
+  #   arguments_checker = Proc.new do |e|
+  #     sentry_call_count += 1
+  #   end
+
+  #   PenderSentry.stub(:notify, arguments_checker) do
+  #     assert_nothing_raised do
+  #       m.as_json(archivers: 'archive_org')
+  #     end
+  #   end
+  #   assert_equal 1, sentry_call_count
+
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  # end
+
+  # test "when Archive.org fails with blocked-url it should NOT retry, and should notify Sentry" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status: 'error', status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
+
+  #   m = Media.new url: url, key: api_key
+
+  #   sentry_call_count = 0
+  #   arguments_checker = Proc.new do |e|
+  #     sentry_call_count += 1
+  #   end
+
+  #   PenderSentry.stub(:notify, arguments_checker) do
+  #     assert_nothing_raised do
+  #       m.as_json(archivers: 'archive_org')
+  #     end
+  #   end
+  #   assert_equal 1, sentry_call_count
+
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  # end
+
+  # test "when Archive.org fails to make/complete a request it should retry and update data with error" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://meedan.com/post/annual-report-2022'
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:any, /archive.org/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+  #   m = create_media url: url, key: api_key
+  #   assert_raises StandardError do
+  #     data = m.as_json(archivers: 'archive_org')
+  #     assert_nil data.dig('archives', 'archive_org')
+  #   end
+
+  #   data = m.as_json
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'archive_org', 'error', 'code')
+  #   assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'archive_org', 'error', 'message')
+  # end
+
+  # test "when Perma.cc fails with Pender::Exception::PermaCcError it should update media with error and retry" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://example.com'
+
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "A random error." }.to_json)
+
+  #   m = Media.new url: url, key: api_key
+  #   assert_raises StandardError do
+  #     m.as_json(archivers: 'perma_cc')
+  #   end
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
+  #   assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
+  # end
+
+  # test "when Perma.cc fails with Pender::Exception::TooManyCaptures it should update media with error and not retry" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://example.com'
+
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
+
+  #   m = Media.new url: url, key: api_key
+  #   assert_nothing_raised do
+  #     m.as_json(archivers: 'perma_cc')
+  #   end
+
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
+  #   assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
+  # end
+
+  # test "when Perma.cc fails to make/complete a request it should retry and update data with error" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://meedan.com/post/annual-report-2022'
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
+
+  #   m = create_media url: url, key: api_key
+  #   assert_raises StandardError do
+  #     data = m.as_json(archivers: 'perma_cc')
+  #     assert_nil data.dig('archives', 'perma_cc')
+  #   end
+
+  #   data = m.as_json
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'perma_cc', 'error', 'code')
+  #   assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'perma_cc', 'error', 'message')
+  # end
+
+  # test "should update media with error when archive to Archive.org hits the limit of retries" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
+
+  #   media = Media.new url: url, key: api_key
+  #   assert_raises StandardError do
+  #     media.as_json(archivers: 'archive_org')
+  #   end
+  #   Media.give_up({ args: [url, 'archive_org', api_key], error_message: 'Gave Up', error_class: 'error class'})
+
+  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  #   assert_equal "Gave Up", media_data.dig('archives', 'archive_org', 'error', 'message')
+  # end
+
+  # test "if a refresh is not requested and archive is present in cache should not archive on Archive.org" do
+  #   url = 'https://example.com/'
+  #   api_key = create_api_key_with_webhook
+
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+
+  #   m = Media.new url: url, key: api_key
+  #   id = Media.get_id(m.url)
+
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+  #   m.as_json(archivers: 'archive_org')
+
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['archive_org'], cached.keys
+  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
+
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+  #   m.as_json(archivers: 'archive_org')
+
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['archive_org'], cached.keys
+  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
+  # end
+
+  # test "if a refresh is requested it should try to archive on Archive.org" do
+  #   url = 'https://example.com/'
+  #   api_key = create_api_key_with_webhook
     
-    Media.any_instance.unstub(:archive_to_archive_org)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
 
-    m = Media.new url: url, key: api_key
-    id = Media.get_id(m.url)
+  #   m = Media.new url: url, key: api_key
+  #   id = Media.get_id(m.url)
 
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    m.as_json(archivers: 'archive_org')
+  #   m.as_json(archivers: 'archive_org')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['archive_org'], cached.keys
-    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['archive_org'], cached.keys
+  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
 
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    m.as_json(force: true, archivers: 'archive_org')
+  #   m.as_json(force: true, archivers: 'archive_org')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['archive_org'], cached.keys
-    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-SECOND/https://example.com/'}, cached['archive_org'])
-  end
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['archive_org'], cached.keys
+  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-SECOND/https://example.com/'}, cached['archive_org'])
+  # end
 
-  test "if a refresh is not requested and archive is present in cache it should not try to archive on Perma.cc" do
-    url = 'https://example.com'
-    api_key = create_api_key_with_webhook_for_perma_cc
+  # test "if a refresh is not requested and archive is present in cache it should not try to archive on Perma.cc" do
+  #   url = 'https://example.com'
+  #   api_key = create_api_key_with_webhook_for_perma_cc
 
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
 
-    m = Media.new url: url, key: api_key
-    id = Media.get_id(m.url)
+  #   m = Media.new url: url, key: api_key
+  #   id = Media.get_id(m.url)
 
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    m.as_json(archivers: 'perma_cc')
+  #   m.as_json(archivers: 'perma_cc')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['perma_cc'], cached.keys
-    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['perma_cc'], cached.keys
+  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
 
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
 
-    m.as_json(archivers: 'perma_cc')
+  #   m.as_json(archivers: 'perma_cc')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['perma_cc'], cached.keys
-    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
-  end
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['perma_cc'], cached.keys
+  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
+  # end
 
-  test "if a refresh is requested it should try to create a new archive on Perma.cc" do
-    url = 'https://example.com'
-    api_key = create_api_key_with_webhook_for_perma_cc
+  # test "if a refresh is requested it should try to create a new archive on Perma.cc" do
+  #   url = 'https://example.com'
+  #   api_key = create_api_key_with_webhook_for_perma_cc
 
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
 
-    m = Media.new url: url, key: api_key
-    id = Media.get_id(m.url)
+  #   m = Media.new url: url, key: api_key
+  #   id = Media.get_id(m.url)
 
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    m.as_json(archivers: 'perma_cc')
+  #   m.as_json(archivers: 'perma_cc')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['perma_cc'], cached.keys
-    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['perma_cc'], cached.keys
+  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
 
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
 
-    m.as_json(force: true, archivers: 'perma_cc')
+  #   m.as_json(force: true, archivers: 'perma_cc')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['perma_cc'], cached.keys
-    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-SECOND'}, cached['perma_cc'])
-  end
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['perma_cc'], cached.keys
+  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-SECOND'}, cached['perma_cc'])
+  # end
 
-  test "should not archive in any archiver if none is requested" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
+  # test "should not archive in any archiver if none is requested" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
     
-    Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.any_instance.unstub(:archive_to_archive_org)
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp'})
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp'})
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    id = Media.get_id(url)
-    m = create_media url: url, key: api_key
-    m.as_json
-    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+  #   id = Media.get_id(url)
+  #   m = create_media url: url, key: api_key
+  #   m.as_json
+  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
 
-    m.as_json(archivers: '')
-    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+  #   m.as_json(archivers: '')
+  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
 
-    m.as_json(archivers: nil)
-    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+  #   m.as_json(archivers: nil)
+  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
 
-    m.as_json(archivers: 'none')
-    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+  #   m.as_json(archivers: 'none')
+  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
 
-    m.as_json(archivers: 'archive_org')
-    assert_equal({'archive_org' => {"location" => 'https://web.archive.org/web/archive-timestamp/https://example.com/'}}, Pender::Store.current.read(id, :json)[:archives])
-  end
+  #   m.as_json(archivers: 'archive_org')
+  #   assert_equal({'archive_org' => {"location" => 'https://web.archive.org/web/archive-timestamp/https://example.com/'}}, Pender::Store.current.read(id, :json)[:archives])
+  # end
 
-  test "should update cache when a new archiver is requested without the need to request for a refresh" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://example.com/'
+  # test "should update cache when a new archiver is requested without the need to request for a refresh" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://example.com/'
 
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   Media.any_instance.unstub(:archive_to_archive_org)
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    id = Media.get_id(url)
-    m = create_media url: url, key: api_key
-    m.as_json(archivers: 'perma_cc')
-    assert_equal({'perma_cc' => {"location" => 'http://perma.cc/perma-cc-guid-1'}}, Pender::Store.current.read(id, :json)[:archives])
+  #   id = Media.get_id(url)
+  #   m = create_media url: url, key: api_key
+  #   m.as_json(archivers: 'perma_cc')
+  #   assert_equal({'perma_cc' => {"location" => 'http://perma.cc/perma-cc-guid-1'}}, Pender::Store.current.read(id, :json)[:archives])
 
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
-    m.as_json(archivers: 'perma_cc, archive_org')
-    assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
-  end
+  #   m.as_json(archivers: 'perma_cc, archive_org')
+  #   assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
+  # end
 
-  test "should not archive again if media on cache has both archivers" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://fakewebsite.com/'
+  # test "should not archive again if media on cache has both archivers" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://fakewebsite.com/'
     
-    Media.any_instance.unstub(:archive_to_archive_org)
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    Media.stubs(:get_available_archive_org_snapshot).returns(nil)
+  #   Media.any_instance.unstub(:archive_to_archive_org)
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   Media.stubs(:get_available_archive_org_snapshot).returns(nil)
 
-    # Our webhook response
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    # A fake website that never redirects us, so that our Media.get_id stays consistent
-    WebMock.stub_request(:get, /fakewebsite.com/).to_return(status: 200, body: '')
+  #   # Our webhook response
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   # A fake website that never redirects us, so that our Media.get_id stays consistent
+  #   WebMock.stub_request(:get, /fakewebsite.com/).to_return(status: 200, body: '')
 
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
 
-    # First archiver request responses
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+  #   # First archiver request responses
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
 
-    id = Media.get_id(url)
-    m = create_media url: url, key: api_key
-    m.as_json(archivers: 'perma_cc, archive_org')
-    assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
+  #   id = Media.get_id(url)
+  #   m = create_media url: url, key: api_key
+  #   m.as_json(archivers: 'perma_cc, archive_org')
+  #   assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
 
-    # Second archiver request responses
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-2' })
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp2'})
+  #   # Second archiver request responses
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-2' })
+  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp2'})
 
-    m.as_json
-    assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
-    assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
+  #   m.as_json
+  #   assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
+  #   assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
 
-    m.as_json(archivers: 'none')
-    assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
-    assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
-  end
+  #   m.as_json(archivers: 'none')
+  #   assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
+  #   assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
+  # end
 
-  test "return the enabled archivers" do
-    enabled_archivers = Media::ENABLED_ARCHIVERS
-    Media.const_set(:ENABLED_ARCHIVERS, [{key: 'archive_org'}, {key: 'perma_cc'}])
+  # test "return the enabled archivers" do
+  #   enabled_archivers = Media::ENABLED_ARCHIVERS
+  #   Media.const_set(:ENABLED_ARCHIVERS, [{key: 'archive_org'}, {key: 'perma_cc'}])
 
-    assert_equal ['archive_org', 'perma_cc'].sort, Media.enabled_archivers(['archive_org', 'perma_cc']).keys
+  #   assert_equal ['archive_org', 'perma_cc'].sort, Media.enabled_archivers(['archive_org', 'perma_cc']).keys
 
-    quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, [{key: 'archive_org'}])
+  #   quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, [{key: 'archive_org'}])
 
-    assert_equal ['archive_org'].sort, Media.enabled_archivers(['perma_cc', 'archive_org']).keys
-  ensure
-    quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled_archivers)
-  end
+  #   assert_equal ['archive_org'].sort, Media.enabled_archivers(['perma_cc', 'archive_org']).keys
+  # ensure
+  #   quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled_archivers)
+  # end
 
-  test "should archive to perma.cc and store the URL on archives if perma_cc_key is present" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://example.com'
+  # test "should archive to perma.cc and store the URL on archives if perma_cc_key is present" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://example.com'
     
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    m = Media.new url: url, key: api_key
-    id = Media.get_id(m.url)
-    m.as_json(archivers: 'perma_cc')
+  #   m = Media.new url: url, key: api_key
+  #   id = Media.get_id(m.url)
+  #   m.as_json(archivers: 'perma_cc')
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['perma_cc'], cached.keys
-    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
-  end
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['perma_cc'], cached.keys
+  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
+  # end
 
-  test "should add disabled Perma.cc archiver error message if perma_key is not defined" do
-    api_key = create_api_key_with_webhook
-    url = 'https://example.com/'
+  # test "should add disabled Perma.cc archiver error message if perma_key is not defined" do
+  #   api_key = create_api_key_with_webhook
+  #   url = 'https://example.com/'
 
-    Media.any_instance.unstub(:archive_to_perma_cc)
-    Media.stubs(:available_archivers).returns(['perma_cc'])
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, "https://example.com/webhook.php").to_return(status: 200, body: '')
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
+  #   Media.stubs(:available_archivers).returns(['perma_cc'])
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, "https://example.com/webhook.php").to_return(status: 200, body: '')
 
-    m = Media.new url: url, key: api_key
-    m.as_json(archivers: 'perma_cc')
+  #   m = Media.new url: url, key: api_key
+  #   m.as_json(archivers: 'perma_cc')
     
-    id = Media.get_id(url)
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_match 'missing authentication', cached.dig('perma_cc', 'error', 'message').downcase
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY'), cached.dig('perma_cc', 'error', 'code')
-  end
+  #   id = Media.get_id(url)
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_match 'missing authentication', cached.dig('perma_cc', 'error', 'message').downcase
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY'), cached.dig('perma_cc', 'error', 'code')
+  # end
 
-  test "should return api key settings" do
-    key1 = create_api_key application_settings: {'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-    key2 = create_api_key application_settings: {}
-    key3 = create_api_key
-    [key1.id, key2.id, key3.id, -1].each do |id|
-      assert_nothing_raised do
-        Media.api_key_settings(id)
-      end
-    end
-  end
+  # test "should return api key settings" do
+  #   key1 = create_api_key application_settings: {'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+  #   key2 = create_api_key application_settings: {}
+  #   key3 = create_api_key
+  #   [key1.id, key2.id, key3.id, -1].each do |id|
+  #     assert_nothing_raised do
+  #       Media.api_key_settings(id)
+  #     end
+  #   end
+  # end
 
-  test "include error on data when cannot use archiver" do
-    skip = ENV['archiver_skip_hosts']
-    ENV['archiver_skip_hosts'] = 'example.com'
+  # test "include error on data when cannot use archiver" do
+  #   skip = ENV['archiver_skip_hosts']
+  #   ENV['archiver_skip_hosts'] = 'example.com'
 
-    url = 'https://example.com'
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   url = 'https://example.com'
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
 
-    m = Media.new url: url
-    m.data = Media.minimal_data(m)
+  #   m = Media.new url: url
+  #   m.data = Media.minimal_data(m)
 
-    m.archive('archive_org')
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_HOST_SKIPPED'), m.data.dig('archives', 'archive_org', 'error', 'code')
-    assert_match 'Host Skipped: example.com', m.data.dig('archives', 'archive_org', 'error', 'message')
-    ENV['archiver_skip_hosts'] = ''
+  #   m.archive('archive_org')
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_HOST_SKIPPED'), m.data.dig('archives', 'archive_org', 'error', 'code')
+  #   assert_match 'Host Skipped: example.com', m.data.dig('archives', 'archive_org', 'error', 'message')
+  #   ENV['archiver_skip_hosts'] = ''
 
-    PenderConfig.reload
-    enabled = Media::ENABLED_ARCHIVERS
-    Media.const_set(:ENABLED_ARCHIVERS, [])
+  #   PenderConfig.reload
+  #   enabled = Media::ENABLED_ARCHIVERS
+  #   Media.const_set(:ENABLED_ARCHIVERS, [])
 
-    m.archive('archive_org,unexistent_archive')
+  #   m.archive('archive_org,unexistent_archive')
 
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_NOT_FOUND'), m.data.dig('archives', 'unexistent_archive', 'error', 'code')
-    assert_match 'Not Found', m.data.dig('archives', 'unexistent_archive', 'error', 'message')
-    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_DISABLED'), m.data.dig('archives', 'archive_org', 'error', 'code')
-    assert_match 'Disabled', m.data.dig('archives', 'archive_org', 'error', 'message')
-  ensure
-    quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled)
-    ENV['archiver_skip_hosts'] = skip
-  end
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_NOT_FOUND'), m.data.dig('archives', 'unexistent_archive', 'error', 'code')
+  #   assert_match 'Not Found', m.data.dig('archives', 'unexistent_archive', 'error', 'message')
+  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_DISABLED'), m.data.dig('archives', 'archive_org', 'error', 'code')
+  #   assert_match 'Disabled', m.data.dig('archives', 'archive_org', 'error', 'message')
+  # ensure
+  #   quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled)
+  #   ENV['archiver_skip_hosts'] = skip
+  # end
 
-  test "should get and return the available snapshot if page was already archived on Archive.org" do
-    url = 'https://example.com/'
-    api_key = create_api_key_with_webhook
+  # test "should get and return the available snapshot if page was already archived on Archive.org" do
+  #   url = 'https://example.com/'
+  #   api_key = create_api_key_with_webhook
 
-    url = 'https://example.com/'
-    api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-    encoded_uri = RequestHelper.encode_url(url)
+  #   url = 'https://example.com/'
+  #   api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+  #   encoded_uri = RequestHelper.encode_url(url)
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return_json(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}})
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return_json(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}})
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
 
-    snapshot = Media.get_available_archive_org_snapshot(encoded_uri, api_key)
-    assert_equal 'http://web.archive.org/web/20210223111252/http://example.com/' , snapshot[:location]
-  end
+  #   snapshot = Media.get_available_archive_org_snapshot(encoded_uri, api_key)
+  #   assert_equal 'http://web.archive.org/web/20210223111252/http://example.com/' , snapshot[:location]
+  # end
 
-  test "should return nil if page was not previously archived on Archive.org" do
-    url = 'https://example.com/'
+  # test "should return nil if page was not previously archived on Archive.org" do
+  #   url = 'https://example.com/'
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}})
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}})
 
-    assert_nil Media.get_available_archive_org_snapshot(url, nil)
-  end
+  #   assert_nil Media.get_available_archive_org_snapshot(url, nil)
+  # end
 
-  test "should still cache data if notifying webhook fails" do
-    api_key = create_api_key_with_webhook_for_perma_cc
-    url = 'https://example.com/'
+  # test "should still cache data if notifying webhook fails" do
+  #   api_key = create_api_key_with_webhook_for_perma_cc
+  #   url = 'https://example.com/'
 
-    Media.any_instance.unstub(:archive_to_perma_cc)
+  #   Media.any_instance.unstub(:archive_to_perma_cc)
 
-    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 425, body: '')
+  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 425, body: '')
 
-    m = Media.new url: url, key: api_key
-    id = Media.get_id(m.url)
-    assert_raises Pender::Exception::RetryLater do
-      m.as_json(archivers: 'perma_cc')
-    end
+  #   m = Media.new url: url, key: api_key
+  #   id = Media.get_id(m.url)
+  #   assert_raises Pender::Exception::RetryLater do
+  #     m.as_json(archivers: 'perma_cc')
+  #   end
 
-    cached = Pender::Store.current.read(id, :json)[:archives]
-    assert_equal ['perma_cc'], cached.keys
-    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
-  end
+  #   cached = Pender::Store.current.read(id, :json)[:archives]
+  #   assert_equal ['perma_cc'], cached.keys
+  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
+  # end
 
   test "when Archive.org returns 429 Too Many Requests it should notify Sentry with RateLimitExceeded" do
     api_key = create_api_key_with_webhook

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -816,7 +816,7 @@ class ArchiverTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
     WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: 'Item Not Avaiable' )
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: 'Item Not Available' )
     WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
 
     m = Media.new url: url, key: api_key
@@ -825,7 +825,7 @@ class ArchiverTest < ActiveSupport::TestCase
     arguments_checker = Proc.new do |e|
       sentry_call_count += 1
       assert_instance_of Pender::Exception::ItemNotAvailable, e
-      assert_includes e.message, 'Item Not Avaiable'
+      assert_includes e.message, 'Item Not Available'
     end
 
     PenderSentry.stub(:notify, arguments_checker) do
@@ -837,7 +837,7 @@ class ArchiverTest < ActiveSupport::TestCase
     assert_equal 1, sentry_call_count
 
     media_data = Pender::Store.current.read(Media.get_id(url), :json)
-    expected_error_message = "Item Not Avaiable"
+    expected_error_message = "Item Not Available"
     assert_includes media_data.dig('archives', 'archive_org', 'error', 'message'), expected_error_message
     assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
   end

--- a/test/models/archiver_test.rb
+++ b/test/models/archiver_test.rb
@@ -29,763 +29,775 @@ class ArchiverTest < ActiveSupport::TestCase
     create_api_key application_settings: { config: { 'perma_cc_key': 'my-perma-key' }, 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
   end
 
-  # # I don't really understand what this test is doing
-  # test "should skip screenshots" do
-  #   stub_configs({'archiver_skip_hosts' => '' })
-
-  #   api_key = create_api_key
-
-  #   url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390'
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   m = create_media url: url, key: api_key
-  #   data = m.as_json
-
-  #   stub_configs({'archiver_skip_hosts' => 'checkmedia.org' })
-
-  #   url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390?hide_tasks=1'
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   m = create_media url: url, key: api_key
-  #   data = m.as_json
-  # end
-
-  # test "should archive to Archive.org" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
-
-  #   media = create_media url: url, key: api_key
-  #   data = media.as_json(archivers: 'archive_org')
-
-  #   assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
-  # end
-
-  # test "should log archiver information when archiving URLs" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-  #   log = StringIO.new
-  #   Rails.logger = Logger.new(log)
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
-
-  #   media = create_media url: url, key: api_key
-  #   media.as_json(archivers: 'archive_org')
-    
-  #   assert_match '[Archiver] Archiving new URL', log.string
-  #   assert_match url, log.string
-  # end
-  
-  # test "should archive Arabics url to Archive.org" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>صفحة باللغة العربية</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
-
-  #   assert_nothing_raised do
-  #     m = create_media url: url, key: api_key
-  #     m.as_json
-  #   end
-  # end
-
-  # test "should archive to Perma.cc" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid' })
-
-  #   media = create_media url: url, key: api_key
-  #   data = media.as_json(archivers: 'perma_cc')
-
-  #   assert_equal "http://perma.cc/perma-cc-guid", data.dig('archives', 'perma_cc', 'location') 
-  # end
-
-  # test "should update media with error when Archive.org can't archive the url" do
-  #   api_key = create_api_key_with_webhook
-  #   urls = {
-  #     'http://localhost:3333/unreachable-url' => {status_ext: 'error:invalid-url-syntax', message: 'URL syntax is not valid'},
-  #     'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html' => {status_ext: 'error:invalid-host-resolution', message: 'Cannot resolve host'},
-  #   }
-
-  #   Media.any_instance.stubs(:follow_redirections)
-  #   Media.any_instance.stubs(:get_canonical_url).returns(true)
-  #   Media.any_instance.stubs(:try_https)
-  #   Media.any_instance.stubs(:parse)
-  #   Media.any_instance.stubs(:archive)
-
-  #   urls.each_pair do |url, data|
-  #     m = Media.new url: url
-  #     m.as_json(archivers: 'none')
-  #     assert_nil m.data.dig('archives', 'archive_org')
-
-  #     WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #     WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #     WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: { status: 'error', status_ext: data[:status_ext], message: data[:message] })
-  #     WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: { "archived_snapshots": {} }.to_json, headers: {})
-
-  #     assert_raises StandardError do
-  #       Media.send_to_archive_org(url.to_s, api_key.id)
-  #     end
-  #     media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #     assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  #     assert_equal "(#{data[:status_ext]}) #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
-  #     end
-  # end
-
-  # test "when Archive.org fails with Pender::Exception::ArchiveOrgError it should retry, update data with snapshot (if available) and error" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
-
-  #   media = create_media url: url, key: api_key
-  #   assert_raises StandardError do
-  #     media.as_json(archivers: 'archive_org')
-  #   end
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal '(500) Random Error.', media_data.dig('archives', 'archive_org', 'error', 'message') 
-  #   assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
-  # end
-
-  # test "when Archive.org fails with the same snapshot has been made... it should NOT retry, and should notify Sentry" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   Media.stubs(:get_available_archive_org_snapshot).returns({ message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url })
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
-
-  #   m = Media.new url: url, key: api_key
-
-  #   sentry_call_count = 0
-  #   arguments_checker = Proc.new do |e|
-  #     sentry_call_count += 1
-  #   end
-
-  #   PenderSentry.stub(:notify, arguments_checker) do
-  #     assert_nothing_raised do
-  #       m.as_json(archivers: 'archive_org')
-  #     end
-  #   end
-  #   assert_equal 1, sentry_call_count
-
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  # end
-
-  # test "when Archive.org fails with too-many-daily-captures it should NOT retry, and should notify Sentry" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url })
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url})
-
-  #   m = Media.new url: url, key: api_key
-
-  #   sentry_call_count = 0
-  #   arguments_checker = Proc.new do |e|
-  #     sentry_call_count += 1
-  #   end
-
-  #   PenderSentry.stub(:notify, arguments_checker) do
-  #     assert_nothing_raised do
-  #       m.as_json(archivers: 'archive_org')
-  #     end
-  #   end
-  #   assert_equal 1, sentry_call_count
-
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  # end
-
-  # test "when Archive.org fails with blocked-url it should NOT retry, and should notify Sentry" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status: 'error', status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
-
-  #   m = Media.new url: url, key: api_key
-
-  #   sentry_call_count = 0
-  #   arguments_checker = Proc.new do |e|
-  #     sentry_call_count += 1
-  #   end
-
-  #   PenderSentry.stub(:notify, arguments_checker) do
-  #     assert_nothing_raised do
-  #       m.as_json(archivers: 'archive_org')
-  #     end
-  #   end
-  #   assert_equal 1, sentry_call_count
-
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  # end
-
-  # test "when Archive.org fails to make/complete a request it should retry and update data with error" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://meedan.com/post/annual-report-2022'
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:any, /archive.org/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m = create_media url: url, key: api_key
-  #   assert_raises StandardError do
-  #     data = m.as_json(archivers: 'archive_org')
-  #     assert_nil data.dig('archives', 'archive_org')
-  #   end
-
-  #   data = m.as_json
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'archive_org', 'error', 'code')
-  #   assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'archive_org', 'error', 'message')
-  # end
-
-  # test "when Perma.cc fails with Pender::Exception::PermaCcError it should update media with error and retry" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://example.com'
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "A random error." }.to_json)
-
-  #   m = Media.new url: url, key: api_key
-  #   assert_raises StandardError do
-  #     m.as_json(archivers: 'perma_cc')
-  #   end
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
-  #   assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
-  # end
-
-  # test "when Perma.cc fails with Pender::Exception::TooManyCaptures it should update media with error and not retry" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://example.com'
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
-
-  #   m = Media.new url: url, key: api_key
-  #   assert_nothing_raised do
-  #     m.as_json(archivers: 'perma_cc')
-  #   end
-
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
-  #   assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
-  # end
-
-  # test "when Perma.cc fails to make/complete a request it should retry and update data with error" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://meedan.com/post/annual-report-2022'
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
-
-  #   m = create_media url: url, key: api_key
-  #   assert_raises StandardError do
-  #     data = m.as_json(archivers: 'perma_cc')
-  #     assert_nil data.dig('archives', 'perma_cc')
-  #   end
-
-  #   data = m.as_json
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'perma_cc', 'error', 'code')
-  #   assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'perma_cc', 'error', 'message')
-  # end
-
-  # test "should update media with error when archive to Archive.org hits the limit of retries" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
-
-  #   media = Media.new url: url, key: api_key
-  #   assert_raises StandardError do
-  #     media.as_json(archivers: 'archive_org')
-  #   end
-  #   Media.give_up({ args: [url, 'archive_org', api_key], error_message: 'Gave Up', error_class: 'error class'})
-
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  #   assert_equal "Gave Up", media_data.dig('archives', 'archive_org', 'error', 'message')
-  # end
-
-  # test "if a refresh is not requested and archive is present in cache should not archive on Archive.org" do
-  #   url = 'https://example.com/'
-  #   api_key = create_api_key_with_webhook
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-
-  #   m = Media.new url: url, key: api_key
-  #   id = Media.get_id(m.url)
-
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m.as_json(archivers: 'archive_org')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['archive_org'], cached.keys
-  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
-
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m.as_json(archivers: 'archive_org')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['archive_org'], cached.keys
-  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
-  # end
-
-  # test "if a refresh is requested it should try to archive on Archive.org" do
-  #   url = 'https://example.com/'
-  #   api_key = create_api_key_with_webhook
-    
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-
-  #   m = Media.new url: url, key: api_key
-  #   id = Media.get_id(m.url)
-
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m.as_json(archivers: 'archive_org')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['archive_org'], cached.keys
-  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
-
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m.as_json(force: true, archivers: 'archive_org')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['archive_org'], cached.keys
-  #   assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-SECOND/https://example.com/'}, cached['archive_org'])
-  # end
-
-  # test "if a refresh is not requested and archive is present in cache it should not try to archive on Perma.cc" do
-  #   url = 'https://example.com'
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-
-  #   m = Media.new url: url, key: api_key
-  #   id = Media.get_id(m.url)
-
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m.as_json(archivers: 'perma_cc')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['perma_cc'], cached.keys
-  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
-
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
-
-  #   m.as_json(archivers: 'perma_cc')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['perma_cc'], cached.keys
-  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
-  # end
-
-  # test "if a refresh is requested it should try to create a new archive on Perma.cc" do
-  #   url = 'https://example.com'
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-
-  #   m = Media.new url: url, key: api_key
-  #   id = Media.get_id(m.url)
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m.as_json(archivers: 'perma_cc')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['perma_cc'], cached.keys
-  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
-
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
-
-  #   m.as_json(force: true, archivers: 'perma_cc')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['perma_cc'], cached.keys
-  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-SECOND'}, cached['perma_cc'])
-  # end
-
-  # test "should not archive in any archiver if none is requested" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-    
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp'})
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   id = Media.get_id(url)
-  #   m = create_media url: url, key: api_key
-  #   m.as_json
-  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
-
-  #   m.as_json(archivers: '')
-  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
-
-  #   m.as_json(archivers: nil)
-  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
-
-  #   m.as_json(archivers: 'none')
-  #   assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
-
-  #   m.as_json(archivers: 'archive_org')
-  #   assert_equal({'archive_org' => {"location" => 'https://web.archive.org/web/archive-timestamp/https://example.com/'}}, Pender::Store.current.read(id, :json)[:archives])
-  # end
-
-  # test "should update cache when a new archiver is requested without the need to request for a refresh" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   id = Media.get_id(url)
-  #   m = create_media url: url, key: api_key
-  #   m.as_json(archivers: 'perma_cc')
-  #   assert_equal({'perma_cc' => {"location" => 'http://perma.cc/perma-cc-guid-1'}}, Pender::Store.current.read(id, :json)[:archives])
-
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
-
-  #   m.as_json(archivers: 'perma_cc, archive_org')
-  #   assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
-  # end
-
-  # test "should not archive again if media on cache has both archivers" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://fakewebsite.com/'
-    
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   Media.stubs(:get_available_archive_org_snapshot).returns(nil)
-
-  #   # Our webhook response
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   # A fake website that never redirects us, so that our Media.get_id stays consistent
-  #   WebMock.stub_request(:get, /fakewebsite.com/).to_return(status: 200, body: '')
-
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-
-  #   # First archiver request responses
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
-
-  #   id = Media.get_id(url)
-  #   m = create_media url: url, key: api_key
-  #   m.as_json(archivers: 'perma_cc, archive_org')
-  #   assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
-
-  #   # Second archiver request responses
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-2' })
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp2'})
-
-  #   m.as_json
-  #   assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
-  #   assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
-
-  #   m.as_json(archivers: 'none')
-  #   assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
-  #   assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
-  # end
-
-  # test "return the enabled archivers" do
-  #   enabled_archivers = Media::ENABLED_ARCHIVERS
-  #   Media.const_set(:ENABLED_ARCHIVERS, [{key: 'archive_org'}, {key: 'perma_cc'}])
-
-  #   assert_equal ['archive_org', 'perma_cc'].sort, Media.enabled_archivers(['archive_org', 'perma_cc']).keys
-
-  #   quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, [{key: 'archive_org'}])
-
-  #   assert_equal ['archive_org'].sort, Media.enabled_archivers(['perma_cc', 'archive_org']).keys
-  # ensure
-  #   quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled_archivers)
-  # end
-
-  # test "should archive to perma.cc and store the URL on archives if perma_cc_key is present" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://example.com'
-    
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   m = Media.new url: url, key: api_key
-  #   id = Media.get_id(m.url)
-  #   m.as_json(archivers: 'perma_cc')
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['perma_cc'], cached.keys
-  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
-  # end
-
-  # test "should add disabled Perma.cc archiver error message if perma_key is not defined" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-  #   Media.stubs(:available_archivers).returns(['perma_cc'])
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, "https://example.com/webhook.php").to_return(status: 200, body: '')
-
-  #   m = Media.new url: url, key: api_key
-  #   m.as_json(archivers: 'perma_cc')
-    
-  #   id = Media.get_id(url)
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_match 'missing authentication', cached.dig('perma_cc', 'error', 'message').downcase
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY'), cached.dig('perma_cc', 'error', 'code')
-  # end
-
-  # test "should return api key settings" do
-  #   key1 = create_api_key application_settings: {'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-  #   key2 = create_api_key application_settings: {}
-  #   key3 = create_api_key
-  #   [key1.id, key2.id, key3.id, -1].each do |id|
-  #     assert_nothing_raised do
-  #       Media.api_key_settings(id)
-  #     end
-  #   end
-  # end
-
-  # test "include error on data when cannot use archiver" do
-  #   skip = ENV['archiver_skip_hosts']
-  #   ENV['archiver_skip_hosts'] = 'example.com'
-
-  #   url = 'https://example.com'
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-
-  #   m = Media.new url: url
-  #   m.data = Media.minimal_data(m)
-
-  #   m.archive('archive_org')
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_HOST_SKIPPED'), m.data.dig('archives', 'archive_org', 'error', 'code')
-  #   assert_match 'Host Skipped: example.com', m.data.dig('archives', 'archive_org', 'error', 'message')
-  #   ENV['archiver_skip_hosts'] = ''
-
-  #   PenderConfig.reload
-  #   enabled = Media::ENABLED_ARCHIVERS
-  #   Media.const_set(:ENABLED_ARCHIVERS, [])
-
-  #   m.archive('archive_org,unexistent_archive')
-
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_NOT_FOUND'), m.data.dig('archives', 'unexistent_archive', 'error', 'code')
-  #   assert_match 'Not Found', m.data.dig('archives', 'unexistent_archive', 'error', 'message')
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_DISABLED'), m.data.dig('archives', 'archive_org', 'error', 'code')
-  #   assert_match 'Disabled', m.data.dig('archives', 'archive_org', 'error', 'message')
-  # ensure
-  #   quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled)
-  #   ENV['archiver_skip_hosts'] = skip
-  # end
-
-  # test "should get and return the available snapshot if page was already archived on Archive.org" do
-  #   url = 'https://example.com/'
-  #   api_key = create_api_key_with_webhook
-
-  #   url = 'https://example.com/'
-  #   api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
-  #   encoded_uri = RequestHelper.encode_url(url)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return_json(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}})
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-
-  #   snapshot = Media.get_available_archive_org_snapshot(encoded_uri, api_key)
-  #   assert_equal 'http://web.archive.org/web/20210223111252/http://example.com/' , snapshot[:location]
-  # end
-
-  # test "should return nil if page was not previously archived on Archive.org" do
-  #   url = 'https://example.com/'
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}})
-
-  #   assert_nil Media.get_available_archive_org_snapshot(url, nil)
-  # end
-
-  # test "should still cache data if notifying webhook fails" do
-  #   api_key = create_api_key_with_webhook_for_perma_cc
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_perma_cc)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 425, body: '')
-
-  #   m = Media.new url: url, key: api_key
-  #   id = Media.get_id(m.url)
-  #   assert_raises Pender::Exception::RetryLater do
-  #     m.as_json(archivers: 'perma_cc')
-  #   end
-
-  #   cached = Pender::Store.current.read(id, :json)[:archives]
-  #   assert_equal ['perma_cc'], cached.keys
-  #   assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
-  # end
-
-  # test "when Archive.org status returns 429 Too Many Requests it should notify Sentry with RateLimitExceeded" do
-  #   api_key = create_api_key_with_webhook
-  #   url = 'https://example.com/'
-
-  #   Media.any_instance.unstub(:archive_to_archive_org)
-
-  #   WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
-  #   WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
-  #   WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
-  #   # This response comes from ArchiveStatusJob, in order to call it we need to get a job_id
-  #   WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
-  #   WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
-  #   WebMock.stub_request(:get, /archive.org\/save\/status/).to_return(body:  '429 Too Many Requests')
-
-  #   m = Media.new url: url, key: api_key
-
-  #   sentry_call_count = 0
-  #   arguments_checker = Proc.new do |e|
-  #     sentry_call_count += 1
-  #     assert_instance_of Pender::Exception::RateLimitExceeded, e
-  #     assert_equal '429 Too Many Requests', e.message
-  #   end
-
-  #   PenderSentry.stub(:notify, arguments_checker) do
-  #     assert_nothing_raised do
-  #       m.as_json(archivers: 'archive_org')
-  #     end
-  #   end
-
-  #   assert_equal 1, sentry_call_count
-
-  #   media_data = Pender::Store.current.read(Media.get_id(url), :json)
-  #   expected_error_message = "<html><body><h1>429 Too Many Requests</h1>"
-  #   assert_includes media_data.dig('archives', 'archive_org', 'error', 'message'), expected_error_message
-  #   assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
-  # end
-
-  test "when Archive.org status returns 429 Too Many Requests it should notify Sentry with RateLimitExceeded #2" do
+  # I don't really understand what this test is doing
+  test "should skip screenshots" do
+    stub_configs({'archiver_skip_hosts' => '' })
+
+    api_key = create_api_key
+
+    url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390'
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    m = create_media url: url, key: api_key
+    data = m.as_json
+
+    stub_configs({'archiver_skip_hosts' => 'checkmedia.org' })
+
+    url = 'https://checkmedia.org/caio-screenshots/project/1121/media/8390?hide_tasks=1'
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    m = create_media url: url, key: api_key
+    data = m.as_json
+  end
+
+  test "should archive to Archive.org" do
     api_key = create_api_key_with_webhook
     url = 'https://example.com/'
-    job_id = 'ebb13d31-7fcf-4dce-890c-c256e2823ca0'
 
+    Media.any_instance.unstub(:archive_to_archive_org)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+
+    media = create_media url: url, key: api_key
+    data = media.as_json(archivers: 'archive_org')
+
+    assert_equal "https://web.archive.org/web/timestamp/#{url}", data.dig('archives', 'archive_org', 'location') 
+  end
+
+  test "should log archiver information when archiving URLs" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+    log = StringIO.new
+    Rails.logger = Logger.new(log)
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+  
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+
+    media = create_media url: url, key: api_key
+    media.as_json(archivers: 'archive_org')
+    
+    assert_match '[Archiver] Archiving new URL', log.string
+    assert_match url, log.string
+  end
+  
+  test "should archive Arabics url to Archive.org" do
+    api_key = create_api_key_with_webhook
+    url = 'https://www.yallakora.com/ar/news/342470/%D8%A7%D8%AA%D8%AD%D8%A7%D8%AF-%D8%A7%D9%84%D9%83%D8%B1%D8%A9-%D8%B9%D9%86-%D8%A3%D8%B2%D9%85%D8%A9-%D8%A7%D9%84%D8%B3%D8%B9%D9%8A%D8%AF-%D9%84%D8%A7%D8%A8%D8%AF-%D9%85%D9%86-%D8%AD%D9%84-%D9%85%D8%B9-%D8%A7%D9%84%D8%B2%D9%85%D8%A7%D9%84%D9%83/2504'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>صفحة باللغة العربية</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+
+    assert_nothing_raised do
+      m = create_media url: url, key: api_key
+      m.as_json
+    end
+  end
+
+  test "should archive to Perma.cc" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid' })
+
+    media = create_media url: url, key: api_key
+    data = media.as_json(archivers: 'perma_cc')
+
+    assert_equal "http://perma.cc/perma-cc-guid", data.dig('archives', 'perma_cc', 'location') 
+  end
+
+  test "should update media with error when Archive.org can't archive the url" do
+    api_key = create_api_key_with_webhook
+    urls = {
+      'http://localhost:3333/unreachable-url' => {status_ext: 'error:invalid-url-syntax', message: 'URL syntax is not valid'},
+      'http://www.dutertenewsupdate.info/2018/01/duterte-turned-philippines-into.html' => {status_ext: 'error:invalid-host-resolution', message: 'Cannot resolve host'},
+    }
+
+    Media.any_instance.stubs(:follow_redirections)
+    Media.any_instance.stubs(:get_canonical_url).returns(true)
+    Media.any_instance.stubs(:try_https)
+    Media.any_instance.stubs(:parse)
+    Media.any_instance.stubs(:archive)
+
+    urls.each_pair do |url, data|
+      m = Media.new url: url
+      m.as_json(archivers: 'none')
+      assert_nil m.data.dig('archives', 'archive_org')
+
+      WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+      WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+      WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: { status: 'error', status_ext: data[:status_ext], message: data[:message] })
+      WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: { "archived_snapshots": {} }.to_json, headers: {})
+
+      assert_raises StandardError do
+        Media.send_to_archive_org(url.to_s, api_key.id)
+      end
+      media_data = Pender::Store.current.read(Media.get_id(url), :json)
+      assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+      assert_equal "(#{data[:status_ext]}) #{data[:message]}", media_data.dig('archives', 'archive_org', 'error', 'message')
+      end
+  end
+
+  test "when Archive.org fails with Pender::Exception::ArchiveOrgError it should retry, update data with snapshot (if available) and error" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
+
+    media = create_media url: url, key: api_key
+    assert_raises StandardError do
+      media.as_json(archivers: 'archive_org')
+    end
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal '(500) Random Error.', media_data.dig('archives', 'archive_org', 'error', 'message') 
+    assert_equal "https://web.archive.org/web/timestamp/#{url}", media_data.dig('archives', 'archive_org', 'location') 
+  end
+
+  test "when Archive.org fails with the same snapshot has been made... it should NOT retry, and should notify Sentry" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { message: 'The same snapshot had been made 1 hour, 12 minutes ago. You can make new capture of this URL after 24 hours.', url: url})
+
+    m = Media.new url: url, key: api_key
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
+    end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+    assert_equal 1, sentry_call_count
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
+
+  test "when Archive.org fails with too-many-daily-captures it should NOT retry, and should notify Sentry" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status_ext: 'error:too-many-daily-captures', message: 'This URL has been already captured 7 times today, which is a daily limit we have set for that Resource type. Please try again tomorrow. Please email us at "info@archive.org" if you would like to discuss this more.', url: url})
+
+    m = Media.new url: url, key: api_key
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
+    end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+    assert_equal 1, sentry_call_count
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
+
+  test "when Archive.org fails with blocked-url it should NOT retry, and should notify Sentry" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 200, body: { status: 'error', status_ext: 'error:blocked-url', message: 'This URL is in the Save Page Now service block list and cannot be captured.', url: url })
+
+    m = Media.new url: url, key: api_key
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
+    end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+    assert_equal 1, sentry_call_count
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
+
+  test "when Archive.org fails to make/complete a request it should retry and update data with error" do
+    api_key = create_api_key_with_webhook
+    url = 'https://meedan.com/post/annual-report-2022'
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:any, /archive.org/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m = create_media url: url, key: api_key
+    assert_raises StandardError do
+      data = m.as_json(archivers: 'archive_org')
+      assert_nil data.dig('archives', 'archive_org')
+    end
+
+    data = m.as_json
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'archive_org', 'error', 'code')
+    assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'archive_org', 'error', 'message')
+  end
+
+  test "when Perma.cc fails with Pender::Exception::PermaCcError it should update media with error and retry" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://example.com'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "A random error." }.to_json)
+
+    m = Media.new url: url, key: api_key
+    assert_raises StandardError do
+      m.as_json(archivers: 'perma_cc')
+    end
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
+    assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
+  end
+
+  test "when Perma.cc fails with Pender::Exception::TooManyCaptures it should update media with error and not retry" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://example.com'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return(status: [400, 'Bad Request'], body: { 'error': "Perma can't create this link. You've reached your usage limit. Visit your Usage Plan page for information and plan options." }.to_json)
+
+    m = Media.new url: url, key: api_key
+    assert_nothing_raised do
+      m.as_json(archivers: 'perma_cc')
+    end
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'perma_cc', 'error', 'code')
+    assert_equal '(400) Bad Request', media_data.dig('archives', 'perma_cc', 'error', 'message')
+  end
+
+  test "when Perma.cc fails to make/complete a request it should retry and update data with error" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://meedan.com/post/annual-report-2022'
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /api.perma.cc/).to_raise(Net::ReadTimeout.new('Exception from WebMock'))
+
+    m = create_media url: url, key: api_key
+    assert_raises StandardError do
+      data = m.as_json(archivers: 'perma_cc')
+      assert_nil data.dig('archives', 'perma_cc')
+    end
+
+    data = m.as_json
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), data.dig('archives', 'perma_cc', 'error', 'code')
+    assert_equal 'Net::ReadTimeout with "Exception from WebMock"', data.dig('archives', 'perma_cc', 'error', 'message')
+  end
+
+  test "should update media with error when archive to Archive.org hits the limit of retries" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.stubs(:get_available_archive_org_snapshot).returns({ location: "https://web.archive.org/web/timestamp/#{url}" })
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(status: 500, body: { status_ext: '500', message: 'Random Error.', url: url})
+
+    media = Media.new url: url, key: api_key
+    assert_raises StandardError do
+      media.as_json(archivers: 'archive_org')
+    end
+    Media.give_up({ args: [url, 'archive_org', api_key], error_message: 'Gave Up', error_class: 'error class'})
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_FAILURE'), media_data.dig('archives', 'archive_org', 'error', 'code')
+    assert_equal "Gave Up", media_data.dig('archives', 'archive_org', 'error', 'message')
+  end
+
+  test "if a refresh is not requested and archive is present in cache should not archive on Archive.org" do
+    url = 'https://example.com/'
+    api_key = create_api_key_with_webhook
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+
+    m = Media.new url: url, key: api_key
+    id = Media.get_id(m.url)
+
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m.as_json(archivers: 'archive_org')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['archive_org'], cached.keys
+    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
+
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m.as_json(archivers: 'archive_org')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['archive_org'], cached.keys
+    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
+  end
+
+  test "if a refresh is requested it should try to archive on Archive.org" do
+    url = 'https://example.com/'
+    api_key = create_api_key_with_webhook
+    
+    Media.any_instance.unstub(:archive_to_archive_org)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+
+    m = Media.new url: url, key: api_key
+    id = Media.get_id(m.url)
+
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-FIRST'})
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m.as_json(archivers: 'archive_org')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['archive_org'], cached.keys
+    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-FIRST/https://example.com/'}, cached['archive_org'])
+
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp-SECOND'})
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m.as_json(force: true, archivers: 'archive_org')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['archive_org'], cached.keys
+    assert_equal({ 'location' => 'https://web.archive.org/web/archive-timestamp-SECOND/https://example.com/'}, cached['archive_org'])
+  end
+
+  test "if a refresh is not requested and archive is present in cache it should not try to archive on Perma.cc" do
+    url = 'https://example.com'
+    api_key = create_api_key_with_webhook_for_perma_cc
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+
+    m = Media.new url: url, key: api_key
+    id = Media.get_id(m.url)
+
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m.as_json(archivers: 'perma_cc')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['perma_cc'], cached.keys
+    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
+
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
+
+    m.as_json(archivers: 'perma_cc')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['perma_cc'], cached.keys
+    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
+  end
+
+  test "if a refresh is requested it should try to create a new archive on Perma.cc" do
+    url = 'https://example.com'
+    api_key = create_api_key_with_webhook_for_perma_cc
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+
+    m = Media.new url: url, key: api_key
+    id = Media.get_id(m.url)
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-FIRST' })
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m.as_json(archivers: 'perma_cc')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['perma_cc'], cached.keys
+    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-FIRST'}, cached['perma_cc'])
+
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-SECOND' })
+
+    m.as_json(force: true, archivers: 'perma_cc')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['perma_cc'], cached.keys
+    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-SECOND'}, cached['perma_cc'])
+  end
+
+  test "should not archive in any archiver if none is requested" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+    
+    Media.any_instance.unstub(:archive_to_archive_org)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: 'archive_org/first_archiving', job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'archive-timestamp'})
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    id = Media.get_id(url)
+    m = create_media url: url, key: api_key
+    m.as_json
+    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+
+    m.as_json(archivers: '')
+    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+
+    m.as_json(archivers: nil)
+    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+
+    m.as_json(archivers: 'none')
+    assert_equal({}, Pender::Store.current.read(id, :json)[:archives])
+
+    m.as_json(archivers: 'archive_org')
+    assert_equal({'archive_org' => {"location" => 'https://web.archive.org/web/archive-timestamp/https://example.com/'}}, Pender::Store.current.read(id, :json)[:archives])
+  end
+
+  test "should update cache when a new archiver is requested without the need to request for a refresh" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    Media.any_instance.unstub(:archive_to_archive_org)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    id = Media.get_id(url)
+    m = create_media url: url, key: api_key
+    m.as_json(archivers: 'perma_cc')
+    assert_equal({'perma_cc' => {"location" => 'http://perma.cc/perma-cc-guid-1'}}, Pender::Store.current.read(id, :json)[:archives])
+
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return(body: {"archived_snapshots":{}}.to_json, headers: {})
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+
+    m.as_json(archivers: 'perma_cc, archive_org')
+    assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
+  end
+
+  test "should not archive again if media on cache has both archivers" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://fakewebsite.com/'
+    
+    Media.any_instance.unstub(:archive_to_archive_org)
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    Media.stubs(:get_available_archive_org_snapshot).returns(nil)
+
+    # Our webhook response
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    # A fake website that never redirects us, so that our Media.get_id stays consistent
+    WebMock.stub_request(:get, /fakewebsite.com/).to_return(status: 200, body: '')
+
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+
+    # First archiver request responses
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp'})
+
+    id = Media.get_id(url)
+    m = create_media url: url, key: api_key
+    m.as_json(archivers: 'perma_cc, archive_org')
+    assert_equal({'perma_cc' => {'location' => 'http://perma.cc/perma-cc-guid-1'}, 'archive_org' => {'location' => "https://web.archive.org/web/timestamp/#{url}" }}, Pender::Store.current.read(id, :json)[:archives])
+
+    # Second archiver request responses
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-2' })
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /web.archive.org\/save\/status/).to_return_json(body: {status: 'success', timestamp: 'timestamp2'})
+
+    m.as_json
+    assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
+    assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
+
+    m.as_json(archivers: 'none')
+    assert_equal({'location' => 'http://perma.cc/perma-cc-guid-1'}, Pender::Store.current.read(id, :json)[:archives][:perma_cc])
+    assert_equal({'location' => "https://web.archive.org/web/timestamp/#{url}" }, Pender::Store.current.read(id, :json)[:archives][:archive_org])
+  end
+
+  test "return the enabled archivers" do
+    enabled_archivers = Media::ENABLED_ARCHIVERS
+    Media.const_set(:ENABLED_ARCHIVERS, [{key: 'archive_org'}, {key: 'perma_cc'}])
+
+    assert_equal ['archive_org', 'perma_cc'].sort, Media.enabled_archivers(['archive_org', 'perma_cc']).keys
+
+    quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, [{key: 'archive_org'}])
+
+    assert_equal ['archive_org'].sort, Media.enabled_archivers(['perma_cc', 'archive_org']).keys
+  ensure
+    quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled_archivers)
+  end
+
+  test "should archive to perma.cc and store the URL on archives if perma_cc_key is present" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://example.com'
+    
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    m = Media.new url: url, key: api_key
+    id = Media.get_id(m.url)
+    m.as_json(archivers: 'perma_cc')
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['perma_cc'], cached.keys
+    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
+  end
+
+  test "should add disabled Perma.cc archiver error message if perma_key is not defined" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+    Media.stubs(:available_archivers).returns(['perma_cc'])
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, "https://example.com/webhook.php").to_return(status: 200, body: '')
+
+    m = Media.new url: url, key: api_key
+    m.as_json(archivers: 'perma_cc')
+    
+    id = Media.get_id(url)
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_match 'missing authentication', cached.dig('perma_cc', 'error', 'message').downcase
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_MISSING_KEY'), cached.dig('perma_cc', 'error', 'code')
+  end
+
+  test "should return api key settings" do
+    key1 = create_api_key application_settings: {'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    key2 = create_api_key application_settings: {}
+    key3 = create_api_key
+    [key1.id, key2.id, key3.id, -1].each do |id|
+      assert_nothing_raised do
+        Media.api_key_settings(id)
+      end
+    end
+  end
+
+  test "include error on data when cannot use archiver" do
+    skip = ENV['archiver_skip_hosts']
+    ENV['archiver_skip_hosts'] = 'example.com'
+
+    url = 'https://example.com'
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+
+    m = Media.new url: url
+    m.data = Media.minimal_data(m)
+
+    m.archive('archive_org')
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_HOST_SKIPPED'), m.data.dig('archives', 'archive_org', 'error', 'code')
+    assert_match 'Host Skipped: example.com', m.data.dig('archives', 'archive_org', 'error', 'message')
+    ENV['archiver_skip_hosts'] = ''
+
+    PenderConfig.reload
+    enabled = Media::ENABLED_ARCHIVERS
+    Media.const_set(:ENABLED_ARCHIVERS, [])
+
+    m.archive('archive_org,unexistent_archive')
+
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_NOT_FOUND'), m.data.dig('archives', 'unexistent_archive', 'error', 'code')
+    assert_match 'Not Found', m.data.dig('archives', 'unexistent_archive', 'error', 'message')
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_DISABLED'), m.data.dig('archives', 'archive_org', 'error', 'code')
+    assert_match 'Disabled', m.data.dig('archives', 'archive_org', 'error', 'message')
+  ensure
+    quietly_redefine_constant(Media, :ENABLED_ARCHIVERS, enabled)
+    ENV['archiver_skip_hosts'] = skip
+  end
+
+  test "should get and return the available snapshot if page was already archived on Archive.org" do
+    url = 'https://example.com/'
+    api_key = create_api_key_with_webhook
+
+    url = 'https://example.com/'
+    api_key = create_api_key application_settings: { 'webhook_url': 'https://example.com/webhook.php', 'webhook_token': 'test' }
+    encoded_uri = RequestHelper.encode_url(url)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:get, /archive.org\/wayback\/available?.+url=#{url}/).to_return_json(body: {"archived_snapshots":{ closest: { available: true, url: 'http://web.archive.org/web/20210223111252/http://example.com/' }}})
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+
+    snapshot = Media.get_available_archive_org_snapshot(encoded_uri, api_key)
+    assert_equal 'http://web.archive.org/web/20210223111252/http://example.com/' , snapshot[:location]
+  end
+
+  test "should return nil if page was not previously archived on Archive.org" do
+    url = 'https://example.com/'
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}})
+
+    assert_nil Media.get_available_archive_org_snapshot(url, nil)
+  end
+
+  test "should still cache data if notifying webhook fails" do
+    api_key = create_api_key_with_webhook_for_perma_cc
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_perma_cc)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A Page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /api.perma.cc/).to_return_json(body: { guid: 'perma-cc-guid-1' })
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 425, body: '')
+
+    m = Media.new url: url, key: api_key
+    id = Media.get_id(m.url)
+    assert_raises Pender::Exception::RetryLater do
+      m.as_json(archivers: 'perma_cc')
+    end
+
+    cached = Pender::Store.current.read(id, :json)[:archives]
+    assert_equal ['perma_cc'], cached.keys
+    assert_equal({ 'location' => 'http://perma.cc/perma-cc-guid-1'}, cached['perma_cc'])
+  end
+
+  test "when Archive.org status returns 429 Too Many Requests it should notify Sentry with RateLimitExceeded" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    # This response comes from ArchiveStatusJob, in order to call it we need to get a job_id
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: {url: url, job_id: 'ebb13d31-7fcf-4dce-890c-c256e2823ca0' })
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
     WebMock.stub_request(:get, /archive.org\/save\/status/).to_return(body:  '429 Too Many Requests')
+
+    m = Media.new url: url, key: api_key
 
     sentry_call_count = 0
     arguments_checker = Proc.new do |e|
       sentry_call_count += 1
       assert_instance_of Pender::Exception::RateLimitExceeded, e
-      assert_equal '429 Too Many Requests', e.message
+      assert_equal e.message, '429 Too Many Requests'
     end
 
     PenderSentry.stub(:notify, arguments_checker) do
       assert_nothing_raised do
-        Media.get_archive_org_status(job_id, url, api_key)
+        m.as_json(archivers: 'archive_org')
       end
     end
 
     assert_equal 1, sentry_call_count
-  end  
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    expected_error_message = "Too Many Requests"
+    assert_includes media_data.dig('archives', 'archive_org', 'error', 'message'), expected_error_message
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
+
+  test "when Archive.org returns HTML response it should notify Sentry with JSON::ParserError" do
+    api_key = create_api_key_with_webhook
+    url = 'https://example.com/'
+
+    Media.any_instance.unstub(:archive_to_archive_org)
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: '<html>A page</html>')
+    WebMock.stub_request(:post, /safebrowsing\.googleapis\.com/).to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, /example.com\/webhook/).to_return(status: 200, body: '')
+    WebMock.stub_request(:post, /web.archive.org\/save/).to_return_json(body: 'Item Not Avaiable' )
+    WebMock.stub_request(:get, /archive.org\/wayback/).to_return_json(body: {"archived_snapshots":{}}, headers: {})
+
+    m = Media.new url: url, key: api_key
+
+    sentry_call_count = 0
+    arguments_checker = Proc.new do |e|
+      sentry_call_count += 1
+      assert_instance_of JSON::ParserError, e
+      assert_includes e.message, 'Item Not Avaiable'
+    end
+
+    PenderSentry.stub(:notify, arguments_checker) do
+      assert_nothing_raised do
+        m.as_json(archivers: 'archive_org')
+      end
+    end
+
+    assert_equal 1, sentry_call_count
+
+    media_data = Pender::Store.current.read(Media.get_id(url), :json)
+    expected_error_message = "Item Not Avaiable"
+    assert_includes media_data.dig('archives', 'archive_org', 'error', 'message'), expected_error_message
+    assert_equal Lapis::ErrorCodes::const_get('ARCHIVER_ERROR'), media_data.dig('archives', 'archive_org', 'error', 'code')
+  end
 end


### PR DESCRIPTION
## Description

### Context
- Sometimes ArchiveOrg will send a HTML response: 
    - which are usually issues on their side like: “429 Too Many Requests” and “Item Not Avaiable”, 
    - but also caused an error on our side, since we always expected a JSON.
- We have two jobs that run for ArchiveOrg, both make requests, so this happens at different places/time, but need very similar error handling.
- We also wanted to take this opportunity to try to centralize more our error handling.

### How 
- Handling HTML errors
   - I extracted a method `json_parse` we can use for our both requests. It rescues JSON::ParserError, and re-raises it as a more specific error or as itself.
   - Then `handle_archiving_exceptions` deals with it.
- Other errors
   - To make this more cohesive, I updated this to have the same behavior as when we are dealing with HTML errors,
   - so we also re-raise the errors and `handle_archiving_exceptions` deals with it.
- On `handle_archiving_exceptions`:
    - We had been dealing with ArchiveOrg errors directly in its module, but even if they are more ArchiveOrg related, I think it makes sense to centralize everything in `handle_archiving_exceptions`.
- I did some work before where we moved error handling inside `get_archive_org_status`
   - https://github.com/meedan/pender/commit/28941ecd6bbe20be1b9a794a4f219aa8963d45c7
   - I think this might not be needed,
   - but even if it is, I think it might make more sense for us to wrap this job with `handle_archiving_exceptions`?
   - It would be easier for us to avoid duplication.

References: CV2-4482

## How has this been tested?

`bin/rails test test/models/archiver_test.rb`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

