### PR TITLE
Fix test caching issue: use clear_bucket instead of Rails.cache.clear

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,20 +31,20 @@ class ActiveSupport::TestCase
   # Shared setup/teardown for tests as we make
   # the unit tests isolated
   def isolated_setup
-    Rails.cache.clear
     WebMock.enable!
     WebMock.disable_net_connect!(allow: [/minio/])
     Sidekiq::Testing.fake!
     ApiKey.current = PenderConfig.current = Pender::Store.current = nil
+    clear_bucket
   end
 
   def isolated_teardown
-    Rails.cache.clear
     Sidekiq::Worker.clear_all
     Sidekiq::Testing.inline! # reset, to match current test_helper teardown
     WebMock.reset!
     WebMock.allow_net_connect!
     WebMock.disable!
+    clear_bucket
   end
 
   # This will run before any test
@@ -52,7 +52,6 @@ class ActiveSupport::TestCase
   def setup
     # For debugging only: print the test name before it runs
     # puts "#{self.class.name}::#{self.method_name}"
-    Rails.cache.clear
     Sidekiq::Testing.inline!
     Rails.application.reload_routes!
     Media.any_instance.stubs(:archive_to_archive_org).returns(nil)
@@ -66,7 +65,6 @@ class ActiveSupport::TestCase
   # This will run after any test
 
   def teardown
-    Rails.cache.clear
     WebMock.reset!
     WebMock.allow_net_connect!
     Media::ARCHIVERS['perma_cc'][:enabled] = false


### PR DESCRIPTION
## Description

I ran again into issues when testing due to unexpected cache being available. I realized that instead of `Rails.cache.clear`, I should probably be using `clear_bucket`. 

We already called this method in the bigger setup and teardown, but we should also call it in isolated_setup and isolated_teardown.

Relates to https://github.com/meedan/pender/pull/585

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

