### PR TITLE
6414 – The failed parsing of author_picture or picture urls should not stop the creation of an item

### DIFF
--- a/app/helpers/medias_helper.rb
+++ b/app/helpers/medias_helper.rb
@@ -126,7 +126,10 @@ module MediasHelper
     [:author_picture, :picture].each do |attr|
       img_url = self.data.dig(attr)
       next if img_url.blank?
-      parsed_url = RequestHelper.parse_url(img_url)
+
+      parsed_url = RequestHelper.parse_nonmandatory_url(img_url)
+      next if parsed_url.nil?
+
       if upload_image(id, attr, parsed_url)
         updates[attr] = self.data[attr]
       end

--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -78,6 +78,15 @@ class RequestHelper
       end
     end
 
+    def parse_nonmandatory_url(url)
+      begin
+        parse_url(url)
+      rescue RequestHelper::UrlFormatError => e
+        Rails.logger.warn level: 'WARN', message: "[RequestHelper] Could not parse url: '#{url}'. Error: #{e.class} - #{e.message}"
+        nil
+      end
+    end
+
     def extended_headers(uri = nil)
       uri = self.parse_url(self.decode_uri(uri)) if uri.is_a?(String)
       ({

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -639,4 +639,14 @@ class MediaUnitTest < ActiveSupport::TestCase
     assert_not_includes media.url, 'igsh'
     assert_equal media.url, 'https://www.instagram.com/p/xyz?param1=value1&param2=value2'
   end
+
+  test 'invalid image URL should not stop an item from being parsed' do
+    WebMock.stub_request(:get, /example.com/).and_return(status: 200, body: 'fake response body')
+    Parser::PageItem.any_instance.stubs(:parse_data).returns({ picture: 'http://{image}' })
+
+    m = create_media url: 'http://www.example.com'
+    assert_nothing_raised do
+      m.as_json force: true
+    end
+  end
 end


### PR DESCRIPTION
## Description

If the author or author_picture urls are invalid, we should not stop the
item from being parsed.

I thought the best way to handle this was to create a new method
`parse_nonmandatory_url` in the `RequestHelper` module. This
way, we can safely attempt to parse URLs that might not be critical
to the media item.

It is only a wrapper around the existing `parse_url` method, so if there
are changes to parsing itself, we should only need to update
`parse_url`.

References: CV2-6414

## How has this been tested?

```ruby
rails test test/models/media_test.rb:643
```

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

