### PR TITLE
handle_apify_error method should not fail when the parsed_response is a hash

### DIFF
--- a/app/models/concerns/media_apify_item.rb
+++ b/app/models/concerns/media_apify_item.rb
@@ -102,7 +102,15 @@ module MediaApifyItem
     end
 
     def self.parsed_apify_response(parsed_response)
-      apify_response = parsed_response.nil? ? {} : parsed_response.first
+        apify_response =
+          case parsed_response
+          when Array
+            parsed_response.first || {}
+          when Hash
+            parsed_response
+          else
+            {}
+          end
 
       apify_response_url = apify_response['url'].presence
       apify_response_error = apify_response['error'].presence

--- a/test/models/media_apify_item_test.rb
+++ b/test/models/media_apify_item_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class MediaApifyItemTest < ActiveSupport::TestCase
+  def setup
+    @error = StandardError.new('Something went wrong')
+    @apify_url = 'https://api.apify.com/v2/acts/apify~facebook-posts-scraper'
+  end
+
+  test '.handle_apify_error works with array parsed_response' do
+    parsed_response = [{ 'url' => 'https://example.com', 'error' => 'error', 'errorDescription' => 'desc' }]
+    PenderSentry.stub :notify, true do
+      Rails.logger.stub :warn, true do
+        assert_nothing_raised do
+          Media.handle_apify_error(@error, @apify_url, parsed_response)
+        end
+      end
+    end
+  end
+
+  test '.handle_apify_error works with nil parsed_response' do
+    parsed_response = nil
+    PenderSentry.stub :notify, true do
+      Rails.logger.stub :warn, true do
+        assert_nothing_raised do
+          Media.handle_apify_error(@error, @apify_url, parsed_response)
+        end
+      end
+    end
+  end
+
+  test '.handle_apify_error fails with hash parsed_response' do
+    parsed_response = { 'url' => 'https://example.com', 'error' => 'error', 'errorDescription' => 'desc' }
+    PenderSentry.stub :notify, true do
+      Rails.logger.stub :warn, true do
+        assert_nothing_raised do
+          Media.handle_apify_error(@error, @apify_url, parsed_response)
+        end
+      end
+    end
+  end
+end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -602,26 +602,4 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
     assert_equal 'this is a page title', data['title']
     assert_equal 'this is the page description', data['description']
   end
-
-  test "event URL: sets fallbacks from metatags for event when apify response is a hash" do
-    hash_response = <<~JSON
-      {
-        "url": "https://www.facebook.com/123456789/posts/123456789",
-        "error": "not_available",
-        "errorDescription": "This content isn't available because the owner only shared it with a small group of people or changed who can see it, or it's been deleted."
-      }
-    JSON
-
-    WebMock.stub_request(:post, /api\.apify\.com\/v2\/acts\/apify/).to_return(status: 200, body: hash_response)
-
-    doc = Nokogiri::HTML(<<~HTML)
-      <meta property="og:title" content="this is a page title | Facebook" />
-      <meta property="og:description" content="this is the page description" />
-      <meta property="og:image" content="https://example.com/image" />
-    HTML
-
-    data = Parser::FacebookItem.new('https://www.facebook.com/events/331430157280289').parse_data(doc, throwaway_url)
-    assert_equal 'this is a page title', data['title']
-    assert_equal 'this is the page description', data['description']
-  end
 end

--- a/test/models/parser/facebook_item_test.rb
+++ b/test/models/parser/facebook_item_test.rb
@@ -602,4 +602,26 @@ class FacebookItemUnitTest < ActiveSupport::TestCase
     assert_equal 'this is a page title', data['title']
     assert_equal 'this is the page description', data['description']
   end
+
+  test "event URL: sets fallbacks from metatags for event when apify response is a hash" do
+    hash_response = <<~JSON
+      {
+        "url": "https://www.facebook.com/123456789/posts/123456789",
+        "error": "not_available",
+        "errorDescription": "This content isn't available because the owner only shared it with a small group of people or changed who can see it, or it's been deleted."
+      }
+    JSON
+
+    WebMock.stub_request(:post, /api\.apify\.com\/v2\/acts\/apify/).to_return(status: 200, body: hash_response)
+
+    doc = Nokogiri::HTML(<<~HTML)
+      <meta property="og:title" content="this is a page title | Facebook" />
+      <meta property="og:description" content="this is the page description" />
+      <meta property="og:image" content="https://example.com/image" />
+    HTML
+
+    data = Parser::FacebookItem.new('https://www.facebook.com/events/331430157280289').parse_data(doc, throwaway_url)
+    assert_equal 'this is a page title', data['title']
+    assert_equal 'this is the page description', data['description']
+  end
 end


### PR DESCRIPTION
## Description

Most of the time, it seems the Apify response is an array with a hash,
but sometimes it can be a hash. Which was causing a TypeError. E.g.:

`a = {a: 1}.first` returns `[:a, 1]`
`a[:a]` returns `no implicit conversion of Symbol into Integer (TypeError)`

References: CV2-6460

## How has this been tested?

```
rails test test/models/media_apify_item_test.rb
```

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

