### PR TITLE
6210 – Remove OpenUriRedirections gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'yt', '~> 0.25.5'
 gem 'rswag-api'
 gem 'rswag-ui'
 gem 'sass-rails'
-gem 'open_uri_redirections', require: false
 gem 'postrank-uri', git: 'https://github.com/postrank-labs/postrank-uri.git', ref: '485ac46', require: false # Ruby 3.0 support, as of 2/6/23 no gem relaease
 gem 'retryable'
 gem 'puma', '5.6.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
-    open_uri_redirections (0.2.1)
     opentelemetry-api (1.4.0)
     opentelemetry-common (0.21.0)
       opentelemetry-api (~> 1.0)
@@ -547,7 +546,6 @@ DEPENDENCIES
   net-http
   net-protocol
   nokogiri (= 1.18.9)
-  open_uri_redirections
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-action_pack
   opentelemetry-instrumentation-action_view

--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -189,7 +189,7 @@ class RequestHelper
     end
 
     def redirect_https_to_http?(header_options, message)
-      message.match?('redirection forbidden') && header_options[:allow_redirections] != :all
+      message.match?('redirection forbidden')
     end
 
     def proxy_format(proxy, format = :array)

--- a/app/models/concerns/request_helper.rb
+++ b/app/models/concerns/request_helper.rb
@@ -13,7 +13,7 @@ class RequestHelper
         proxy = self.get_proxy(uri, :array, force_proxy)
         options = proxy ? { proxy_http_basic_authentication: proxy, 'Accept-Language' => LANG } : header_options
         html = ''.freeze
-        OpenURI.open_uri(uri, options.merge(read_timeout: PenderConfig.get('timeout', 30).to_i)) do |f|
+        URI.open(uri, options.merge(read_timeout: PenderConfig.get('timeout', 30).to_i)) do |f|
           f.binmode
           html = f.read
         end
@@ -57,7 +57,7 @@ class RequestHelper
 
     def html_options(url)
       uri = url.is_a?(String) ? self.parse_url(url) : url
-      uri.host.match?(/twitter\.com/) ? self.extended_headers(url) : { allow_redirections: :safe, proxy: nil, 'User-Agent' => 'Mozilla/5.0 (X11)', 'Accept' => '*/*', 'Accept-Language' => LANG, 'Cookie' => self.set_cookies(uri) }.merge(self.get_cf_credentials(uri))
+      uri.host.match?(/twitter\.com/) ? self.extended_headers(url) : { proxy: nil, 'User-Agent' => 'Mozilla/5.0 (X11)', 'Accept' => '*/*', 'Accept-Language' => LANG, 'Cookie' => self.set_cookies(uri) }.merge(self.get_cf_credentials(uri))
     end
 
     def encode_url(url)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -41,7 +41,6 @@
 #    2. If the page has an oEmbed url, request it and get the response
 #    2. If the page doesn't have an oEmbed url, generate the oEmbed info based on the media json data
 
-require 'open_uri_redirections'
 require 'nokogiri'
 
 class Media

--- a/app/models/parser/page_item.rb
+++ b/app/models/parser/page_item.rb
@@ -6,17 +6,17 @@ module Parser
       def type
         'page_item'.freeze
       end
-  
+
       def patterns
         [/^.*$/]
       end
     end
-    
+
     private
 
     # Main function for class
     def parse_data_for_parser(doc, original_url, _jsonld_array)
-      doc = refetch_html(url, {allow_redirections: :all}) if doc.nil?
+      doc = refetch_html(url) if doc.nil?
 
       handle_exceptions(StandardError) do
         raise HtmlFetchingError.new("Could not parse this media") if doc.blank?

--- a/test/models/parser/page_item_test.rb
+++ b/test/models/parser/page_item_test.rb
@@ -35,7 +35,7 @@ class PageItemUnitTest < ActiveSupport::TestCase
 
   test "re-fetches HTML and re-sets metatags, following all redirects, if doc is empty" do
     url = 'https://example.com'
-    RequestHelper.stubs(:get_html).with(url, kind_of(Method), {allow_redirections: :all}, false).returns(Nokogiri::HTML('<meta name="description" content="hello" />'))
+    RequestHelper.stubs(:get_html).with(url, kind_of(Method), false).returns(Nokogiri::HTML('<meta name="description" content="hello" />'))
 
     data = Parser::PageItem.new('https://example.com').parse_data(nil, 'https://example.com/original')
     assert_equal data.dig('raw', 'metatags').size, 1


### PR DESCRIPTION
- **Update to use URI.open instead of OpenURI.open_uri**
- **Remove open_uri_redirections**
- **remove syntax related to open_uri_redirections gem**

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context – why has this been changed/fixed.

References: TICKET-ID, TICKET-ID, …

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

