### PR TITLE
Do not try to render cached data if none is there

### DIFF
--- a/app/controllers/api/v1/medias_controller.rb
+++ b/app/controllers/api/v1/medias_controller.rb
@@ -106,7 +106,7 @@ module Api
           yield
         rescue Net::ReadTimeout
           @data = get_timeout_data(nil, @url, @id)
-          render_timeout_media(@data, must_render) and return true
+          render_timeout_media(@data, true) and return true
         end
         return false
       end

--- a/test/controllers/medias_controller_test.rb
+++ b/test/controllers/medias_controller_test.rb
@@ -166,6 +166,15 @@ class MediasControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should not try to render cached data if none is there" do
+    authenticate_with_token
+    Media.stubs(:new).raises(Net::ReadTimeout)
+    @controller.stubs(:render_as_json).raises(RuntimeError, 'render_as_json should not have been called')
+    get :index, params: { url: 'https://meedan.com', format: :json, refresh: '1' }
+    assert_response :success
+    assert_equal 'Timeout', JSON.parse(@response.body).dig('data', 'error', 'message')
+  end
+
   test "should allow URL with non-latin characters" do
     authenticate_with_token
     url = 'https://martinoei.com/article/13071/林鄭月娥-居港夠廿年嗎？'


### PR DESCRIPTION
## Description

#### Motivation
We keep getting a `NoMethodError` from `render_as_json` because
`data` was `nil`.  

Since the Pender Audit had been pretty stable and under control, I took 
some time to look into this. Fewer errors mean less work in the audit hour.

Sentry Issue: [PENDER-1AG](https://meedan.sentry.io/issues/6808569395/events/cf1f6511bbb84d27afeeedc299f0dd58/)

#### Cause
When we got a timeout, and 'must_render' was set to `false`, we called `render_as_json`. 
Because of the timeout, data was `nil`, which caused our `NoMethodError`. 
It still "worked", meaning a media was created because this error was caught and dealt with eventually. 

#### Fix
If we get a timeout we always must render so we can hardcode `true`.

## How has this been tested?
I added a new test `should not try to render cached data if none is there`.
`rails test test/controllers/medias_controller_test.rb:169`
