### PR TITLE
6357 – Fix how we parse a generic Facebook watch page

### DIFF
--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -11,7 +11,7 @@ module ProviderFacebook
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/login/, reason: :login_page },
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/?$/, reason: :login_page },
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/cookie\/consent-page/, reason: :consent_page },
-        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/watch/, reason: :watch_page }
+        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/watch\/*?$/, reason: :watch_page }
       ]
     end
 

--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -10,7 +10,8 @@ module ProviderFacebook
       [
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/login/, reason: :login_page },
         { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/?$/, reason: :login_page },
-        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/cookie\/consent-page/, reason: :consent_page }
+        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/cookie\/consent-page/, reason: :consent_page },
+        { pattern: /^https:\/\/([^\.]+\.)?facebook.com\/watch/, reason: :watch_page }
       ]
     end
 

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -564,4 +564,25 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should return url as the title and empty description when directed to main watch page" do
+    # and I guess the original url as url as well
+    url = 'https://www.facebook.com/watch/?v=687311417207347'
+
+    WebMock.stub_request(:post, /api\.apify\.com\/v2\/acts\/apify/).to_return(status: 200, body: apify_error_response)
+
+    doc = Nokogiri::HTML(<<~HTML)
+      <meta property="og:title" content="Discover Popular Videos" />
+      <meta property="og:description" content="Video is the place to enjoy videos and shows together. Watch the latest reels, discover original shows and catch up with your favorite creators." />
+    HTML
+
+    WebMock.stub_request(:get, url).to_return(status: 200, body: doc.to_s)
+
+    parser = Parser::FacebookItem.new(url)
+    data = parser.parse_data(doc, url)
+
+    p data
+    assert_equal data[:title], url
+    assert_empty data[:description]
+  end
 end


### PR DESCRIPTION
## Description

A facebook video from facebook watch was sometimes redirecting to the main watch page. Meaning we were getting pretty generic content, like:
- url: `https://www.facebook.com/watch/`
- title: `"Discover Popular Videos"`

This caused `This item already exists` to be raised for different items. So, if an url redirects to the main watch page, we want the title and url to be the url from the request.

References: 6357

## How has this been tested?

```ruby
# "should return url as the title and empty description when directed to main watch page"
rails test test/models/parser/facebook_item_test.rb:568

# "should return title and description when directed to a watch item"
rails test test/models/parser/facebook_item_test.rb:568
```

## Something to think about

I think we might want to change `set_facebook_privacy_error` method name and its error message, or at least the error message. 

https://github.com/meedan/pender/blob/903c7f244c8f5cec748c4c92f11f68ec37fa0c10/app/models/concerns/provider_facebook.rb#L84-L103

### Why?
Because this method doesn't only set the privacy error, but it checks if a page is unavailable, and then sets the error. The reason why a page is unavailable isn't always because of a `privacy_error` or `login_required`. Right now, we have two situations, consent page and watch page, where a page is unavailable because we were redirected to a dead end.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

