### PR TITLE
5814 – fix apify sentry notification

### DIFF
--- a/app/models/concerns/media_apify_item.rb
+++ b/app/models/concerns/media_apify_item.rb
@@ -69,10 +69,10 @@ module MediaApifyItem
     def self.handle_response(response, apify_url)
       Rails.logger.info level: 'INFO', message: '[Parser] Initiated scraping job on Apify', url: apify_url
 
+      parsed_response = JSON.parse(response.body)
       raise ApifyResponseError if response.nil? || !['200', '201'].include?(response.code) || response.body.blank?
       raise ApifyResponseError if response.body.include?("This content isn't available")
 
-      parsed_response = JSON.parse(response.body)
       parsed_response
     rescue ApifyResponseError, JSON::ParserError => error
       handle_apify_error(error, apify_url, parsed_response)

--- a/app/models/concerns/media_apify_item.rb
+++ b/app/models/concerns/media_apify_item.rb
@@ -69,7 +69,7 @@ module MediaApifyItem
     def self.handle_response(response, apify_url)
       Rails.logger.info level: 'INFO', message: '[Parser] Initiated scraping job on Apify', url: apify_url
 
-      parsed_response = JSON.parse(response.body)
+      parsed_response = JSON.parse(response.body) unless response.nil?
       raise ApifyResponseError if response.nil? || !['200', '201'].include?(response.code) || response.body.blank?
       raise ApifyResponseError if response.body.include?("This content isn't available")
 
@@ -88,14 +88,27 @@ module MediaApifyItem
 
     def self.handle_apify_error(error, apify_url, parsed_response)
       apify_url = URI.parse(apify_url).path
+      apify_response_url, apify_response_error, apify_response_error_description = parsed_apify_response(parsed_response)
 
       PenderSentry.notify(
         ApifyError.new(error),
         apify_url: apify_url,
         error_message: error.message,
-        apify_response: parsed_response
+        apify_response_url: apify_response_url,
+        apify_response_error: apify_response_error,
+        apify_response_error_description: apify_response_error_description,
       )
       Rails.logger.warn level: 'WARN', message: '[Parser] Could not process Apify request', apify_url: apify_url, error_class: error.class
+    end
+
+    def self.parsed_apify_response(parsed_response)
+      apify_response = parsed_response.nil? ? {} : parsed_response.first
+
+      apify_response_url = apify_response['url'].presence
+      apify_response_error = apify_response['error'].presence
+      apify_response_error_description = apify_response['errorDescription'].presence
+
+      [apify_response_url, apify_response_error, apify_response_error_description]
     end
   end
 end


### PR DESCRIPTION
## Description

We need to set the parsed_response variable before raising `ApifyResponseError`. 
I'm also parsing the Apify response, so we can have a better formatting for the data in Sentry.

References: CV2-5814

## How has this been tested?

```ruby
bin/rails test test/models/parser/facebook_item_test.rb
bin/rails test test/models/parser/instagram_item_test.rb
```

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

