### PR TITLE
5999 – Add timeout to apify request

### DIFF
--- a/app/models/concerns/media_apify_item.rb
+++ b/app/models/concerns/media_apify_item.rb
@@ -57,6 +57,7 @@ module MediaApifyItem
     def self.make_apify_request(apify_url, payload)
       uri = URI.parse(apify_url)
       http = Net::HTTP.new(uri.host, uri.port)
+      http.read_timeout = PenderConfig.get('timeout', 30).to_i
       http.use_ssl = true
       headers = { 'content-type' => 'application/json' }
       request = Net::HTTP::Post.new(uri.request_uri, headers)

--- a/app/models/concerns/provider_facebook.rb
+++ b/app/models/concerns/provider_facebook.rb
@@ -49,7 +49,6 @@ module ProviderFacebook
       return { error: { message: apify_data.first['errorDescription'], code: Lapis::ErrorCodes::const_get('UNKNOWN') }}
     end
 
-
     apify_data.is_a?(Array) ? apify_data.first : apify_data
   end
 


### PR DESCRIPTION
## Description

We have been running into some Gateway time-out and Net::ReadTimeout errors, in QA and Live, that seem connected to the apify request. So we are adding read_timeout to the request.

References: CV2-5999

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

