### PR TITLE
Use SSH agent for GitLab sync CV2-6368

### DIFF
--- a/.github/workflows/gitlab-mirror.yml
+++ b/.github/workflows/gitlab-mirror.yml
@@ -12,8 +12,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - uses: webfactory/ssh-agent@v0.9.0
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
     - uses: wangchucheng/git-repo-sync@v0.1.0
       with:
         target-url: https://gitlab.com/meedan/pender.git/
         target-username: sonoransun
-        target-token: ${{ secrets.GITLAB_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

Use SSH Agent during Workflow sync process.

References: https://meedan.atlassian.net/browse/CV2-6368

## Checklist

- [X] I have performed a self-review of my own code
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
