### PR TITLE
6489 – Deal with successful Apify response for a restricted page

### DIFF
--- a/app/models/parser/instagram_item.rb
+++ b/app/models/parser/instagram_item.rb
@@ -31,10 +31,10 @@ module Parser
         if apify_data
           @parsed_data['raw']['apify'] = apify_data[0]
 
-          set_data_field('title', @parsed_data['raw']['apify']['caption'])
-          set_data_field('description', @parsed_data['raw']['apify']['caption'])
+          set_data_field('title', title(@parsed_data['raw']['apify']))
+          set_data_field('description', description(@parsed_data['raw']['apify']))
           set_data_field('username', "@#{@parsed_data['raw']['apify']['ownerUsername']}")
-          set_data_field('picture', @parsed_data['raw']['apify']['displayUrl'])
+          set_data_field('picture', image(@parsed_data['raw']['apify']))
           set_data_field('author_name', @parsed_data['raw']['apify']['ownerFullName'])
           set_data_field('author_url', "https://instagram.com/#{@parsed_data['raw']['apify']['ownerUsername']}")
           set_data_field('author_picture', @parsed_data['raw']['apify'].dig('latestComments', 0, 'ownerProfilePicUrl'))
@@ -72,6 +72,18 @@ module Parser
       request_url = request_url + "/" unless request_url.end_with? "/"
 
       '<div><iframe src="' + request_url + 'embed" width="397" height="477" frameborder="0" scrolling="no" allowtransparency="true"></iframe></div>'
+    end
+
+    def title(apify_data)
+      apify_data['caption'] || apify_data['title']
+    end
+
+    def description(apify_data)
+      apify_data['caption'] || apify_data['description']
+    end
+
+    def image(apify_data)
+      apify_data['displayUrl'] || apify_data['image']
     end
   end
 end


### PR DESCRIPTION
## Description

Sometimes an item might be restricted, and the Apify API returns a
partial response. That response has different keys than the regular one,
so we need to handle it.

References: CV2-6489

## How has this been tested?

```rails
rails test test/models/parser/instagram_item_test.rb:103
rails test test/models/parser/instagram_item_test.rb:118
```

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

