### PR TITLE
6504 – Skip get_canonical_url for Twitter items

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -221,7 +221,8 @@ class Media
 
   def skip_get_canonical_url?
     # FIX-ME: This is Parser logic inside of Media, but it needs bigger refactoring before we can move it out
-    skip_hosts = [Parser::InstagramItem.patterns].flatten
+    skip_hosts = [Parser::InstagramItem.patterns, Parser::TwitterItem.patterns].flatten
+
     host = RequestHelper.parse_url(self.original_url).host
     if host && skip_hosts.any? { |skip_host| host.match?(skip_host) }
       Rails.logger.info level: 'INFO', message: "[Parser] Skipped get_canonical_url", url: self.url

--- a/app/models/parser/twitter_item.rb
+++ b/app/models/parser/twitter_item.rb
@@ -3,7 +3,7 @@ module Parser
     include ProviderTwitter
 
     TWITTER_ITEM_URL = /^https?:\/\/([^\.]+\.)?(twitter|x)\.com\/((%23|#)!\/)?(?<user>[^\/]+)\/status\/(?<id>[0-9]+).*/
-    TWITTER_HOST = /^(https?:\/\/)?([^\.]+\.)?(twitter|x)\.com\/?/
+    TWITTER_HOST = /^(https?:\/\/)?(www\.)?(x\.com|twitter\.com)(?:\/|$)/
 
     class << self
       def type

--- a/app/models/parser/twitter_item.rb
+++ b/app/models/parser/twitter_item.rb
@@ -3,6 +3,7 @@ module Parser
     include ProviderTwitter
 
     TWITTER_ITEM_URL = /^https?:\/\/([^\.]+\.)?(twitter|x)\.com\/((%23|#)!\/)?(?<user>[^\/]+)\/status\/(?<id>[0-9]+).*/
+    TWITTER_HOST = /^(https?:\/\/)?([^\.]+\.)?(twitter|x)\.com\/?/
 
     class << self
       def type
@@ -10,7 +11,7 @@ module Parser
       end
   
       def patterns
-        [TWITTER_ITEM_URL]
+        [TWITTER_ITEM_URL, TWITTER_HOST]
       end
     end
 


### PR DESCRIPTION
## Description

The OpenURI request fails with a 400, because there is authorization that
is specific to the Twitter parser, that Media does not have access to.

So since we know this will fail, we skip it. But it is another sign
that this is Parser logic inside of Media, and it needs to be refactored.

References: CV2-6504

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

